### PR TITLE
fix: allow returning more than a single page of data

### DIFF
--- a/docs/internal/http/README.md
+++ b/docs/internal/http/README.md
@@ -49,7 +49,7 @@ LinkHeaderPager represents a pagination implementation that adheres to RFC 5988.
 #### func (*LinkHeaderPager) Parse
 
 ```go
-func (l *LinkHeaderPager) Parse(res *resty.Response) Paging
+func (l *LinkHeaderPager) Parse(res *resty.Response) (*Paging, error)
 ```
 Parse is used to parse a pagination context from an HTTP response.
 
@@ -85,12 +85,12 @@ func (n *NewRelicClient) Delete(path string) error
 ```
 Delete executes an HTTP DELETE request. nolint
 
-#### func (*NewRelicClient) Get
+#### func (*NewRelicClient) GetMultiple
 
 ```go
-func (n *NewRelicClient) Get(path string, params *map[string]string, result interface{}) error
+func (n *NewRelicClient) GetMultiple(path string, params *map[string]string, result interface{}) ([]interface{}, error)
 ```
-Get executes an HTTP GET request.
+GetMultiple executes an HTTP GET request that hydrates a slice of objects.
 
 #### func (*NewRelicClient) Post
 
@@ -124,7 +124,7 @@ SetPager allows for use of different pagination implementations.
 
 ```go
 type Pager interface {
-	Parse(res *resty.Response) Paging
+	Parse(res *resty.Response) (*Paging, error)
 }
 ```
 

--- a/docs/pkg/infrastructure/README.md
+++ b/docs/pkg/infrastructure/README.md
@@ -84,6 +84,22 @@ func (i *Infrastructure) ListAlertConditions(policyID int) ([]AlertCondition, er
 ListAlertConditions is used to retrieve New Relic Infrastructure alert
 conditions.
 
+#### type LinkBodyPager
+
+```go
+type LinkBodyPager struct{}
+```
+
+LinkBodyPager represents a pagination implementation that parses the pagination
+context from the response body.
+
+#### func (*LinkBodyPager) Parse
+
+```go
+func (l *LinkBodyPager) Parse(res *resty.Response) (*http.Paging, error)
+```
+Parse is used to parse a pagination context from an HTTP response.
+
 #### type Threshold
 
 ```go

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -27,14 +27,14 @@ func TestClientHeaders(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	err := cli.Get("/path", nil, nil)
+	_, err := cli.GetMultiple("/path", nil, nil)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestClientDoPaging(t *testing.T) {
+func TestLinkHeaderPaging(t *testing.T) {
 	for i, c := range []struct {
 		expectedNext string
 		linkHeader   string
@@ -81,7 +81,7 @@ func TestErrNotFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 
-	err := cli.Get("/path", nil, nil)
+	_, err := cli.GetMultiple("/path", nil, nil)
 
 	if err != ErrNotFound {
 		t.Fatal(err)
@@ -93,7 +93,7 @@ func TestInternalServerError(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
-	err := cli.Get("/path", nil, nil)
+	_, err := cli.GetMultiple("/path", nil, nil)
 
 	if err == nil {
 		t.Fatal(err)

--- a/internal/http/paging.go
+++ b/internal/http/paging.go
@@ -7,7 +7,7 @@ import (
 
 // Pager represents a pagination implementation.
 type Pager interface {
-	Parse(res *resty.Response) Paging
+	Parse(res *resty.Response) (*Paging, error)
 }
 
 // Paging represents the pagination context returned from the Pager implementation.
@@ -19,7 +19,7 @@ type Paging struct {
 type LinkHeaderPager struct{}
 
 // Parse is used to parse a pagination context from an HTTP response.
-func (l *LinkHeaderPager) Parse(res *resty.Response) Paging {
+func (l *LinkHeaderPager) Parse(res *resty.Response) (*Paging, error) {
 	paging := Paging{}
 	header := res.Header().Get("Link")
 	if header != "" {
@@ -31,5 +31,5 @@ func (l *LinkHeaderPager) Parse(res *resty.Response) Paging {
 		}
 	}
 
-	return paging
+	return &paging, nil
 }

--- a/pkg/apm/applications.go
+++ b/pkg/apm/applications.go
@@ -22,13 +22,20 @@ type listApplicationsResponse struct {
 func (apm *APM) ListApplications(params *ListApplicationsParams) ([]Application, error) {
 	res := listApplicationsResponse{}
 	paramsMap := buildListApplicationsParamsMap(params)
-	err := apm.client.Get("/applications.json", &paramsMap, &res)
+	responses, err := apm.client.GetMultiple("/applications.json", &paramsMap, &res)
+
+	applications := []Application{}
+	for _, r := range responses {
+		if response, ok := r.(*listApplicationsResponse); ok {
+			applications = append(applications, response.Applications...)
+		}
+	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	return res.Applications, nil
+	return applications, nil
 }
 
 func buildListApplicationsParamsMap(params *ListApplicationsParams) map[string]string {

--- a/pkg/infrastructure/alert_conditions_integration_test.go
+++ b/pkg/infrastructure/alert_conditions_integration_test.go
@@ -22,5 +22,13 @@ func TestIntegrationListAlertConditions(t *testing.T) {
 		APIKey: apiKey,
 	})
 
-	api.ListAlertConditions(1234)
+	c, err := api.ListAlertConditions(586577)
+
+	if err != nil {
+		t.Fatalf("ListAlertConditions error: %s", err)
+	}
+
+	if len(c) != 2 {
+		t.Fatalf("expected 2 conditions, received %d", len(c))
+	}
 }

--- a/pkg/infrastructure/errors.go
+++ b/pkg/infrastructure/errors.go
@@ -1,0 +1,20 @@
+package infrastructure
+
+// ErrorResponse represents an error response from New Relic Infrastructure.
+type ErrorResponse struct {
+	Errors []*ErrorDetail `json:"errors,omitempty"`
+}
+
+// ErrorDetail represents the details of an error response from New Relic Infrastructure.
+type ErrorDetail struct {
+	Status string `json:"status,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// Error surfaces an error message from the Infrastructure error response.
+func (e *ErrorResponse) Error() string {
+	if e != nil && len(e.Errors) > 0 && e.Errors[0].Detail != "" {
+		return e.Errors[0].Detail
+	}
+	return "Unknown error"
+}

--- a/pkg/infrastructure/infrastructure.go
+++ b/pkg/infrastructure/infrastructure.go
@@ -6,33 +6,14 @@ import (
 )
 
 var baseURLs = map[config.RegionType]string{
-	config.Region.US:      "https://infra-api.newrelic.com/v2/alerts/conditions",
-	config.Region.EU:      "https://infra-api.eu.newrelic.com/v2/alerts/conditions",
-	config.Region.Staging: "https://staging-infra-api.newrelic.com/v2/alerts/conditions",
+	config.Region.US:      "https://infra-api.newrelic.com/v2",
+	config.Region.EU:      "https://infra-api.eu.newrelic.com/v2",
+	config.Region.Staging: "https://staging-infra-api.newrelic.com/v2",
 }
 
 // Infrastructure is used to communicate with the New Relic Infrastructure product.
 type Infrastructure struct {
 	client http.NewRelicClient
-}
-
-// ErrorResponse represents an error response from New Relic Infrastructure.
-type ErrorResponse struct {
-	Errors []*ErrorDetail `json:"errors,omitempty"`
-}
-
-// ErrorDetail represents the details of an error response from New Relic Infrastructure.
-type ErrorDetail struct {
-	Status string `json:"status,omitempty"`
-	Detail string `json:"detail,omitempty"`
-}
-
-// Error surfaces an error message from the Infrastructure error response.
-func (e *ErrorResponse) Error() string {
-	if e != nil && len(e.Errors) > 0 && e.Errors[0].Detail != "" {
-		return e.Errors[0].Detail
-	}
-	return "Unknown error"
 }
 
 // New is used to create a new Infrastructure client instance.
@@ -43,7 +24,7 @@ func New(config config.Config) Infrastructure {
 
 	c := http.NewClient(config).
 		SetError(&ErrorResponse{}).
-		SetPager(&http.LinkHeaderPager{})
+		SetPager(&LinkBodyPager{})
 
 	pkg := Infrastructure{
 		client: c,

--- a/pkg/infrastructure/infrastructure_test.go
+++ b/pkg/infrastructure/infrastructure_test.go
@@ -13,7 +13,7 @@ func TestDefaultEnvironment(t *testing.T) {
 	a := New(config.Config{})
 
 	actual := a.client.Client.HostURL
-	expected := "https://infra-api.newrelic.com/v2/alerts/conditions"
+	expected := "https://infra-api.newrelic.com/v2"
 	if actual != expected {
 		t.Errorf("expected baseURL: %s, received: %s", expected, actual)
 	}
@@ -26,7 +26,7 @@ func TestEUEnvironment(t *testing.T) {
 	})
 
 	actual := a.client.Client.HostURL
-	expected := "https://infra-api.eu.newrelic.com/v2/alerts/conditions"
+	expected := "https://infra-api.eu.newrelic.com/v2"
 	if actual != expected {
 		t.Errorf("expected baseURL: %s, received: %s", expected, actual)
 	}
@@ -39,7 +39,7 @@ func TestStagingEnvironment(t *testing.T) {
 	})
 
 	actual := a.client.Client.HostURL
-	expected := "https://staging-infra-api.newrelic.com/v2/alerts/conditions"
+	expected := "https://staging-infra-api.newrelic.com/v2"
 	if actual != expected {
 		t.Errorf("expected baseURL: %s, received: %s", expected, actual)
 	}

--- a/pkg/infrastructure/paging.go
+++ b/pkg/infrastructure/paging.go
@@ -1,0 +1,38 @@
+package infrastructure
+
+import (
+	"encoding/json"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/newrelic/newrelic-client-go/internal/http"
+)
+
+// LinkBodyPager represents a pagination implementation that parses the pagination context from the response body.
+type LinkBodyPager struct{}
+
+// Parse is used to parse a pagination context from an HTTP response.
+func (l *LinkBodyPager) Parse(res *resty.Response) (*http.Paging, error) {
+	paging := http.Paging{}
+
+	body := res.Body()
+	if len(body) == 0 {
+		return &paging, nil
+	}
+
+	linksResponse := struct {
+		Links struct {
+			Next string `json:"next"`
+		} `json:"links"`
+	}{}
+
+	err := json.Unmarshal(body, &linksResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if linksResponse.Links.Next != "" {
+		paging.Next = linksResponse.Links.Next
+	}
+
+	return &paging, nil
+}

--- a/pkg/synthetics/monitors.go
+++ b/pkg/synthetics/monitors.go
@@ -1,6 +1,8 @@
 package synthetics
 
-import "strconv"
+import (
+	"strconv"
+)
 
 const (
 	listMonitorsLimit = 100
@@ -17,11 +19,18 @@ func (s *Synthetics) ListMonitors() ([]Monitor, error) {
 		"limit": strconv.Itoa(listMonitorsLimit),
 	}
 
-	err := s.client.Get("/monitors", &paramsMap, &res)
+	responses, err := s.client.GetMultiple("/monitors", &paramsMap, &res)
+
+	monitors := []Monitor{}
+	for _, r := range responses {
+		if response, ok := r.(*listMonitorsResponse); ok {
+			monitors = append(monitors, response.Monitors...)
+		}
+	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	return res.Monitors, nil
+	return monitors, nil
 }


### PR DESCRIPTION
Allow returning more than a single page of data.

This PR refactors the client's `Get` method to a `GetMultiple` that returns a pointer to a slice of interfaces that can then be asserted into a slice of response types at the resource level.  This allows the HTTP paging to remain abstracted away from the resources, but each resource now needs to execute its own aggregation of resource types over the list of returned responses.  

This concern could be abstracted into the client by having each of the resources pass their own aggregation functions into the client.  Without support for generics however, each of the resource types would then still need to be unboxed at the resource level, which would be awkward and inefficient as an O(n) operation.

This PR seems to suggest that the code may not be well factored as-is.  Thoughts?