### PR TITLE
Linter updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 tmp/*
 bin/*
-build/*
 coverage/*
-vendor/*/*
+vendor/*
 
 *.csv
 *.yml

--- a/Makefile
+++ b/Makefile
@@ -6,26 +6,6 @@ PROJECT_VER  := $(shell git describe --tags --always --dirty | sed -e '/^v/s/^v\
 SRCDIR       ?= .
 GO            = go
 
-# Main API Entry point
-PACKAGES = ${SRCDIR}/newrelic
-
-# Determine packages by looking into pkg/*
-ifneq ("$(wildcard ${SRCDIR}/pkg/*)","")
-	PACKAGES += $(wildcard ${SRCDIR}/pkg/*)
-endif
-ifneq ("$(wildcard ${SRCDIR}/internal/*)","")
-	PACKAGES += $(wildcard ${SRCDIR}/internal/*)
-endif
-
-# Determine commands by looking into cmd/*
-COMMANDS = $(wildcard ${SRCDIR}/cmd/*)
-
-GO_FILES := $(shell find $(COMMANDS) $(PACKAGES) -type f -name "*.go")
-
-# Determine binary names by stripping out the dir names
-BINS=$(foreach cmd,${COMMANDS},$(notdir ${cmd}))
-
-
 
 #############################
 # Targets

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ clean: clean-cover clean-compile
 include build/compile.mk
 include build/deps.mk
 include build/document.mk
-include build/testing.mk
+include build/lint.mk
+include build/test.mk
 include build/util.mk
 
 .PHONY: all build build-ci clean

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CircleCI](https://circleci.com/gh/newrelic/newrelic-client-go.svg?style=svg)](https://circleci.com/gh/newrelic/newrelic-client-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/newrelic/newrelic-client-go?style=flat-square)](https://goreportcard.com/report/github.com/newrelic/newrelic-client-go)
-[![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](http://godoc.org/github.com/newrelic/newrelic-client-go)
+[![GoDoc](https://godoc.org/github.com/newrelic/newrelic-client-go?status.svg)](https://godoc.org/github.com/newrelic/newrelic-client-go)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/newrelic/newrelic-client-go/blob/master/LICENSE)
 [![Release](https://img.shields.io/github/release/newrelic/newrelic-client-go?style=flat-square)](https://github.com/newrelic/newrelic-client-go/releases/latest)
-
 
 The New Relic Client provides the building blocks for tools in the [Developer Toolkit](https://newrelic.github.io/developer-toolkit/), enabling quick access to the suite of New Relic APIs. As a library, it can also be leveraged within your own custom applications.
 

--- a/build/compile.mk
+++ b/build/compile.mk
@@ -7,6 +7,13 @@ BUILD_DIR  ?= ./bin/
 LDFLAGS    ?= '-X main.Version=$(PROJECT_VER)'
 SRCDIR     ?= .
 
+# Determine commands by looking into cmd/*
+COMMANDS   ?= $(wildcard ${SRCDIR}/cmd/*)
+
+# Determine binary names by stripping out the dir names
+BINS       := $(foreach cmd,${COMMANDS},$(notdir ${cmd}))
+
+
 clean-compile:
 	@echo "=== $(PROJECT_NAME) === [ clean-compile    ]: removing binaries..."
 	@rm -rfv $(BUILD_DIR)/*

--- a/build/lint.mk
+++ b/build/lint.mk
@@ -1,9 +1,8 @@
 #
-# Makefile fragment for Testing
+# Makefile fragment for Linting
 #
 
 GO           ?= go
-GOLINTER     ?= golangci-lint
 MISSPELL     ?= misspell
 GOFMT        ?= gofmt
 
@@ -13,16 +12,11 @@ FILES        ?= $(shell find ${SRCDIR} -type f | grep -v -e '.git/' -e '/vendor/
 
 GOTOOLS += github.com/client9/misspell/cmd/misspell \
            github.com/fzipp/gocyclo \
-           github.com/golangci/golangci-lint/cmd/golangci-lint \
            github.com/gordonklaus/ineffassign \
            github.com/remyoudompheng/go-misc/deadcode \
            github.com/timakin/bodyclose \
            golang.org/x/lint/golint
 
-
-#lint: deps spell-check
-#	@echo "=== $(PROJECT_NAME) === [ lint             ]: Validating source code running $(GOLINTER)..."
-#	@$(GOLINTER) -v run ./...
 
 lint: deps spell-check gofmt govet golint ineffassign gocyclo deadcode bodyclose
 lint-fix: deps spell-check-fix gofmt-fix

--- a/build/lint.mk
+++ b/build/lint.mk
@@ -1,0 +1,73 @@
+#
+# Makefile fragment for Testing
+#
+
+GO           ?= go
+GOLINTER     ?= golangci-lint
+MISSPELL     ?= misspell
+GOFMT        ?= gofmt
+
+SRCDIR       ?= .
+GO_PKGS      ?= $(shell ${GO} list ./... | grep -v -e "/vendor/" -e "/example")
+FILES        ?= $(shell find ${SRCDIR} -type f | grep -v -e '.git/' -e '/vendor/')
+
+GOTOOLS += github.com/client9/misspell/cmd/misspell \
+           github.com/fzipp/gocyclo \
+           github.com/golangci/golangci-lint/cmd/golangci-lint \
+           github.com/gordonklaus/ineffassign \
+           github.com/remyoudompheng/go-misc/deadcode \
+           github.com/timakin/bodyclose \
+           golang.org/x/lint/golint
+
+
+#lint: deps spell-check
+#	@echo "=== $(PROJECT_NAME) === [ lint             ]: Validating source code running $(GOLINTER)..."
+#	@$(GOLINTER) -v run ./...
+
+lint: deps spell-check gofmt govet golint ineffassign gocyclo deadcode bodyclose
+lint-fix: deps spell-check-fix gofmt-fix
+
+#
+# Check spelling on all the files, not just source code
+#
+spell-check: deps
+	@echo "=== $(PROJECT_NAME) === [ spell-check      ]: Checking for spelling mistakes with $(MISSPELL)..."
+	@$(MISSPELL) -source text $(FILES)
+
+spell-check-fix: deps
+	@echo "=== $(PROJECT_NAME) === [ spell-check-fix  ]: Fixing spelling mistakes with $(MISSPELL)..."
+	@$(MISSPELL) -source text -w $(FILES)
+
+gofmt: deps
+	@echo "=== $(PROJECT_NAME) === [ gofmt            ]: Checking file format with $(GOFMT)..."
+	@$(GOFMT) -e -l -s -d ${SRCDIR}
+
+gofmt-fix: deps
+	@echo "=== $(PROJECT_NAME) === [ gofmt-fix        ]: Fixing file format with $(GOFMT)..."
+	@$(GOFMT) -e -l -s -w ${SRCDIR}
+
+govet: deps
+	@echo "=== $(PROJECT_NAME) === [ govet            ]: Checking file format with $(GO) vet..."
+	@$(GO) vet $(GO_PKGS)
+
+golint: deps
+	@echo "=== $(PROJECT_NAME) === [ golint           ]: Checking source files with golint..."
+	@golint -set_exit_status $(SRCDIR)/...
+
+ineffassign: deps
+	@echo "=== $(PROJECT_NAME) === [ ineffassign      ]: Checking for ineffectual assignments..."
+	@ineffassign $(SRCDIR)
+
+gocyclo: deps
+	@echo "=== $(PROJECT_NAME) === [ gocyclo          ]: Calculating cyclomatic complexities of functions (gocyclo)..."
+	@gocyclo -over 20 $(SRCDIR)
+
+deadcode: deps
+	@echo "=== $(PROJECT_NAME) === [ deadcode         ]: Checking for unused code (deadcode)..."
+	@deadcode $(GO_PKGS)
+
+bodyclose: deps
+	@echo "=== $(PROJECT_NAME) === [ bodyclose        ]: Checking that http response bodies are closed (bodyclose)..."
+	@$(GO) vet -vettool=$(shell which bodyclose) $(SRCDIR)/...
+
+.PHONY: lint spell-check spell-check-fix gofmt gofmt-fix lint-fix

--- a/build/test.mk
+++ b/build/test.mk
@@ -4,20 +4,20 @@
 
 GO           ?= go
 GOLINTER     ?= golangci-lint
+MISSPELL     ?= misspell
+GOFMT        ?= gofmt
+
 COVERAGE_DIR ?= ./coverage/
 COVERMODE    ?= atomic
+SRCDIR       ?= .
 GO_PKGS      ?= $(shell ${GO} list ./... | grep -v -e "/vendor/" -e "/example")
+FILES        ?= $(shell find ${SRCDIR} -type f | grep -v -e '.git/' -e '/vendor/')
 
-GOTOOLS += github.com/golangci/golangci-lint/cmd/golangci-lint \
-           github.com/stretchr/testify/assert
+GOTOOLS += github.com/stretchr/testify/assert
 
 clean-cover:
 	@echo "=== $(PROJECT_NAME) === [ clean-cover      ]: removing coverage files..."
 	@rm -rfv $(COVERAGE_DIR)/*
-
-lint: deps
-	@echo "=== $(PROJECT_NAME) === [ lint             ]: Validating source code running $(GOLINTER)..."
-	@$(GOLINTER) run ./...
 
 test: test-only
 test-only: test-unit test-integration
@@ -43,4 +43,4 @@ cover-report:
 cover-view: cover-report
 	@$(GO) tool cover -html=$(COVERAGE_DIR)/coverage.out
 
-.PHONY: lint test test-only test-unit test-integration cover-report cover-view
+.PHONY: test test-only test-unit test-integration cover-report cover-view

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,15 @@ go 1.13
 
 require (
 	github.com/client9/misspell v0.3.4
+	github.com/fzipp/gocyclo v0.0.0-20150627053110-6acd4345c835
 	github.com/golangci/golangci-lint v1.21.0
 	github.com/google/go-cmp v0.2.0
+	github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8
 	github.com/hashicorp/go-retryablehttp v0.6.4
+	github.com/remyoudompheng/go-misc v0.0.0-20190427085024-2d6ac652a50e
 	github.com/stretchr/testify v1.4.0
+	github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
 	golang.org/x/tools v0.0.0-20191010075000-0337d82405ff
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fzipp/gocyclo v0.0.0-20150627053110-6acd4345c835 h1:roDmqJ4Qes7hrDOsWsMCce0vQHz3xiMPjJ9m4c2eeNs=
+github.com/fzipp/gocyclo v0.0.0-20150627053110-6acd4345c835/go.mod h1:BjL/N0+C+j9uNX+1xcNuM9vdSIcXCZrQZUYbXOFbgN8=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db h1:GYXWx7Vr3+zv833u+8IoXbNnQY0AdXsxAgI0kX7xcwA=
@@ -122,6 +124,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8 h1:ehVe1P3MbhHjeN/Rn66N2fGLrP85XXO1uxpLhv0jtX8=
+github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3 h1:JVnpOZS+qxli+rgVl98ILOXVNbW+kb5wcxeGx8ShUIw=
@@ -147,6 +151,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kisielk/errcheck v1.1.0 h1:ZqfnKyx9KGpRcW04j5nnPDgRgoXUeLh2YFBeFzphcA0=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -212,6 +217,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzr
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
+github.com/remyoudompheng/go-misc v0.0.0-20190427085024-2d6ac652a50e h1:eTWZyPUnHcuGRDiryS/l2I7FfKjbU3IBx3IjqHPxuKU=
+github.com/remyoudompheng/go-misc v0.0.0-20190427085024-2d6ac652a50e/go.mod h1:80FQABjoFzZ2M5uEa6FUaJYEmqU2UOKojlFVak1UAwI=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -291,13 +298,16 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoebLNy/2lXT9EtprMuTFWt1M=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
@@ -332,6 +342,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181117154741-2ddaf7f79a09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190110163146-51295c7ec13a/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190228203856-589c23e65e65/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190311215038-5c2858a9cfe5/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190322203728-c1a832b0ad89/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
@@ -344,6 +355,7 @@ golang.org/x/tools v0.0.0-20191010075000-0337d82405ff h1:XdBG6es/oFDr1HwaxkxgVve
 golang.org/x/tools v0.0.0-20191010075000-0337d82405ff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -7,12 +7,14 @@ import (
 	"github.com/newrelic/newrelic-client-go/pkg/synthetics"
 )
 
+// NewRelic is a connection to New Relic APIs
 type NewRelic struct {
 	Alerts     alerts.Alerts
 	APM        apm.APM
 	Synthetics synthetics.Synthetics
 }
 
+// New returns a NewRelic API connection struct
 func New(config config.Config) NewRelic {
 	return NewRelic{
 		Alerts:     alerts.New(config),

--- a/pkg/alerts/alert_policies_test.go
+++ b/pkg/alerts/alert_policies_test.go
@@ -110,7 +110,7 @@ func TestListAlertPoliciesWithParams(t *testing.T) {
 
 		name := values.Get("filter[name]")
 		if name != expectedName {
-			t.Errorf(`expected name filter "%s", recieved: "%s"`, expectedName, name)
+			t.Errorf(`expected name filter "%s", received: "%s"`, expectedName, name)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/alerts/alert_policy_channels_test.go
+++ b/pkg/alerts/alert_policy_channels_test.go
@@ -86,8 +86,8 @@ func newTestPolicyChannelsClient(handler http.Handler) Alerts {
 	ts := httptest.NewServer(handler)
 
 	c := New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
+		APIKey:  "abc123",
+		BaseURL: ts.URL,
 	})
 
 	return c

--- a/pkg/alerts/alert_policy_channels_types.go
+++ b/pkg/alerts/alert_policy_channels_types.go
@@ -1,5 +1,6 @@
 package alerts
 
+// PolicyChannels represents a New Relic Alert Policy Channel
 type PolicyChannels struct {
 	ID         int   `json:"id,omitempty"`
 	ChannelIDs []int `json:"channel_ids,omitempty"`

--- a/pkg/apm/applications_test.go
+++ b/pkg/apm/applications_test.go
@@ -244,7 +244,7 @@ func TestUpdateApplication(t *testing.T) {
 	}))
 
 	params := UpdateApplicationParams{
-		Name: testApplication.Name,
+		Name:     testApplication.Name,
 		Settings: testApplication.Settings,
 	}
 

--- a/pkg/apm/applications_test.go
+++ b/pkg/apm/applications_test.go
@@ -156,22 +156,22 @@ func TestListApplicationsWithParams(t *testing.T) {
 
 		name := values.Get("filter[name]")
 		if name != expectedName {
-			t.Errorf(`expected name filter "%s", recieved: "%s"`, expectedName, name)
+			t.Errorf(`expected name filter "%s", received: "%s"`, expectedName, name)
 		}
 
 		host := values.Get("filter[host]")
 		if host != expectedHost {
-			t.Errorf(`expected host filter "%s", recieved: "%s"`, expectedHost, host)
+			t.Errorf(`expected host filter "%s", received: "%s"`, expectedHost, host)
 		}
 
 		ids := values.Get("filter[ids]")
 		if ids != expectedIDs {
-			t.Errorf(`expected ids filter "%s", recieved: "%s"`, expectedIDs, ids)
+			t.Errorf(`expected ids filter "%s", received: "%s"`, expectedIDs, ids)
 		}
 
 		language := values.Get("filter[language]")
 		if language != expectedLanguage {
-			t.Errorf(`expected language filter "%s", recieved: "%s"`, expectedLanguage, language)
+			t.Errorf(`expected language filter "%s", received: "%s"`, expectedLanguage, language)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/dashboards/dashboards_test.go
+++ b/pkg/dashboards/dashboards_test.go
@@ -88,14 +88,14 @@ var (
 				1234,
 			},
 			CompareWith: []DashboardWidgetDataCompareWith{
-				DashboardWidgetDataCompareWith{
+				{
 					OffsetDuration: "P7D",
 					Presentation: DashboardWidgetDataCompareWithPresentation{
 						Name:  "Last week",
 						Color: "#b1b6ba",
 					},
 				},
-				DashboardWidgetDataCompareWith{
+				{
 					OffsetDuration: "P1D",
 					Presentation: DashboardWidgetDataCompareWithPresentation{
 						Name:  "Yesterday",
@@ -104,7 +104,7 @@ var (
 				},
 			},
 			Metrics: []DashboardWidgetDataMetric{
-				DashboardWidgetDataMetric{
+				{
 					Name:  "CPU/System/Utilization",
 					Units: "",
 					Scope: "",

--- a/pkg/synthetics/monitor_scripts_integration_test.go
+++ b/pkg/synthetics/monitor_scripts_integration_test.go
@@ -69,4 +69,5 @@ func TestIntegrationMonitorScripts(t *testing.T) {
 
 	// Teardown
 	err = synthetics.DeleteMonitor(monitorID)
+	require.NoError(t, err)
 }

--- a/tools.go
+++ b/tools.go
@@ -3,8 +3,16 @@
 package main
 
 import (
-	_ "github.com/client9/misspell/cmd/misspell"
-	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	// build/test.mk
 	_ "github.com/stretchr/testify/assert"
+
+	// build/lint.mk
+	_ "github.com/client9/misspell/cmd/misspell"
+	_ "github.com/fzipp/gocyclo"
+	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/gordonklaus/ineffassign"
+	_ "github.com/remyoudompheng/go-misc/deadcode"
+	_ "github.com/timakin/bodyclose"
+	_ "golang.org/x/lint/golint"
 	_ "golang.org/x/tools/cmd/godoc"
 )


### PR DESCRIPTION
For some reason, golangci-lint has stopped working as expected.  I've updated the make system to directly call a handful of linters instead.

- misspell: Spell check all files (not just source code)
- gofmt: File formatting
- go vet
- golint
- ineffassign: ineffectual assignments
- gocyclo: cyclomatic complexities of functions
- deadcode: Unused code
- bodyclose: HTTP response bodies are closed correctly

Also fixed the linting issues found with the above checks.