### PR TITLE
feat: publicly expose error types

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/newrelic/newrelic-client-go/internal/version"
 	"github.com/newrelic/newrelic-client-go/pkg/config"
+	"github.com/newrelic/newrelic-client-go/pkg/errors"
 )
 
 const (
@@ -228,7 +229,7 @@ func (c *NewRelicClient) do(
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, &ErrorNotFound{}
+		return nil, &errors.ErrorNotFound{}
 	}
 
 	body, readErr := ioutil.ReadAll(resp.Body)
@@ -240,9 +241,9 @@ func (c *NewRelicClient) do(
 		errorValue := c.errorValue
 		_ = json.Unmarshal(body, &errorValue)
 
-		return nil, &ErrorUnexpectedStatusCode{
-			statusCode: resp.StatusCode,
-			err:        c.errorValue.Error()}
+		return nil, &errors.ErrorUnexpectedStatusCode{
+			StatusCode: resp.StatusCode,
+			Err:        c.errorValue.Error()}
 	}
 
 	if value == nil {

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/newrelic/newrelic-client-go/pkg/config"
+	"github.com/newrelic/newrelic-client-go/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,7 +52,7 @@ func TestDefaultErrorValue(t *testing.T) {
 
 	_, err := c.Get("/path", nil, nil)
 
-	assert.Equal(t, err.(*ErrorUnexpectedStatusCode).err, "error message")
+	assert.Equal(t, err.(*errors.ErrorUnexpectedStatusCode).Err, "error message")
 }
 
 type CustomErrorResponse struct {
@@ -74,7 +75,7 @@ func TestCustomErrorValue(t *testing.T) {
 
 	_, err := c.Get("/path", nil, nil)
 
-	assert.Equal(t, err.(*ErrorUnexpectedStatusCode).err, "error message")
+	assert.Equal(t, err.(*errors.ErrorUnexpectedStatusCode).Err, "error message")
 }
 
 type CustomResponseValue struct {
@@ -236,7 +237,7 @@ func TestErrNotFound(t *testing.T) {
 
 	_, err := c.Get("/path", nil, nil)
 
-	assert.IsType(t, &ErrorNotFound{}, err)
+	assert.IsType(t, &errors.ErrorNotFound{}, err)
 }
 
 func TestInternalServerError(t *testing.T) {
@@ -247,7 +248,7 @@ func TestInternalServerError(t *testing.T) {
 
 	_, err := c.Get("/path", nil, nil)
 
-	assert.IsType(t, &ErrorUnexpectedStatusCode{}, err)
+	assert.IsType(t, &errors.ErrorUnexpectedStatusCode{}, err)
 }
 
 func TestPost(t *testing.T) {

--- a/internal/http/errors.go
+++ b/internal/http/errors.go
@@ -30,29 +30,3 @@ func (e *DefaultErrorResponse) Error() string {
 
 	return m
 }
-
-// ErrorNotFound is returned when a 404 response is returned
-// from New Relic's APIs.
-type ErrorNotFound struct{}
-
-func (e *ErrorNotFound) Error() string {
-	return fmt.Sprintf("404 not found")
-}
-
-// ErrorUnexpectedStatusCode is returned when an unexpected
-// status code is returned from New Relic's APIs.
-type ErrorUnexpectedStatusCode struct {
-	err        string
-	statusCode int
-}
-
-func (e *ErrorUnexpectedStatusCode) Error() string {
-
-	msg := fmt.Sprintf("%d response returned", e.statusCode)
-
-	if e.err != "" {
-		msg += fmt.Sprintf(": %s", e.err)
-	}
-
-	return msg
-}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,31 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// ErrorNotFound is returned when a 404 response is returned
+// from New Relic's APIs.
+type ErrorNotFound struct{}
+
+func (e *ErrorNotFound) Error() string {
+	return fmt.Sprintf("404 not found")
+}
+
+// ErrorUnexpectedStatusCode is returned when an unexpected
+// status code is returned from New Relic's APIs.
+type ErrorUnexpectedStatusCode struct {
+	Err        string
+	StatusCode int
+}
+
+func (e *ErrorUnexpectedStatusCode) Error() string {
+
+	msg := fmt.Sprintf("%d response returned", e.StatusCode)
+
+	if e.Err != "" {
+		msg += fmt.Sprintf(": %s", e.Err)
+	}
+
+	return msg
+}


### PR DESCRIPTION
Resolves #69.

This PR exposes the error types for the client so they can be used in the calling code.  A common use case for this is checking if the error is due to a resource not found error.