### PR TITLE
bug: Change Infra alert condition value to float

### DIFF
--- a/pkg/alerts/infrastructure_conditions_test.go
+++ b/pkg/alerts/infrastructure_conditions_test.go
@@ -15,15 +15,21 @@ import (
 var (
 	testInfrastructureConditionPolicyId  = 111111
 	testInfrastructureConditionTimestamp = serialization.EpochTime(time.Unix(1490996713872, 0))
-	testInfrastructureConditionThreshold = InfrastructureConditionThreshold{
+	testInfrastructureCriticalThreshold  = InfrastructureConditionThreshold{
 		Duration: 6,
-		Value:    0,
+		Function: "all",
+		Value:    12.3,
+	}
+	testInfrastructureWarningThreshold = InfrastructureConditionThreshold{
+		Duration: 6,
+		Function: "all",
+		Value:    10,
 	}
 
 	testInfrastructureCondition = InfrastructureCondition{
 		Comparison:   "equal",
 		CreatedAt:    &testInfrastructureConditionTimestamp,
-		Critical:     &testInfrastructureConditionThreshold,
+		Critical:     &testInfrastructureCriticalThreshold,
 		Enabled:      true,
 		ID:           13890,
 		Name:         "Java is running",
@@ -31,6 +37,7 @@ var (
 		ProcessWhere: "(commandName = 'java')",
 		Type:         "infra_process_running",
 		UpdatedAt:    &testInfrastructureConditionTimestamp,
+		Warning:      &testInfrastructureWarningThreshold,
 		Where:        "(hostname LIKE '%cassandra%')",
 	}
 	testInfrastructureConditionJson = `
@@ -45,8 +52,14 @@ var (
 			"policy_id":111111,
 			"comparison":"equal",
 			"critical_threshold":{
-				"value":0,
-				"duration_minutes":6
+				"value":12.3,
+				"duration_minutes":6,
+				"time_function": "all"
+			},
+			"warning_threshold": {
+				"value": 10,
+				"duration_minutes": 6,
+				"time_function": "all"
 			},
 			"process_where_clause":"(commandName = 'java')"
 		}`

--- a/pkg/alerts/infrastructure_conditions_types.go
+++ b/pkg/alerts/infrastructure_conditions_types.go
@@ -25,7 +25,7 @@ type InfrastructureCondition struct {
 
 // InfrastructureConditionThreshold represents an New Relic Infrastructure alert condition threshold.
 type InfrastructureConditionThreshold struct {
-	Duration int    `json:"duration_minutes,omitempty"`
-	Function string `json:"time_function,omitempty"`
-	Value    int    `json:"value,omitempty"`
+	Duration int     `json:"duration_minutes,omitempty"`
+	Function string  `json:"time_function,omitempty"`
+	Value    float64 `json:"value,omitempty"`
 }


### PR DESCRIPTION
The API endpoint accepts a float for Infrastructure Alert Condition value, update the client to use float.

* Change field from `int` to `float64`
* Add test for Warning threshold
* Test using float and int in JSON response body