### PR TITLE
feat: encode monitor script text

### DIFF
--- a/pkg/synthetics/monitor_scripts.go
+++ b/pkg/synthetics/monitor_scripts.go
@@ -1,6 +1,7 @@
 package synthetics
 
 import (
+	"encoding/base64"
 	"fmt"
 )
 
@@ -15,11 +16,21 @@ func (s *Synthetics) GetMonitorScript(monitorID string) (*MonitorScript, error) 
 		return nil, err
 	}
 
+	decoded, err := base64.StdEncoding.DecodeString(resp.Text)
+
+	if err != nil {
+		return nil, err
+	}
+
+	resp.Text = string(decoded)
+
 	return &resp, nil
 }
 
 // UpdateMonitorScript is used to add a script to an existing New Relic Synthetics monitor_script.
 func (s *Synthetics) UpdateMonitorScript(monitorID string, script MonitorScript) error {
+	script.Text = base64.StdEncoding.EncodeToString([]byte(script.Text))
+
 	url := fmt.Sprintf("/monitors/%s/script", monitorID)
 	_, err := s.client.Put(url, nil, &script, nil)
 

--- a/pkg/synthetics/monitor_scripts_integration_test.go
+++ b/pkg/synthetics/monitor_scripts_integration_test.go
@@ -29,7 +29,7 @@ var (
 		HMAC: "MjhiNGE4MjVlMDE1N2M4NDQ4MjNjNDFkZDEyYTRjMmUzZDE3NGJlNjU0MWFmOTJlMzNiODExOGU2ZjhkZTY4ZQ",
 	}
 	testIntegrationMonitorScript = MonitorScript{
-		Text: "dmFyIGFzc2VydCA9IHJlcXVpcmUoJ2Fzc2VydCcpOw0KYXNzZXJ0LmVxdWFsKCcxJywgJzEnKTs=",
+		Text: "asdf",
 		Locations: []MonitorScriptLocation{
 			testIntegrationMonitorScriptLocation,
 		},
@@ -65,6 +65,7 @@ func TestIntegrationMonitorScripts(t *testing.T) {
 	script, err := synthetics.GetMonitorScript(monitorID)
 
 	require.NoError(t, err)
+
 	require.Equal(t, testIntegrationMonitorScript.Text, script.Text)
 
 	// Teardown

--- a/pkg/synthetics/monitor_scripts_test.go
+++ b/pkg/synthetics/monitor_scripts_test.go
@@ -15,14 +15,14 @@ var (
 		HMAC: "MjhiNGE4MjVlMDE1N2M4NDQ4MjNjNDFkZDEyYTRjMmUzZDE3NGJlNjU0MWFmOTJlMzNiODExOGU2ZjhkZTY4ZQ",
 	}
 	testMonitorScript = MonitorScript{
-		Text: "dmFyIGFzc2VydCA9IHJlcXVpcmUoJ2Fzc2VydCcpOw0KYXNzZXJ0LmVxdWFsKCcxJywgJzEnKTs",
+		Text: "asdf",
 		Locations: []MonitorScriptLocation{
 			testMonitorScriptLocation,
 		},
 	}
 	testMonitorScriptJson = `
 	{
-		"scriptText": "dmFyIGFzc2VydCA9IHJlcXVpcmUoJ2Fzc2VydCcpOw0KYXNzZXJ0LmVxdWFsKCcxJywgJzEnKTs"
+		"scriptText": "asdf"
 	}
 	`
 )


### PR DESCRIPTION
This PR updates the UpdateMonitorScript method to do the necessary base64 encoding and decoding for the script text so it isn't necessary for the end user.