### PR TITLE
chore: expose region urls

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -24,11 +24,6 @@ const (
 
 var (
 	defaultUserAgent = fmt.Sprintf("newrelic/newrelic-client-go/%s (https://github.com/newrelic/newrelic-client-go)", version.Version)
-	defaultBaseURLs  = map[config.RegionType]string{
-		config.Region.US:      "https://api.newrelic.com/v2",
-		config.Region.EU:      "https://api.eu.newrelic.com/v2",
-		config.Region.Staging: "https://staging-api.newrelic.com/v2",
-	}
 )
 
 // NewRelicClient represents a client for communicating with the New Relic APIs.
@@ -39,27 +34,27 @@ type NewRelicClient struct {
 }
 
 // NewClient is used to create a new instance of NewRelicClient.
-func NewClient(config config.Config) NewRelicClient {
+func NewClient(cfg config.Config) NewRelicClient {
 	c := http.Client{
 		Timeout: defaultTimeout,
 	}
 
-	if config.Timeout != nil {
-		c.Timeout = *config.Timeout
+	if cfg.Timeout != nil {
+		c.Timeout = *cfg.Timeout
 	}
 
-	if config.HTTPTransport != nil {
-		if transport, ok := (*config.HTTPTransport).(*http.Transport); ok {
+	if cfg.HTTPTransport != nil {
+		if transport, ok := (*cfg.HTTPTransport).(*http.Transport); ok {
 			c.Transport = transport
 		}
 	}
 
-	if config.BaseURL == "" {
-		config.BaseURL = defaultBaseURLs[config.Region]
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = config.DefaultBaseURLs[cfg.Region]
 	}
 
-	if config.UserAgent == "" {
-		config.UserAgent = defaultUserAgent
+	if cfg.UserAgent == "" {
+		cfg.UserAgent = defaultUserAgent
 	}
 
 	r := retryablehttp.NewClient()
@@ -69,7 +64,7 @@ func NewClient(config config.Config) NewRelicClient {
 
 	return NewRelicClient{
 		Client:     r,
-		Config:     config,
+		Config:     cfg,
 		errorValue: &DefaultErrorResponse{},
 	}
 }

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -38,7 +38,7 @@ func TestConfigDefaults(t *testing.T) {
 		APIKey: testAPIKey,
 	})
 
-	assert.Equal(t, defaultBaseURLs[c.Config.Region], c.Config.BaseURL)
+	assert.Equal(t, config.DefaultBaseURLs[c.Config.Region], c.Config.BaseURL)
 	assert.Contains(t, c.Config.UserAgent, "newrelic/newrelic-client-go/")
 }
 

--- a/pkg/alerts/alerts.go
+++ b/pkg/alerts/alerts.go
@@ -32,3 +32,6 @@ func New(config config.Config) Alerts {
 
 	return pkg
 }
+
+// BaseURLs represents the base API URLs for the different environments of the New Relic REST API V2.
+var BaseURLs = config.DefaultBaseURLs

--- a/pkg/apm/apm.go
+++ b/pkg/apm/apm.go
@@ -20,3 +20,6 @@ func New(config config.Config) APM {
 
 	return pkg
 }
+
+// BaseURLs represents the base API URLs for the different environments of the New Relic REST API V2.
+var BaseURLs = config.DefaultBaseURLs

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,13 @@ import (
 // RegionType represents the members of the Region enumeration.
 type RegionType int
 
+// DefaultBaseURLs represents the base API URLs for the different environments of the New Relic REST API V2.
+var DefaultBaseURLs = map[RegionType]string{
+	Region.US:      "https://api.newrelic.com/v2",
+	Region.EU:      "https://api.eu.newrelic.com/v2",
+	Region.Staging: "https://staging-api.newrelic.com/v2",
+}
+
 const (
 	// US represents New Relic's US-based production deployment.
 	US = iota

--- a/pkg/dashboards/dashboards.go
+++ b/pkg/dashboards/dashboards.go
@@ -24,6 +24,9 @@ func New(config config.Config) Dashboards {
 	return pkg
 }
 
+// BaseURLs represents the base API URLs for the different environments of the New Relic REST API V2.
+var BaseURLs = config.DefaultBaseURLs
+
 // ListDashboardsParams represents a set of filters to be
 // used when querying New Relic dashboards.
 type ListDashboardsParams struct {

--- a/pkg/synthetics/synthetics.go
+++ b/pkg/synthetics/synthetics.go
@@ -7,7 +7,8 @@ import (
 	"github.com/newrelic/newrelic-client-go/pkg/config"
 )
 
-var baseURLs = map[config.RegionType]string{
+// BaseURLs represents the base API URLs for the different environments of the Synthetics API.
+var BaseURLs = map[config.RegionType]string{
 	config.Region.US:      "https://synthetics.newrelic.com/synthetics/api/v3",
 	config.Region.EU:      "https://synthetics.eu.newrelic.com/synthetics/api/v3",
 	config.Region.Staging: "https://staging-synthetics.newrelic.com/synthetics/api/v3",
@@ -56,7 +57,7 @@ func (e *ErrorResponse) Error() string {
 func New(config config.Config) Synthetics {
 
 	if config.BaseURL == "" {
-		config.BaseURL = baseURLs[config.Region]
+		config.BaseURL = BaseURLs[config.Region]
 	}
 
 	client := http.NewClient(config)


### PR DESCRIPTION
This PR pulls the various API URLs public so they can be referenced by users of the various packages.