### PR TITLE
Disable snyk issues to fail the build on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,5 +13,9 @@ jobs:
       - checkout
 
       - run: make build-ci
-      - snyk/scan
+      - snyk/scan:
+          severity-threshold: high
+          fail-on-issues: false
+          monitor-on-build: true
+
 


### PR DESCRIPTION
Snyk should run, but not cause failures on PRs for now.