### PR TITLE
refactor: update test helpers to use new mock server

### DIFF
--- a/pkg/alerts/alerts_test.go
+++ b/pkg/alerts/alerts_test.go
@@ -12,7 +12,7 @@ import (
 
 // TODO: This is used by incidents_test.go still, need to refactor
 // nolint
-func newTestAlerts(handler http.Handler) Alerts {
+func newTestClient(handler http.Handler) Alerts {
 	ts := httptest.NewServer(handler)
 
 	c := New(config.Config{

--- a/pkg/alerts/channels_test.go
+++ b/pkg/alerts/channels_test.go
@@ -79,7 +79,6 @@ var (
 
 func TestListChannels(t *testing.T) {
 	t.Parallel()
-
 	alerts := newMockResponse(t, testListChannelsResponseJSON, http.StatusOK)
 
 	expected := []*Channel{

--- a/pkg/alerts/incidents_test.go
+++ b/pkg/alerts/incidents_test.go
@@ -81,7 +81,7 @@ var failingTestHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Re
 func TestListIncidents(t *testing.T) {
 	t.Parallel()
 
-	c := newTestAlerts(incidentTestAPIHandler)
+	c := newTestClient(incidentTestAPIHandler)
 
 	expected := []*Incident{
 		{
@@ -115,7 +115,7 @@ func TestListIncidents(t *testing.T) {
 func TestOpenListIncidents(t *testing.T) {
 	t.Parallel()
 
-	c := newTestAlerts(incidentTestAPIHandler)
+	c := newTestClient(incidentTestAPIHandler)
 
 	expected := []*Incident{
 		{
@@ -139,7 +139,7 @@ func TestOpenListIncidents(t *testing.T) {
 func TestListIncidentsWithoutViolations(t *testing.T) {
 	t.Parallel()
 
-	c := newTestAlerts(incidentTestAPIHandler)
+	c := newTestClient(incidentTestAPIHandler)
 
 	expected := []*Incident{
 		{
@@ -171,7 +171,7 @@ func TestListIncidentsWithoutViolations(t *testing.T) {
 func TestListIncidentFailing(t *testing.T) {
 	t.Parallel()
 
-	c := newTestAlerts(failingTestHandler)
+	c := newTestClient(failingTestHandler)
 
 	_, err := c.ListIncidents(false, false)
 
@@ -208,7 +208,7 @@ func TestAcknowledgeIncident(t *testing.T) {
 func TestAcknowledgeIncidentFailing(t *testing.T) {
 	t.Parallel()
 
-	c := newTestAlerts(failingTestHandler)
+	c := newTestClient(failingTestHandler)
 
 	_, err := c.CloseIncident(42)
 
@@ -249,7 +249,7 @@ func TestCloseIncident(t *testing.T) {
 func TestCloseIncidentFailing(t *testing.T) {
 	t.Parallel()
 
-	c := newTestAlerts(failingTestHandler)
+	c := newTestClient(failingTestHandler)
 
 	_, err := c.CloseIncident(42)
 	if err == nil {

--- a/pkg/apm/apm_test.go
+++ b/pkg/apm/apm_test.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"testing"
 
+	mock "github.com/newrelic/newrelic-client-go/internal/testing"
 	"github.com/newrelic/newrelic-client-go/pkg/config"
-	"github.com/stretchr/testify/require"
 )
 
 // nolint
-func newTestAPMClient(handler http.Handler) APM {
+func newTestClient(handler http.Handler) APM {
 	ts := httptest.NewServer(handler)
 
 	c := New(config.Config{
@@ -30,14 +30,13 @@ func newMockResponse(
 	mockJSONResponse string,
 	statusCode int,
 ) APM {
-	return newTestAPMClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(statusCode)
+	ts := mock.NewMockServer(t, mockJSONResponse, statusCode)
 
-		_, err := w.Write([]byte(mockJSONResponse))
-
-		require.NoError(t, err)
-	}))
+	return New(config.Config{
+		APIKey:    "abc123",
+		BaseURL:   ts.URL,
+		UserAgent: "newrelic/newrelic-client-go",
+	})
 }
 
 // nolint

--- a/pkg/apm/applications_test.go
+++ b/pkg/apm/applications_test.go
@@ -5,24 +5,10 @@ package apm
 import (
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/newrelic/newrelic-client-go/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
-
-func NewTestAPM(handler http.Handler) APM {
-	ts := httptest.NewServer(handler)
-
-	c := New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
-		UserAgent: "newrelic/newrelic-client-go",
-	})
-
-	return c
-}
 
 var (
 	testApplicationSummary = ApplicationSummary{
@@ -114,16 +100,8 @@ var (
 
 func TestListApplications(t *testing.T) {
 	t.Parallel()
-	apm := NewTestAPM(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(fmt.Sprintf(`
-		{
-			"applications": [%s]
-		}
-		`, testApplicationJson)))
-
-		assert.NoError(t, err)
-	}))
+	responseJSON := fmt.Sprintf(`{ "applications": [%s] }`, testApplicationJson)
+	apm := newMockResponse(t, responseJSON, http.StatusOK)
 
 	actual, err := apm.ListApplications(nil)
 
@@ -141,7 +119,7 @@ func TestListApplicationsWithParams(t *testing.T) {
 	expectedLanguage := "appLanguage"
 	expectedIDs := "123,456"
 
-	apm := NewTestAPM(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apm := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		values := r.URL.Query()
 
 		name := values.Get("filter[name]")
@@ -174,17 +152,8 @@ func TestListApplicationsWithParams(t *testing.T) {
 
 func TestGetApplication(t *testing.T) {
 	t.Parallel()
-
-	apm := NewTestAPM(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(fmt.Sprintf(`
-		{
-			"application": %s
-		}
-		`, testApplicationJson)))
-
-		assert.NoError(t, err)
-	}))
+	responseJSON := fmt.Sprintf(`{ "application": %s}`, testApplicationJson)
+	apm := newMockResponse(t, responseJSON, http.StatusOK)
 
 	actual, err := apm.GetApplication(testApplication.ID)
 
@@ -195,17 +164,8 @@ func TestGetApplication(t *testing.T) {
 
 func TestUpdateApplication(t *testing.T) {
 	t.Parallel()
-
-	apm := NewTestAPM(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(fmt.Sprintf(`
-		{
-			"application": %s
-		}
-		`, testApplicationJson)))
-
-		assert.NoError(t, err)
-	}))
+	responseJSON := fmt.Sprintf(`{ "application": %s}`, testApplicationJson)
+	apm := newMockResponse(t, responseJSON, http.StatusOK)
 
 	params := UpdateApplicationParams{
 		Name:     testApplication.Name,
@@ -221,17 +181,8 @@ func TestUpdateApplication(t *testing.T) {
 
 func TestDeleteApplication(t *testing.T) {
 	t.Parallel()
-
-	apm := NewTestAPM(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(fmt.Sprintf(`
-		{
-			"application": %s
-		}
-		`, testApplicationJson)))
-
-		assert.NoError(t, err)
-	}))
+	responseJSON := fmt.Sprintf(`{ "application": %s}`, testApplicationJson)
+	apm := newMockResponse(t, responseJSON, http.StatusOK)
 
 	actual, err := apm.DeleteApplication(testApplication.ID)
 

--- a/pkg/apm/key_transactions_test.go
+++ b/pkg/apm/key_transactions_test.go
@@ -116,7 +116,7 @@ func TestListKeyTransactionsWithParams(t *testing.T) {
 	keyTransactionName := "test-key-transaction"
 	idsFilter := "123,456,789"
 
-	apm := newTestAPMClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	apm := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		values := r.URL.Query()
 		name := values.Get("filter[name]")
 

--- a/pkg/plugins/components_test.go
+++ b/pkg/plugins/components_test.go
@@ -116,8 +116,9 @@ var (
 func TestListComponents(t *testing.T) {
 	t.Parallel()
 	responseJSON := fmt.Sprintf(`{"components": [%s]}`, testComponentJSON)
-	client := newMockResponse(t, responseJSON, http.StatusOK)
-	c, err := client.ListComponents(nil)
+	plugins := newMockResponse(t, responseJSON, http.StatusOK)
+
+	c, err := plugins.ListComponents(nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, c)
@@ -131,7 +132,7 @@ func TestListComponentsWithParams(t *testing.T) {
 	expectedPluginID := "1234"
 	expectedHealthStatus := "true"
 
-	client := newTestPluginsClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	plugins := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		values := r.URL.Query()
 
 		name := values.Get("filter[name]")
@@ -167,16 +168,18 @@ func TestListComponentsWithParams(t *testing.T) {
 		HealthStatus: true,
 	}
 
-	c, err := client.ListComponents(&params)
+	c, err := plugins.ListComponents(&params)
 
 	require.NoError(t, err)
 	require.NotNil(t, c)
 }
 
 func TestGetComponent(t *testing.T) {
+	t.Parallel();
 	responseJSON := fmt.Sprintf(`{"component": %s}`, testComponentJSON)
-	client := newMockResponse(t, responseJSON, http.StatusOK)
-	c, err := client.GetComponent(testComponent.ID)
+	plugins := newMockResponse(t, responseJSON, http.StatusOK)
+
+	c, err := plugins.GetComponent(testComponent.ID)
 
 	require.NoError(t, err)
 	require.NotNil(t, c)
@@ -184,10 +187,11 @@ func TestGetComponent(t *testing.T) {
 }
 
 func TestListComponentMetrics(t *testing.T) {
+	t.Parallel();
 	responseJSON := fmt.Sprintf(`{"metrics": [%s]}`, testComponentMetricJSON)
-	client := newMockResponse(t, responseJSON, http.StatusOK)
+	plugins := newMockResponse(t, responseJSON, http.StatusOK)
 
-	m, err := client.ListComponentMetrics(testComponent.ID, nil)
+	m, err := plugins.ListComponentMetrics(testComponent.ID, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, m)
@@ -195,13 +199,15 @@ func TestListComponentMetrics(t *testing.T) {
 }
 
 func TestGetComponentMetricData(t *testing.T) {
+	t.Parallel();
 	responseJSON := fmt.Sprintf(`{
 		"metric_data": {
 			 "metrics": [%s]
 		}
 	}`, testMetricDataJSON)
-	client := newMockResponse(t, responseJSON, http.StatusOK)
-	m, err := client.GetComponentMetricData(testComponent.ID, nil)
+	plugins := newMockResponse(t, responseJSON, http.StatusOK)
+
+	m, err := plugins.GetComponentMetricData(testComponent.ID, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, m)
@@ -209,6 +215,7 @@ func TestGetComponentMetricData(t *testing.T) {
 }
 
 func TestGetComponentMetricDataWithParams(t *testing.T) {
+	t.Parallel();
 	expectedNames := "componentName"
 	expectedValues := "123"
 	expectedTo := testTimestamp.Format(time.RFC3339)
@@ -217,7 +224,7 @@ func TestGetComponentMetricDataWithParams(t *testing.T) {
 	expectedSummarize := "true"
 	expectedRaw := "true"
 
-	client := newTestPluginsClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	plugins := newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		values := r.URL.Query()
 
 		names := values.Get("names[]")
@@ -270,7 +277,7 @@ func TestGetComponentMetricDataWithParams(t *testing.T) {
 		Summarize: true,
 		Raw:       true,
 	}
-	_, err := client.GetComponentMetricData(testComponent.ID, &params)
+	_, err := plugins.GetComponentMetricData(testComponent.ID, &params)
 
 	require.NoError(t, err)
 }

--- a/pkg/synthetics/synthetics_test.go
+++ b/pkg/synthetics/synthetics_test.go
@@ -63,7 +63,7 @@ func TestError(t *testing.T) {
 }
 
 // nolint
-func newTestAlerts(handler http.Handler) Synthetics {
+func newTestClient(handler http.Handler) Synthetics {
 	ts := httptest.NewServer(handler)
 
 	c := New(config.Config{
@@ -82,7 +82,7 @@ func newMockResponse(
 	mockJSONResponse string,
 	statusCode int,
 ) Synthetics {
-	return newTestAlerts(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return newTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
 


### PR DESCRIPTION
Resolves: #34 

This PR also includes some minor refactor for a few unit tests to use our latest patterns.