### PR TITLE
fix: retry HTTP requests on 429 status codes

### DIFF
--- a/internal/http/retry.go
+++ b/internal/http/retry.go
@@ -56,7 +56,11 @@ func RetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, err
 	// disallowing retries for 500 errors here as the underlying APIs use them to
 	// provide useful error validation messages that should be passed back to the
 	// end user. This will catch invalid response codes as well, like 0 and 999.
-	if resp.StatusCode == 0 || (resp.StatusCode >= 502) {
+	// 429 Too Many Requests is retried as well to handle the aggressive rate limiting
+	// of the Synthetics API.
+	if resp.StatusCode == 0 ||
+		resp.StatusCode == 429 ||
+		resp.StatusCode >= 502 {
 		return true, nil
 	}
 


### PR DESCRIPTION
This PR introduces up to 3 HTTP request retries if the server sends back a 429 (Too Many Requests) as the response's status code.   This counteracts the aggressive rate limiting policy of the Synthetics API (6 req/sec), which often leads to integration test failures.