### PR TITLE
refactor: validate that at least one API key is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,8 @@ import (
 )
 
 func main() {
-	cfg := config.Config{
-		APIKey: os.Getenv("NEWRELIC_API_KEY"),
-	}
-
-	nr := newrelic.New(cfg)
+	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	nr := newrelic.New(ConfigAPIKey(apiKey))
 
 	params := apm.ListApplicationsParams{
 		Name: "RPM",

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -38,7 +38,7 @@ func New(opts ...ConfigOption) (*NewRelic, error) {
 	}
 
 	if config.APIKey == "" && config.PersonalAPIKey == "" {
-		return nil, errors.New("apiKey pr personalAPIKey required")
+		return nil, errors.New("use of ConfigAPIKey and/or ConfigPersonalAPIKey is required")
 	}
 
 	nr := &NewRelic{
@@ -54,9 +54,12 @@ func New(opts ...ConfigOption) (*NewRelic, error) {
 }
 
 // ConfigOption configures the Config when provided to NewApplication.
+// https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
 type ConfigOption func(*config.Config) error
 
 // ConfigAPIKey sets the New Relic Admin API key this client will use.
+// One of ConfigAPIKey or ConfigPersonalAPIKey must be used to create a client.
+// https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
 func ConfigAPIKey(apiKey string) ConfigOption {
 	return func(cfg *config.Config) error {
 		cfg.APIKey = apiKey
@@ -65,6 +68,8 @@ func ConfigAPIKey(apiKey string) ConfigOption {
 }
 
 // ConfigPersonalAPIKey sets the New Relic Personal API key this client will use.
+// One of ConfigAPIKey or ConfigPersonalAPIKey must be used to create a client.
+// https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
 func ConfigPersonalAPIKey(personalAPIKey string) ConfigOption {
 	return func(cfg *config.Config) error {
 		cfg.PersonalAPIKey = personalAPIKey

--- a/newrelic/newrelic_test.go
+++ b/newrelic/newrelic_test.go
@@ -18,7 +18,7 @@ var testAPIkey = "asdf1234"
 func TestNew_invalid(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New("")
+	nr, err := New(ConfigAPIKey(""))
 
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("apiKey required"), err)
@@ -27,7 +27,7 @@ func TestNew_invalid(t *testing.T) {
 func TestNew_basic(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(testAPIkey)
+	nr, err := New(ConfigAPIKey(testAPIkey))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -37,16 +37,25 @@ func TestNew_configOptionError(t *testing.T) {
 	t.Parallel()
 
 	badOption := func(cfg *config.Config) error { return errors.New("option with error") }
-	nr, err := New(testAPIkey, badOption)
+	nr, err := New(ConfigAPIKey(testAPIkey), badOption)
 
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("option with error"), err)
 }
 
+func TestNew_setPersonalAPIKey(t *testing.T) {
+	t.Parallel()
+
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigPersonalAPIKey(testAPIkey))
+
+	assert.NotNil(t, nr)
+	assert.NoError(t, err)
+}
+
 func TestNew_setRegion(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(testAPIkey, ConfigRegion("US"))
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigRegion("US"))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -56,7 +65,7 @@ func TestNew_optionTimeout(t *testing.T) {
 	t.Parallel()
 
 	timeout := time.Second * 30
-	nr, err := New(testAPIkey, ConfigHTTPTimeout(timeout))
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigHTTPTimeout(timeout))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -65,12 +74,12 @@ func TestNew_optionTimeout(t *testing.T) {
 func TestNew_optionTransport(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(testAPIkey, ConfigHTTPTransport(nil))
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigHTTPTransport(nil))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("HTTP Transport can not be nil"), err)
 
 	transport := http.DefaultTransport
-	nr, err = New(testAPIkey, ConfigHTTPTransport(&transport))
+	nr, err = New(ConfigAPIKey(testAPIkey), ConfigHTTPTransport(&transport))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -79,11 +88,11 @@ func TestNew_optionTransport(t *testing.T) {
 func TestNew_optionUserAgent(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(testAPIkey, ConfigUserAgent(""))
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigUserAgent(""))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("user-agent can not be empty"), err)
 
-	nr, err = New(testAPIkey, ConfigUserAgent("my-user-agent"))
+	nr, err = New(ConfigAPIKey(testAPIkey), ConfigUserAgent("my-user-agent"))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -92,11 +101,11 @@ func TestNew_optionUserAgent(t *testing.T) {
 func TestNew_optionBaseURL(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(testAPIkey, ConfigBaseURL(""))
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigBaseURL(""))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("base URL can not be empty"), err)
 
-	nr, err = New(testAPIkey, ConfigBaseURL("http://localhost/"))
+	nr, err = New(ConfigAPIKey(testAPIkey), ConfigBaseURL("http://localhost/"))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR exposes the `Entities` API via the `newrelic` catchall client, and abstracts the api key configuration behind `ConfigOption` methods.