### PR TITLE
chore(internal/version): skip version test on release branches

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -27,7 +27,7 @@ test-only: test-unit test-integration
 test-unit:
 	@echo "=== $(PROJECT_NAME) === [ test-unit        ]: running unit tests..."
 	@mkdir -p $(COVERAGE_DIR)
-	@$(GO) test -ldflags=$(LDFLAGS_UNIT) -parallel 4 -tags unit -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/unit.tmp $(GO_PKGS)
+	@$(GO) test -v -ldflags=$(LDFLAGS_UNIT) -parallel 4 -tags unit -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/unit.tmp $(GO_PKGS)
 
 test-integration:
 	@echo "=== $(PROJECT_NAME) === [ test-integration ]: running integration tests..."

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -3,6 +3,8 @@
 package version
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +14,10 @@ var GitTag = "undefined"
 
 func TestVersionTag(t *testing.T) {
 	t.Parallel()
+
+	if strings.HasPrefix(os.Getenv("CIRCLE_BRANCH"), "release/") {
+		t.Skip("skipping version test due to release branch")
+	}
 
 	assert.Equal(t, Version, GitTag)
 }

--- a/pkg/dashboards/dashboards_integration_test.go
+++ b/pkg/dashboards/dashboards_integration_test.go
@@ -20,7 +20,7 @@ func TestIntegrationDashboards(t *testing.T) {
 	}
 
 	dashboards := New(config.Config{
-		APIKey: apiKey,
+		APIKey:   apiKey,
 		LogLevel: "debug",
 	})
 

--- a/pkg/plugins/components_integration_test.go
+++ b/pkg/plugins/components_integration_test.go
@@ -20,7 +20,7 @@ func TestIntegrationComponents(t *testing.T) {
 	}
 
 	api := New(config.Config{
-		APIKey: apiKey,
+		APIKey:   apiKey,
 		LogLevel: "debug",
 	})
 

--- a/pkg/plugins/components_test.go
+++ b/pkg/plugins/components_test.go
@@ -175,7 +175,7 @@ func TestListComponentsWithParams(t *testing.T) {
 }
 
 func TestGetComponent(t *testing.T) {
-	t.Parallel();
+	t.Parallel()
 	responseJSON := fmt.Sprintf(`{"component": %s}`, testComponentJSON)
 	plugins := newMockResponse(t, responseJSON, http.StatusOK)
 
@@ -187,7 +187,7 @@ func TestGetComponent(t *testing.T) {
 }
 
 func TestListComponentMetrics(t *testing.T) {
-	t.Parallel();
+	t.Parallel()
 	responseJSON := fmt.Sprintf(`{"metrics": [%s]}`, testComponentMetricJSON)
 	plugins := newMockResponse(t, responseJSON, http.StatusOK)
 
@@ -199,7 +199,7 @@ func TestListComponentMetrics(t *testing.T) {
 }
 
 func TestGetComponentMetricData(t *testing.T) {
-	t.Parallel();
+	t.Parallel()
 	responseJSON := fmt.Sprintf(`{
 		"metric_data": {
 			 "metrics": [%s]
@@ -215,7 +215,7 @@ func TestGetComponentMetricData(t *testing.T) {
 }
 
 func TestGetComponentMetricDataWithParams(t *testing.T) {
-	t.Parallel();
+	t.Parallel()
 	expectedNames := "componentName"
 	expectedValues := "123"
 	expectedTo := testTimestamp.Format(time.RFC3339)

--- a/pkg/synthetics/monitors_integration_test.go
+++ b/pkg/synthetics/monitors_integration_test.go
@@ -36,7 +36,7 @@ func TestIntegrationMonitors(t *testing.T) {
 	}
 
 	synthetics := New(config.Config{
-		APIKey: apiKey,
+		APIKey:   apiKey,
 		LogLevel: "debug",
 	})
 


### PR DESCRIPTION
We need to skip `TestVersionTag` on releases because it will inevitably fail due to version mismatches on those PRs