### PR TITLE
fix(alerts): custom unmarshal of channel configuration Headers and Payload fields

### DIFF
--- a/pkg/alerts/alerts_types.go
+++ b/pkg/alerts/alerts_types.go
@@ -1,6 +1,8 @@
 package alerts
 
 import (
+	"encoding/json"
+
 	"github.com/newrelic/newrelic-client-go/internal/serialization"
 )
 
@@ -20,25 +22,29 @@ type ChannelLinks struct {
 
 // ChannelConfiguration represents a Configuration type within Channels
 type ChannelConfiguration struct {
-	Recipients            string      `json:"recipients,omitempty"`
-	IncludeJSONAttachment string      `json:"include_json_attachment,omitempty"`
-	AuthToken             string      `json:"auth_token,omitempty"`
-	APIKey                string      `json:"api_key,omitempty"`
-	Teams                 string      `json:"teams,omitempty"`
-	Tags                  string      `json:"tags,omitempty"`
-	URL                   string      `json:"url,omitempty"`
-	Channel               string      `json:"channel,omitempty"`
-	Key                   string      `json:"key,omitempty"`
-	RouteKey              string      `json:"route_key,omitempty"`
-	ServiceKey            string      `json:"service_key,omitempty"`
-	BaseURL               string      `json:"base_url,omitempty"`
-	AuthUsername          string      `json:"auth_username,omitempty"`
-	AuthPassword          string      `json:"auth_password,omitempty"`
-	PayloadType           string      `json:"payload_type,omitempty"`
-	Region                string      `json:"region,omitempty"`
-	UserID                string      `json:"user_id,omitempty"`
-	Payload               interface{} `json:"payload,omitempty"` // Note: Can be either an empty string or an object (causes marshal issues)
-	Headers               interface{} `json:"headers,omitempty"` // Note: Can be either an empty string or an object (causes marshal issues)
+	Recipients            string `json:"recipients,omitempty"`
+	IncludeJSONAttachment string `json:"include_json_attachment,omitempty"`
+	AuthToken             string `json:"auth_token,omitempty"`
+	APIKey                string `json:"api_key,omitempty"`
+	Teams                 string `json:"teams,omitempty"`
+	Tags                  string `json:"tags,omitempty"`
+	URL                   string `json:"url,omitempty"`
+	Channel               string `json:"channel,omitempty"`
+	Key                   string `json:"key,omitempty"`
+	RouteKey              string `json:"route_key,omitempty"`
+	ServiceKey            string `json:"service_key,omitempty"`
+	BaseURL               string `json:"base_url,omitempty"`
+	AuthUsername          string `json:"auth_username,omitempty"`
+	AuthPassword          string `json:"auth_password,omitempty"`
+	PayloadType           string `json:"payload_type,omitempty"`
+	Region                string `json:"region,omitempty"`
+	UserID                string `json:"user_id,omitempty"`
+
+	// Payload is unmarshaled to type map[string]string
+	Payload MapStringString `json:"payload,omitempty"`
+
+	// Headers is unmarshaled to type map[string]string
+	Headers MapStringString `json:"headers,omitempty"`
 }
 
 // Condition represents a New Relic alert condition.
@@ -182,4 +188,30 @@ type SyntheticsCondition struct {
 	Enabled    bool   `json:"enabled"`
 	RunbookURL string `json:"runbook_url,omitempty"`
 	MonitorID  string `json:"monitor_id,omitempty"`
+}
+
+// MapStringString is used for custom unmarshaling of
+// fields that have potentially dynamic types.
+// E.g. when a field can be a string or an object/map
+type MapStringString map[string]string
+type mapStringStringProxy MapStringString
+
+// UnmarshalJSON is a custom unmarshal method to guard against
+// fields that can have more than one type returned from an API.
+func (c *MapStringString) UnmarshalJSON(data []byte) error {
+	var mapStrStr mapStringStringProxy
+
+	// Check for empty JSON string
+	if string(data) == `""` {
+		return nil
+	}
+
+	err := json.Unmarshal(data, &mapStrStr)
+	if err != nil {
+		return err
+	}
+
+	*c = MapStringString(mapStrStr)
+
+	return nil
 }

--- a/pkg/alerts/alerts_types.go
+++ b/pkg/alerts/alerts_types.go
@@ -1,6 +1,8 @@
 package alerts
 
-import "github.com/newrelic/newrelic-client-go/internal/serialization"
+import (
+	"github.com/newrelic/newrelic-client-go/internal/serialization"
+)
 
 // Channel represents a New Relic alert notification channel
 type Channel struct {
@@ -18,25 +20,25 @@ type ChannelLinks struct {
 
 // ChannelConfiguration represents a Configuration type within Channels
 type ChannelConfiguration struct {
-	Recipients            string            `json:"recipients,omitempty"`
-	IncludeJSONAttachment string            `json:"include_json_attachment,omitempty"`
-	AuthToken             string            `json:"auth_token,omitempty"`
-	APIKey                string            `json:"api_key,omitempty"`
-	Teams                 string            `json:"teams,omitempty"`
-	Tags                  string            `json:"tags,omitempty"`
-	URL                   string            `json:"url,omitempty"`
-	Channel               string            `json:"channel,omitempty"`
-	Key                   string            `json:"key,omitempty"`
-	RouteKey              string            `json:"route_key,omitempty"`
-	ServiceKey            string            `json:"service_key,omitempty"`
-	BaseURL               string            `json:"base_url,omitempty"`
-	AuthUsername          string            `json:"auth_username,omitempty"`
-	AuthPassword          string            `json:"auth_password,omitempty"`
-	PayloadType           string            `json:"payload_type,omitempty"`
-	Region                string            `json:"region,omitempty"`
-	UserID                string            `json:"user_id,omitempty"`
-	Payload               map[string]string `json:"payload,omitempty"`
-	Headers               map[string]string `json:"headers,omitempty"`
+	Recipients            string      `json:"recipients,omitempty"`
+	IncludeJSONAttachment string      `json:"include_json_attachment,omitempty"`
+	AuthToken             string      `json:"auth_token,omitempty"`
+	APIKey                string      `json:"api_key,omitempty"`
+	Teams                 string      `json:"teams,omitempty"`
+	Tags                  string      `json:"tags,omitempty"`
+	URL                   string      `json:"url,omitempty"`
+	Channel               string      `json:"channel,omitempty"`
+	Key                   string      `json:"key,omitempty"`
+	RouteKey              string      `json:"route_key,omitempty"`
+	ServiceKey            string      `json:"service_key,omitempty"`
+	BaseURL               string      `json:"base_url,omitempty"`
+	AuthUsername          string      `json:"auth_username,omitempty"`
+	AuthPassword          string      `json:"auth_password,omitempty"`
+	PayloadType           string      `json:"payload_type,omitempty"`
+	Region                string      `json:"region,omitempty"`
+	UserID                string      `json:"user_id,omitempty"`
+	Payload               interface{} `json:"payload,omitempty"` // Note: Can be either an empty string or an object (causes marshal issues)
+	Headers               interface{} `json:"headers,omitempty"` // Note: Can be either an empty string or an object (causes marshal issues)
 }
 
 // Condition represents a New Relic alert condition.

--- a/pkg/alerts/channels_test.go
+++ b/pkg/alerts/channels_test.go
@@ -75,6 +75,44 @@ var (
 			"channel.policy_ids": "/v2/policies/{policy_id}"
 		}
 	}`
+
+	// Tests serialization of `headers` and `payload` fields
+	testWebhookEmptyHeadersAndPayloadResponseJSON = `{
+		"channels": [
+			{
+				"id": 1,
+				"name": "webhook-EMPTY-headers-and-payload",
+				"type": "webhook",
+				"configuration": {
+					"base_url": "http://example.com",
+					"headers": "",
+					"payload": "",
+					"payload_type": ""
+				},
+				"links": {
+					"policy_ids": []
+				}
+			},
+			{
+				"id": 2,
+				"name": "webhook-WEIRD-headers-and-payload",
+				"type": "webhook",
+				"configuration": {
+					"base_url": "http://example.com",
+					"headers": {
+						"": ""
+					},
+					"payload": {
+						"": ""
+					},
+					"payload_type": "application/json"
+				},
+				"links": {
+					"policy_ids": []
+				}
+			}
+		]
+	}`
 )
 
 func TestListChannels(t *testing.T) {
@@ -100,6 +138,50 @@ func TestListChannels(t *testing.T) {
 			Configuration: ChannelConfiguration{
 				Recipients:            "test@testing.com",
 				IncludeJSONAttachment: "true",
+			},
+			Links: ChannelLinks{
+				PolicyIDs: []int{},
+			},
+		},
+	}
+
+	actual, err := alerts.ListChannels()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestListChannelsWebhookWithEmptyHeadersAndPayload(t *testing.T) {
+	t.Parallel()
+	alerts := newMockResponse(t, testWebhookEmptyHeadersAndPayloadResponseJSON, http.StatusOK)
+
+	expected := []*Channel{
+		{
+			ID:   1,
+			Name: "webhook-EMPTY-headers-and-payload",
+			Type: "webhook",
+			Configuration: ChannelConfiguration{
+				BaseURL:     "http://example.com",
+				PayloadType: "",
+			},
+			Links: ChannelLinks{
+				PolicyIDs: []int{},
+			},
+		},
+		{
+			ID:   2,
+			Name: "webhook-WEIRD-headers-and-payload",
+			Type: "webhook",
+			Configuration: ChannelConfiguration{
+				BaseURL: "http://example.com",
+				Headers: MapStringString{
+					"": "",
+				},
+				Payload: MapStringString{
+					"": "",
+				},
+				PayloadType: "application/json",
 			},
 			Links: ChannelLinks{
 				PolicyIDs: []int{},


### PR DESCRIPTION
Resolves: #101 

### Synopsis
The New Relic v2 API endpoint for alert channels returns two different data types for `configuration.payload` and `configuration.headers`. If either of those fields is "empty" or left black when creating an alert channel in the UI, the API will return an empty string. But if headers and/or payload are included in an alert channel, the API will return an object, hence the need for a custom umarshal method for those fields.

**Example responses:**

Population headers and payload
```
{
  "type": "webhook",
  "configuration": {
    "headers": {                            
      "x-header-test": "header-value"  <-- notice we have an object here
    },                                                 
    "payload": {                                 
      "account_id": "$ACCOUNT_ID"   <-- notice we have an object here
    },
    "payload_type": "application/json",
    "base_url": "http://example.com"
  },
  // ...
}
```
Empty headers and payload
```
{
  "type": "webhook",
  "configuration": {
    "headers":  "",  <-- notice this is a string and NOT an object, so we have to guard for this
    "payload": "",   <-- notice this is a string and NOT an object, so we have to guard for this
    "payload_type": "application/json",
    "base_url": "http://example.com"
  },
  // ...
}
```
