### PR TITLE
feat(newrelic): add the ability to configure base URLs per API

### DIFF
--- a/internal/http/graphql_client.go
+++ b/internal/http/graphql_client.go
@@ -10,22 +10,24 @@ import (
 
 // GraphQLClient represents a graphQL HTTP client.
 type GraphQLClient struct {
-	client *NewRelicClient
+	Client *NewRelicClient
 	config config.Config
 	logger logging.Logger
 }
 
 // NewGraphQLClient returns a new instance of GraphQLClient.
 func NewGraphQLClient(cfg config.Config) *GraphQLClient {
-	if cfg.BaseURL == "" {
-		cfg.BaseURL = region.NerdGraphBaseURLs[region.Parse(cfg.Region)]
+	if cfg.NerdGraphBaseURL == "" {
+		cfg.NerdGraphBaseURL = region.NerdGraphBaseURLs[region.Parse(cfg.Region)]
 	}
+
+	cfg.BaseURL = cfg.NerdGraphBaseURL
 
 	c := NewClient(cfg)
 	c.SetErrorValue(&graphQLErrorResponse{})
 
 	return &GraphQLClient{
-		client: &c,
+		Client: &c,
 		config: cfg,
 		logger: cfg.GetLogger(),
 	}
@@ -42,7 +44,7 @@ func (g *GraphQLClient) Query(query string, vars map[string]interface{}, respBod
 		Data: respBody,
 	}
 
-	if _, err := g.client.Post(g.config.BaseURL, nil, &req, &resp); err != nil {
+	if _, err := g.Client.Post(g.config.BaseURL, nil, &req, &resp); err != nil {
 		return err
 	}
 

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -139,7 +139,7 @@ func ConfigInfrastructureBaseURL(url string) ConfigOption {
 			return nil
 		}
 
-		return errors.New("Infrastructure base URL can not be empty")
+		return errors.New("infrastructure base URL can not be empty")
 	}
 }
 
@@ -151,7 +151,7 @@ func ConfigSyntheticsBaseURL(url string) ConfigOption {
 			return nil
 		}
 
-		return errors.New("Synthetics base URL can not be empty")
+		return errors.New("synthetics base URL can not be empty")
 	}
 }
 
@@ -163,7 +163,7 @@ func ConfigNerdGraphBaseURL(url string) ConfigOption {
 			return nil
 		}
 
-		return errors.New("NerdGraph base URL can not be empty")
+		return errors.New("nerdgraph base URL can not be empty")
 	}
 }
 

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -118,7 +118,7 @@ func ConfigUserAgent(ua string) ConfigOption {
 	}
 }
 
-// ConfigBaseURL sets the Base URL used to make requests.
+// ConfigBaseURL sets the base URL used to make requests to the REST API V2.
 func ConfigBaseURL(url string) ConfigOption {
 	return func(cfg *config.Config) error {
 		if url != "" {
@@ -127,5 +127,41 @@ func ConfigBaseURL(url string) ConfigOption {
 		}
 
 		return errors.New("base URL can not be empty")
+	}
+}
+
+// ConfigInfrastructureBaseURL sets the base URL used to make requests to the Infrastructure API.
+func ConfigInfrastructureBaseURL(url string) ConfigOption {
+	return func(cfg *config.Config) error {
+		if url != "" {
+			cfg.InfrastructureBaseURL = url
+			return nil
+		}
+
+		return errors.New("Infrastructure base URL can not be empty")
+	}
+}
+
+// ConfigSyntheticsBaseURL sets the base URL used to make requests to the Synthetics API.
+func ConfigSyntheticsBaseURL(url string) ConfigOption {
+	return func(cfg *config.Config) error {
+		if url != "" {
+			cfg.SyntheticsBaseURL = url
+			return nil
+		}
+
+		return errors.New("Synthetics base URL can not be empty")
+	}
+}
+
+// ConfigNerdGraphBaseURL sets the base URL used to make requests to the NerdGraph API.
+func ConfigNerdGraphBaseURL(url string) ConfigOption {
+	return func(cfg *config.Config) error {
+		if url != "" {
+			cfg.NerdGraphBaseURL = url
+			return nil
+		}
+
+		return errors.New("NerdGraph base URL can not be empty")
 	}
 }

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/newrelic/newrelic-client-go/internal/logging"
 	"github.com/newrelic/newrelic-client-go/pkg/alerts"
 	"github.com/newrelic/newrelic-client-go/pkg/apm"
 	"github.com/newrelic/newrelic-client-go/pkg/config"
@@ -163,5 +164,38 @@ func ConfigNerdGraphBaseURL(url string) ConfigOption {
 		}
 
 		return errors.New("NerdGraph base URL can not be empty")
+	}
+}
+
+// ConfigLogLevel sets the log level for the client.
+func ConfigLogLevel(logLevel string) ConfigOption {
+	return func(cfg *config.Config) error {
+		if logLevel != "" {
+			cfg.LogLevel = logLevel
+			return nil
+		}
+
+		return errors.New("log level can not be empty")
+	}
+}
+
+// ConfigLogJSON toggles JSON formatting on for the logger if set to true.
+func ConfigLogJSON(logJSON bool) ConfigOption {
+	return func(cfg *config.Config) error {
+		cfg.LogJSON = logJSON
+		return nil
+	}
+}
+
+// ConfigLogger can be used to customize the client's logger.
+// Custom loggers must conform to the logging.Logger interface.
+func ConfigLogger(logger logging.Logger) ConfigOption {
+	return func(cfg *config.Config) error {
+		if logger != nil {
+			cfg.Logger = logger
+			return nil
+		}
+
+		return errors.New("logger can not be nil")
 	}
 }

--- a/newrelic/newrelic_test.go
+++ b/newrelic/newrelic_test.go
@@ -116,7 +116,7 @@ func TestNew_optionInfrastructureBaseURL(t *testing.T) {
 
 	nr, err := New(ConfigAPIKey(testAPIkey), ConfigInfrastructureBaseURL(""))
 	assert.Nil(t, nr)
-	assert.Error(t, errors.New("Infrastructure base URL can not be empty"), err)
+	assert.Error(t, errors.New("infrastructure base URL can not be empty"), err)
 
 	nr, err = New(ConfigAPIKey(testAPIkey), ConfigInfrastructureBaseURL("http://localhost/"))
 
@@ -129,7 +129,7 @@ func TestNew_optionSyntheticsBaseURL(t *testing.T) {
 
 	nr, err := New(ConfigAPIKey(testAPIkey), ConfigSyntheticsBaseURL(""))
 	assert.Nil(t, nr)
-	assert.Error(t, errors.New("Synthetics base URL can not be empty"), err)
+	assert.Error(t, errors.New("synthetics base URL can not be empty"), err)
 
 	nr, err = New(ConfigAPIKey(testAPIkey), ConfigSyntheticsBaseURL("http://localhost/"))
 
@@ -141,7 +141,7 @@ func TestNew_optionNerdGraphBaseURL(t *testing.T) {
 
 	nr, err := New(ConfigAPIKey(testAPIkey), ConfigNerdGraphBaseURL(""))
 	assert.Nil(t, nr)
-	assert.Error(t, errors.New("NerdGraph base URL can not be empty"), err)
+	assert.Error(t, errors.New("nerdgraph base URL can not be empty"), err)
 
 	nr, err = New(ConfigAPIKey(testAPIkey), ConfigNerdGraphBaseURL("http://localhost/"))
 

--- a/newrelic/newrelic_test.go
+++ b/newrelic/newrelic_test.go
@@ -110,3 +110,41 @@ func TestNew_optionBaseURL(t *testing.T) {
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
 }
+
+func TestNew_optionInfrastructureBaseURL(t *testing.T) {
+	t.Parallel()
+
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigInfrastructureBaseURL(""))
+	assert.Nil(t, nr)
+	assert.Error(t, errors.New("Infrastructure base URL can not be empty"), err)
+
+	nr, err = New(ConfigAPIKey(testAPIkey), ConfigInfrastructureBaseURL("http://localhost/"))
+
+	assert.NotNil(t, nr)
+	assert.NoError(t, err)
+}
+
+func TestNew_optionSyntheticsBaseURL(t *testing.T) {
+	t.Parallel()
+
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigSyntheticsBaseURL(""))
+	assert.Nil(t, nr)
+	assert.Error(t, errors.New("Synthetics base URL can not be empty"), err)
+
+	nr, err = New(ConfigAPIKey(testAPIkey), ConfigSyntheticsBaseURL("http://localhost/"))
+
+	assert.NotNil(t, nr)
+	assert.NoError(t, err)
+}
+func TestNew_optionNerdGraphBaseURL(t *testing.T) {
+	t.Parallel()
+
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigNerdGraphBaseURL(""))
+	assert.Nil(t, nr)
+	assert.Error(t, errors.New("NerdGraph base URL can not be empty"), err)
+
+	nr, err = New(ConfigAPIKey(testAPIkey), ConfigNerdGraphBaseURL("http://localhost/"))
+
+	assert.NotNil(t, nr)
+	assert.NoError(t, err)
+}

--- a/newrelic/newrelic_test.go
+++ b/newrelic/newrelic_test.go
@@ -148,3 +148,47 @@ func TestNew_optionNerdGraphBaseURL(t *testing.T) {
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
 }
+
+func TestNew_optionLogLevel(t *testing.T) {
+	t.Parallel()
+
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigLogLevel(""))
+	assert.Nil(t, nr)
+	assert.Error(t, errors.New("log level can not be empty"), err)
+
+	nr, err = New(ConfigAPIKey(testAPIkey), ConfigLogLevel("debug"))
+
+	assert.NotNil(t, nr)
+	assert.NoError(t, err)
+}
+
+func TestNew_optionLogJSON(t *testing.T) {
+	t.Parallel()
+
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigLogJSON(true))
+
+	assert.NotNil(t, nr)
+	assert.NoError(t, err)
+}
+
+type TestLogger struct{}
+
+func (t *TestLogger) Error(s string, a ...interface{}) {}
+func (t *TestLogger) Info(s string, a ...interface{})  {}
+func (t *TestLogger) Debug(s string, a ...interface{}) {}
+func (t *TestLogger) Warn(s string, a ...interface{})  {}
+
+func TestNew_optionLogger(t *testing.T) {
+	t.Parallel()
+
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigLogger(nil))
+	assert.Nil(t, nr)
+	assert.Error(t, errors.New("logger can not be nil"), err)
+
+	testLogger := TestLogger{}
+
+	nr, err = New(ConfigAPIKey(testAPIkey), ConfigLogger(&testLogger))
+
+	assert.NotNil(t, nr)
+	assert.NoError(t, err)
+}

--- a/pkg/alerts/alerts.go
+++ b/pkg/alerts/alerts.go
@@ -20,9 +20,11 @@ type Alerts struct {
 func New(config config.Config) Alerts {
 	infraConfig := config
 
-	if config.BaseURL == "" {
-		infraConfig.BaseURL = infrastructure.BaseURLs[region.Parse(config.Region)]
+	if infraConfig.InfrastructureBaseURL == "" {
+		infraConfig.InfrastructureBaseURL = infrastructure.BaseURLs[region.Parse(config.Region)]
 	}
+
+	infraConfig.BaseURL = infraConfig.InfrastructureBaseURL
 
 	infraClient := http.NewClient(infraConfig)
 	infraClient.SetErrorValue(&infrastructure.ErrorResponse{})

--- a/pkg/alerts/alerts_test.go
+++ b/pkg/alerts/alerts_test.go
@@ -8,6 +8,7 @@ import (
 
 	mock "github.com/newrelic/newrelic-client-go/internal/testing"
 	"github.com/newrelic/newrelic-client-go/pkg/config"
+	"github.com/stretchr/testify/assert"
 )
 
 // TODO: This is used by incidents_test.go still, need to refactor
@@ -16,9 +17,10 @@ func newTestClient(handler http.Handler) Alerts {
 	ts := httptest.NewServer(handler)
 
 	c := New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
-		UserAgent: "newrelic/newrelic-client-go",
+		APIKey:                "abc123",
+		BaseURL:               ts.URL,
+		InfrastructureBaseURL: ts.URL,
+		UserAgent:             "newrelic/newrelic-client-go",
 	})
 
 	return c
@@ -33,9 +35,10 @@ func newMockResponse(
 	ts := mock.NewMockServer(t, mockJSONResponse, statusCode)
 
 	return New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
-		UserAgent: "newrelic/newrelic-client-go",
+		APIKey:                "abc123",
+		BaseURL:               ts.URL,
+		InfrastructureBaseURL: ts.URL,
+		UserAgent:             "newrelic/newrelic-client-go",
 	})
 }
 
@@ -51,4 +54,20 @@ func newIntegrationTestClient(t *testing.T) Alerts {
 		APIKey:   apiKey,
 		LogLevel: "debug",
 	})
+}
+
+func TestSetBaseURL(t *testing.T) {
+	a := New(config.Config{
+		BaseURL: "http://localhost",
+	})
+
+	assert.Equal(t, "http://localhost", a.client.Config.BaseURL)
+}
+
+func TestSetInfrastructureBaseURL(t *testing.T) {
+	a := New(config.Config{
+		InfrastructureBaseURL: "http://localhost",
+	})
+
+	assert.Equal(t, "http://localhost", a.infraClient.Config.BaseURL)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,10 +21,13 @@ type Config struct {
 	Region string
 
 	// HTTP
-	Timeout       *time.Duration
-	HTTPTransport *http.RoundTripper
-	UserAgent     string
-	BaseURL       string
+	Timeout               *time.Duration
+	HTTPTransport         *http.RoundTripper
+	UserAgent             string
+	BaseURL               string
+	SyntheticsBaseURL     string
+	InfrastructureBaseURL string
+	NerdGraphBaseURL      string
 
 	// LogLevel can be one of the following values:
 	// "panic", "fatal", "error", "warn", "info", "debug", "trace"

--- a/pkg/entities/entities_test.go
+++ b/pkg/entities/entities_test.go
@@ -1,0 +1,16 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/newrelic/newrelic-client-go/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetNerdGraphBaseURL(t *testing.T) {
+	a := New(config.Config{
+		NerdGraphBaseURL: "http://localhost",
+	})
+
+	assert.Equal(t, "http://localhost", a.client.Client.Config.BaseURL)
+}

--- a/pkg/synthetics/synthetics.go
+++ b/pkg/synthetics/synthetics.go
@@ -59,9 +59,11 @@ func (e *ErrorResponse) Error() string {
 // New is used to create a new Synthetics client instance.
 func New(config config.Config) Synthetics {
 
-	if config.BaseURL == "" {
-		config.BaseURL = BaseURLs[region.Parse(config.Region)]
+	if config.SyntheticsBaseURL == "" {
+		config.SyntheticsBaseURL = BaseURLs[region.Parse(config.Region)]
 	}
+
+	config.BaseURL = config.SyntheticsBaseURL
 
 	client := http.NewClient(config)
 	client.SetErrorValue(&ErrorResponse{})

--- a/pkg/synthetics/synthetics_test.go
+++ b/pkg/synthetics/synthetics_test.go
@@ -67,10 +67,10 @@ func newTestClient(handler http.Handler) Synthetics {
 	ts := httptest.NewServer(handler)
 
 	c := New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
-		UserAgent: "newrelic/newrelic-client-go",
-		LogLevel:  "debug",
+		APIKey:            "abc123",
+		SyntheticsBaseURL: ts.URL,
+		UserAgent:         "newrelic/newrelic-client-go",
+		LogLevel:          "debug",
 	})
 
 	return c
@@ -90,4 +90,12 @@ func newMockResponse(
 
 		require.NoError(t, err)
 	}))
+}
+
+func TestSetSyntheticsBaseURL(t *testing.T) {
+	a := New(config.Config{
+		SyntheticsBaseURL: "http://localhost",
+	})
+
+	assert.Equal(t, "http://localhost", a.client.Config.BaseURL)
 }


### PR DESCRIPTION
This PR adds the ability to configure base URLs per API when using the rollup client in the `newrelic` package.