### PR TITLE
refactor: post-release clean up

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -46,7 +46,7 @@ func NewClient(cfg config.Config) NewRelicClient {
 	}
 
 	if cfg.HTTPTransport != nil {
-		if transport, ok := (*cfg.HTTPTransport).(*http.Transport); ok {
+		if transport, ok := (cfg.HTTPTransport).(*http.Transport); ok {
 			c.Transport = transport
 		}
 	} else {

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -26,12 +26,12 @@ func TestConfig(t *testing.T) {
 		BaseURL:       testBaseURL,
 		UserAgent:     testUserAgent,
 		Timeout:       &testTimeout,
-		HTTPTransport: &testTransport,
+		HTTPTransport: testTransport,
 	})
 
 	assert.Equal(t, &testTimeout, c.Config.Timeout)
 	assert.Equal(t, testBaseURL, c.Config.BaseURL)
-	assert.Same(t, &testTransport, c.Config.HTTPTransport)
+	assert.Same(t, testTransport, c.Config.HTTPTransport)
 }
 
 func TestConfigDefaults(t *testing.T) {

--- a/internal/logging/structured_logger.go
+++ b/internal/logging/structured_logger.go
@@ -12,15 +12,11 @@ var (
 )
 
 // StructuredLogger is a logger based on logrus.
-type StructuredLogger struct {
-	logger *log.Logger
-}
+type StructuredLogger struct{}
 
 // NewStructuredLogger creates a new structured logger.
 func NewStructuredLogger() StructuredLogger {
-	return StructuredLogger{
-		logger: log.New(),
-	}
+	return StructuredLogger{}
 }
 
 // SetLogLevel allows the log level to be set.
@@ -35,7 +31,7 @@ func (l StructuredLogger) SetLogLevel(logLevel string) StructuredLogger {
 		level, _ = log.ParseLevel(defaultLogLevel)
 	}
 
-	l.logger.SetLevel(level)
+	log.SetLevel(level)
 
 	return l
 }
@@ -43,7 +39,7 @@ func (l StructuredLogger) SetLogLevel(logLevel string) StructuredLogger {
 // LogJSON determines whether or not to format the logs as JSON.
 func (l StructuredLogger) LogJSON(value bool) StructuredLogger {
 	if value {
-		l.logger.SetFormatter(&log.JSONFormatter{})
+		log.SetFormatter(&log.JSONFormatter{})
 	}
 
 	return l
@@ -51,29 +47,29 @@ func (l StructuredLogger) LogJSON(value bool) StructuredLogger {
 
 // SetDefaultFields sets fields to be logged on every use of the logger.
 func (l StructuredLogger) SetDefaultFields(defaultFields map[string]string) StructuredLogger {
-	l.logger.AddHook(&defaultFieldHook{})
+	log.AddHook(&defaultFieldHook{})
 
 	return l
 }
 
 // Error logs an error message.
 func (l StructuredLogger) Error(msg string, fields ...interface{}) {
-	l.logger.WithFields(createFieldMap(fields)).Error(msg)
+	log.WithFields(createFieldMap(fields)).Error(msg)
 }
 
 // Info logs an info message.
 func (l StructuredLogger) Info(msg string, fields ...interface{}) {
-	l.logger.WithFields(createFieldMap(fields)).Info(msg)
+	log.WithFields(createFieldMap(fields)).Info(msg)
 }
 
 // Debug logs a debug message.
 func (l StructuredLogger) Debug(msg string, fields ...interface{}) {
-	l.logger.WithFields(createFieldMap(fields)).Debug(msg)
+	log.WithFields(createFieldMap(fields)).Debug(msg)
 }
 
 // Warn logs an warning message.
 func (l StructuredLogger) Warn(msg string, fields ...interface{}) {
-	l.logger.WithFields(createFieldMap(fields)).Warn(msg)
+	log.WithFields(createFieldMap(fields)).Warn(msg)
 }
 
 func createFieldMap(fields ...interface{}) map[string]interface{} {

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -96,7 +96,7 @@ func ConfigHTTPTimeout(t time.Duration) ConfigOption {
 }
 
 // ConfigHTTPTransport sets the HTTP Transporter.
-func ConfigHTTPTransport(transport *http.RoundTripper) ConfigOption {
+func ConfigHTTPTransport(transport http.RoundTripper) ConfigOption {
 	return func(cfg *config.Config) error {
 		if transport != nil {
 			cfg.HTTPTransport = transport

--- a/newrelic/newrelic_test.go
+++ b/newrelic/newrelic_test.go
@@ -79,7 +79,7 @@ func TestNew_optionTransport(t *testing.T) {
 	assert.Error(t, errors.New("HTTP Transport can not be nil"), err)
 
 	transport := http.DefaultTransport
-	nr, err = New(ConfigAPIKey(testAPIkey), ConfigHTTPTransport(&transport))
+	nr, err = New(ConfigAPIKey(testAPIkey), ConfigHTTPTransport(transport))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 
 	// HTTP
 	Timeout               *time.Duration
-	HTTPTransport         *http.RoundTripper
+	HTTPTransport         http.RoundTripper
 	UserAgent             string
 	BaseURL               string
 	SyntheticsBaseURL     string

--- a/pkg/entities/entities.go
+++ b/pkg/entities/entities.go
@@ -22,8 +22,8 @@ func New(config config.Config) Entities {
 	}
 }
 
-// ListEntitiesParams represents a set of search parameters for retrieving New Relic One entities.
-type ListEntitiesParams struct {
+// SearchEntitiesParams represents a set of search parameters for retrieving New Relic One entities.
+type SearchEntitiesParams struct {
 	AlertSeverity                 EntityAlertSeverityType `json:"alertSeverity,omitempty"`
 	Domain                        EntityDomainType        `json:"domain,omitempty"`
 	InfrastructureIntegrationType string                  `json:"infrastructureIntegrationType,omitempty"`
@@ -34,7 +34,7 @@ type ListEntitiesParams struct {
 }
 
 // SearchEntities searches New Relic One entities based on the provided search parameters.
-func (e *Entities) SearchEntities(params ListEntitiesParams) ([]*Entity, error) {
+func (e *Entities) SearchEntities(params SearchEntitiesParams) ([]*Entity, error) {
 	entities := []*Entity{}
 	var nextCursor *string
 

--- a/pkg/entities/entities_integration_test.go
+++ b/pkg/entities/entities_integration_test.go
@@ -15,7 +15,7 @@ func TestIntegrationSearchEntities(t *testing.T) {
 
 	client := newIntegrationTestClient(t)
 
-	params := ListEntitiesParams{
+	params := SearchEntitiesParams{
 		Name: "Dummy App",
 	}
 	actual, err := client.SearchEntities(params)


### PR DESCRIPTION
This PR updates a few things for conventions' and cleanliness' sake:

- Remove some unnecessary `fmt.Printf`s in test code
- Remove pointers to the `RoundTripper` interface when passing an HTTP transport via config
- Renames `ListEntitiesParams` to `SearchEntitiesParams` for consistency

