### PR TITLE
feat(alerts): Implement multi-location synthetics conditions

### DIFF
--- a/pkg/alerts/alerts_types.go
+++ b/pkg/alerts/alerts_types.go
@@ -192,6 +192,29 @@ type SyntheticsCondition struct {
 	MonitorID  string `json:"monitor_id,omitempty"`
 }
 
+// MultiLocationSyntheticsCondition represents a location-based failure condition.
+//
+// ViolationTimeLimitSeconds must be one of 3600, 7200, 14400, 28800, 43200, 86400.
+type MultiLocationSyntheticsCondition struct {
+	ID                        int                                    `json:"id,omitempty"`
+	Name                      string                                 `json:"name,omitempty"`
+	Enabled                   bool                                   `json:"enabled"`
+	RunbookURL                string                                 `json:"runbook_url,omitempty"`
+	MonitorID                 string                                 `json:"monitor_id,omitempty"`
+	Entities                  []string                               `json:"entities,omitempty"`
+	Terms                     []MultiLocationSyntheticsConditionTerm `json:"terms,omitempty"`
+	ViolationTimeLimitSeconds int                                    `json:"violation_time_limit_seconds,omitempty"`
+}
+
+// MultiLocationSyntheticsConditionTerm represents a single term for a location-based failure condition.
+//
+// Priority must be "warning" or "critical".
+// Threshold must be greater than zero.
+type MultiLocationSyntheticsConditionTerm struct {
+	Priority  string `json:"priority,omitempty"`
+	Threshold int    `json:"threshold,omitempty"`
+}
+
 // MapStringInterface is used for custom unmarshaling of
 // fields that have potentially dynamic types.
 // E.g. when a field can be a string or an object/map

--- a/pkg/alerts/multi_location_synthetics_conditions.go
+++ b/pkg/alerts/multi_location_synthetics_conditions.go
@@ -1,0 +1,94 @@
+package alerts
+
+import (
+	"fmt"
+)
+
+// ListMultiLocationSyntheticsConditions returns alert conditions for a specified policy.
+func (alerts *Alerts) ListMultiLocationSyntheticsConditions(policyID int) ([]*MultiLocationSyntheticsCondition, error) {
+	response := multiLocationSyntheticsConditionListResponse{}
+	multiLocationSyntheticsConditions := []*MultiLocationSyntheticsCondition{}
+	queryParams := listMultiLocationSyntheticsConditionsParams{
+		PolicyID: policyID,
+	}
+
+	nextURL := fmt.Sprintf("/alerts_location_failure_conditions/policies/%d.json", policyID)
+
+	for nextURL != "" {
+		resp, err := alerts.client.Get(nextURL, &queryParams, &response)
+
+		if err != nil {
+			return nil, err
+		}
+
+		multiLocationSyntheticsConditions = append(multiLocationSyntheticsConditions, response.MultiLocationSyntheticsConditions...)
+
+		paging := alerts.pager.Parse(resp)
+		nextURL = paging.Next
+	}
+
+	return multiLocationSyntheticsConditions, nil
+}
+
+// CreateMultiLocationSyntheticsCondition creates an alert condition for a specified policy.
+func (alerts *Alerts) CreateMultiLocationSyntheticsCondition(condition MultiLocationSyntheticsCondition, policyID int) (*MultiLocationSyntheticsCondition, error) {
+	reqBody := multiLocationSyntheticsConditionRequestBody{
+		MultiLocationSyntheticsCondition: condition,
+	}
+	resp := multiLocationSyntheticsConditionCreateResponse{}
+
+	u := fmt.Sprintf("/alerts_location_failure_conditions/policies/%d.json", policyID)
+	_, err := alerts.client.Post(u, nil, &reqBody, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.MultiLocationSyntheticsCondition, nil
+}
+
+// UpdateMultiLocationSyntheticsCondition updates an alert condition.
+func (alerts *Alerts) UpdateMultiLocationSyntheticsCondition(condition MultiLocationSyntheticsCondition) (*MultiLocationSyntheticsCondition, error) {
+	reqBody := multiLocationSyntheticsConditionRequestBody{
+		MultiLocationSyntheticsCondition: condition,
+	}
+	resp := multiLocationSyntheticsConditionCreateResponse{}
+
+	u := fmt.Sprintf("/alerts_location_failure_conditions/%d.json", condition.ID)
+	_, err := alerts.client.Put(u, nil, &reqBody, &resp)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.MultiLocationSyntheticsCondition, nil
+}
+
+// DeleteMultiLocationSyntheticsCondition delete an alert condition.
+func (alerts *Alerts) DeleteMultiLocationSyntheticsCondition(conditionID int) (*MultiLocationSyntheticsCondition, error) {
+	resp := multiLocationSyntheticsConditionCreateResponse{}
+	u := fmt.Sprintf("/alerts_conditions/%d.json", conditionID)
+
+	_, err := alerts.client.Delete(u, nil, &resp)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.MultiLocationSyntheticsCondition, nil
+}
+
+type listMultiLocationSyntheticsConditionsParams struct {
+	PolicyID int `url:"policy_id,omitempty"`
+}
+
+type multiLocationSyntheticsConditionListResponse struct {
+	MultiLocationSyntheticsConditions []*MultiLocationSyntheticsCondition `json:"location_failure_conditions,omitempty"`
+}
+
+type multiLocationSyntheticsConditionCreateResponse struct {
+	MultiLocationSyntheticsCondition MultiLocationSyntheticsCondition `json:"location_failure_condition,omitempty"`
+}
+
+type multiLocationSyntheticsConditionRequestBody struct {
+	MultiLocationSyntheticsCondition MultiLocationSyntheticsCondition `json:"location_failure_condition,omitempty"`
+}

--- a/pkg/alerts/multi_location_synthetics_conditions_integration_test.go
+++ b/pkg/alerts/multi_location_synthetics_conditions_integration_test.go
@@ -1,0 +1,75 @@
+// +build integration
+
+package alerts
+
+import (
+	"fmt"
+	"testing"
+
+	nr "github.com/newrelic/newrelic-client-go/internal/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationMultiLocationSyntheticsConditions(t *testing.T) {
+	t.Parallel()
+
+	var (
+		testIntegrationInfrastructureConditionRandStr = nr.RandSeq(5)
+		testIntegrationInfrastructureConditionPolicy  = Policy{
+			Name: fmt.Sprintf("test-integration-location-failure-condition-%s",
+				testIntegrationInfrastructureConditionRandStr),
+			IncidentPreference: "PER_POLICY",
+		}
+
+		testIntegrationMultiLocationSyntheticsCondition = MultiLocationSyntheticsCondition{
+			Name:    fmt.Sprintf("test-integration-location-failure-condition-%s", testIntegrationInfrastructureConditionRandStr),
+			Enabled: false,
+			Terms: []MultiLocationSyntheticsConditionTerm{
+				{"warning", 10},
+				{"critical", 11},
+			},
+		}
+	)
+
+	alerts := newIntegrationTestClient(t)
+
+	// Setup
+	policy, err := alerts.CreatePolicy(testIntegrationInfrastructureConditionPolicy)
+	require.NoError(t, err)
+
+	// Deferred teardown
+	defer func() {
+		_, err := alerts.DeletePolicy(policy.ID)
+
+		if err != nil {
+			t.Logf("error cleaning up alert policy %d (%s): %s", policy.ID, policy.Name, err)
+		}
+	}()
+
+	// Test: Create
+	created, err := alerts.CreateMultiLocationSyntheticsCondition(testIntegrationMultiLocationSyntheticsCondition, policy.ID)
+	require.NoError(t, err)
+	require.NotZero(t, created)
+
+	defer func() {
+		_, err := alerts.DeleteMultiLocationSyntheticsCondition(created.ID)
+		if err != nil {
+			t.Logf("error cleaning up location failure condition %d (%s): %s", policy.ID, policy.Name, err)
+		}
+	}()
+
+	// // Test: List
+	conditions, err := alerts.ListMultiLocationSyntheticsConditions(policy.ID)
+
+	require.NoError(t, err)
+	require.Greater(t, len(conditions), 0)
+
+	// Test: Update
+	created.Name = "Updated"
+	created.Enabled = true
+	updated, err := alerts.UpdateMultiLocationSyntheticsCondition(*created)
+
+	require.NoError(t, err)
+	require.NotZero(t, updated)
+
+}

--- a/pkg/alerts/multi_location_synthetics_conditions_test.go
+++ b/pkg/alerts/multi_location_synthetics_conditions_test.go
@@ -1,0 +1,152 @@
+package alerts
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testMultiLocationSyntheticsConditionPolicyID = 111111
+	testMultiLocationSyntheticsConditionsJSON    = `
+		{
+			"location_failure_conditions": [
+				{
+					"id": 11425367,
+					"name": "Zach is testing",
+					"enabled": true,
+					"entities": [
+						"0d3d7d23-9d7e-44ba-ac74-242ce325161c",
+						"767958fe-f47a-49ac-88e3-9fbd0d85b2a0",
+						"5d968daa-a226-45b9-b877-1d6601e599d8"
+					],
+					"terms": [
+						{
+							"priority": "warning",
+							"threshold": 1
+						},
+						{
+							"priority": "critical",
+							"threshold": 2
+						}
+					],
+					"violation_time_limit_seconds": 3600
+				}
+			]
+		}
+	`
+
+	testMultiLocationSyntheticsConditionJSON = `
+		{
+			"location_failure_condition": {
+				"id": 11425367,
+				"name": "Zach is testing",
+				"enabled": true,
+				"entities": [
+					"0d3d7d23-9d7e-44ba-ac74-242ce325161c",
+					"767958fe-f47a-49ac-88e3-9fbd0d85b2a0",
+					"5d968daa-a226-45b9-b877-1d6601e599d8"
+				],
+				"terms": [
+					{
+						"priority": "warning",
+						"threshold": 1
+					},
+					{
+						"priority": "critical",
+						"threshold": 2
+					}
+				],
+				"violation_time_limit_seconds": 3600
+			}
+		}
+	`
+
+	testMultiLocationSyntheticsCondition = MultiLocationSyntheticsCondition{
+		ID:      11425367,
+		Name:    "Zach is testing",
+		Enabled: true,
+		Entities: []string{
+			"0d3d7d23-9d7e-44ba-ac74-242ce325161c",
+			"767958fe-f47a-49ac-88e3-9fbd0d85b2a0",
+			"5d968daa-a226-45b9-b877-1d6601e599d8",
+		},
+		Terms: []MultiLocationSyntheticsConditionTerm{
+			{"warning", 1},
+			{"critical", 2},
+		},
+		ViolationTimeLimitSeconds: 3600,
+	}
+
+	testCreateMultiLocationSyntheticsCondition = MultiLocationSyntheticsCondition{
+		Name:    "Zach is testing",
+		Enabled: true,
+		Entities: []string{
+			"0d3d7d23-9d7e-44ba-ac74-242ce325161c",
+			"767958fe-f47a-49ac-88e3-9fbd0d85b2a0",
+			"5d968daa-a226-45b9-b877-1d6601e599d8",
+		},
+		Terms: []MultiLocationSyntheticsConditionTerm{
+			{"warning", 1},
+			{"critical", 2},
+		},
+		ViolationTimeLimitSeconds: 3600,
+	}
+)
+
+func TestListMultiLocationSyntheticsConditions(t *testing.T) {
+	t.Parallel()
+	respJSON := testMultiLocationSyntheticsConditionsJSON
+	alerts := newMockResponse(t, respJSON, http.StatusOK)
+
+	expected := []*MultiLocationSyntheticsCondition{&testMultiLocationSyntheticsCondition}
+
+	actual, err := alerts.ListMultiLocationSyntheticsConditions(testMultiLocationSyntheticsConditionPolicyID)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.Equal(t, expected, actual)
+}
+
+func TestCreateMultiLocationSyntheticsCondition(t *testing.T) {
+	t.Parallel()
+	respJSON := testMultiLocationSyntheticsConditionJSON
+	alerts := newMockResponse(t, respJSON, http.StatusOK)
+
+	expected := &testMultiLocationSyntheticsCondition
+
+	actual, err := alerts.CreateMultiLocationSyntheticsCondition(testCreateMultiLocationSyntheticsCondition, testMultiLocationSyntheticsConditionPolicyID)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.Equal(t, expected, actual)
+}
+
+func TestUpdateMultiLocationSyntheticsCondition(t *testing.T) {
+	t.Parallel()
+	respJSON := testMultiLocationSyntheticsConditionJSON
+	alerts := newMockResponse(t, respJSON, http.StatusOK)
+
+	expected := &testMultiLocationSyntheticsCondition
+
+	actual, err := alerts.UpdateMultiLocationSyntheticsCondition(testMultiLocationSyntheticsCondition)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.Equal(t, expected, actual)
+}
+
+func TestDeleteMultiLocationSyntheticsCondition(t *testing.T) {
+	t.Parallel()
+	respJSON := testMultiLocationSyntheticsConditionJSON
+	alerts := newMockResponse(t, respJSON, http.StatusOK)
+
+	expected := &testMultiLocationSyntheticsCondition
+
+	actual, err := alerts.DeleteMultiLocationSyntheticsCondition(testMultiLocationSyntheticsCondition.ID)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.Equal(t, expected, actual)
+}


### PR DESCRIPTION
resolves: #72

Currently there is no facility to manage location_failure_conditions in the
Alerts API.  Here we add what is necessary to manage these resources.