### PR TITLE
fix(alerts): convert timestamp types to int for consistency

### DIFF
--- a/pkg/alerts/alerts_types.go
+++ b/pkg/alerts/alerts_types.go
@@ -108,7 +108,7 @@ type InfrastructureCondition struct {
 	RunbookURL          string                            `json:"runbook_url,omitempty"`
 	Select              string                            `json:"select_value,omitempty"`
 	Type                string                            `json:"type,omitempty"`
-	UpdatedAt           *int          `json:"updated_at_epoch_millis,omitempty"`
+	UpdatedAt           *int                              `json:"updated_at_epoch_millis,omitempty"`
 	ViolationCloseTimer *int                              `json:"violation_close_timer,omitempty"`
 	Warning             *InfrastructureConditionThreshold `json:"warning_threshold,omitempty"`
 	Where               string                            `json:"where_clause,omitempty"`

--- a/pkg/alerts/alerts_types.go
+++ b/pkg/alerts/alerts_types.go
@@ -2,8 +2,6 @@ package alerts
 
 import (
 	"encoding/json"
-
-	"github.com/newrelic/newrelic-client-go/internal/serialization"
 )
 
 // Channel represents a New Relic alert notification channel
@@ -98,7 +96,7 @@ type IncidentLink struct {
 // InfrastructureCondition represents a New Relic Infrastructure alert condition.
 type InfrastructureCondition struct {
 	Comparison          string                            `json:"comparison,omitempty"`
-	CreatedAt           *serialization.EpochTime          `json:"created_at_epoch_millis,omitempty"`
+	CreatedAt           *int          `json:"created_at_epoch_millis,omitempty"`
 	Critical            *InfrastructureConditionThreshold `json:"critical_threshold,omitempty"`
 	Enabled             bool                              `json:"enabled"`
 	Event               string                            `json:"event_type,omitempty"`
@@ -110,7 +108,7 @@ type InfrastructureCondition struct {
 	RunbookURL          string                            `json:"runbook_url,omitempty"`
 	Select              string                            `json:"select_value,omitempty"`
 	Type                string                            `json:"type,omitempty"`
-	UpdatedAt           *serialization.EpochTime          `json:"updated_at_epoch_millis,omitempty"`
+	UpdatedAt           *int          `json:"updated_at_epoch_millis,omitempty"`
 	ViolationCloseTimer *int                              `json:"violation_close_timer,omitempty"`
 	Warning             *InfrastructureConditionThreshold `json:"warning_threshold,omitempty"`
 	Where               string                            `json:"where_clause,omitempty"`
@@ -171,8 +169,8 @@ type Policy struct {
 	ID                 int                      `json:"id,omitempty"`
 	IncidentPreference string                   `json:"incident_preference,omitempty"`
 	Name               string                   `json:"name,omitempty"`
-	CreatedAt          *serialization.EpochTime `json:"created_at,omitempty"`
-	UpdatedAt          *serialization.EpochTime `json:"updated_at,omitempty"`
+	CreatedAt          *int `json:"created_at,omitempty"`
+	UpdatedAt          *int `json:"updated_at,omitempty"`
 }
 
 // PolicyChannels represents an association of alert channels to a specific alert policy.

--- a/pkg/alerts/alerts_types.go
+++ b/pkg/alerts/alerts_types.go
@@ -96,7 +96,7 @@ type IncidentLink struct {
 // InfrastructureCondition represents a New Relic Infrastructure alert condition.
 type InfrastructureCondition struct {
 	Comparison          string                            `json:"comparison,omitempty"`
-	CreatedAt           *int          `json:"created_at_epoch_millis,omitempty"`
+	CreatedAt           *int                              `json:"created_at_epoch_millis,omitempty"`
 	Critical            *InfrastructureConditionThreshold `json:"critical_threshold,omitempty"`
 	Enabled             bool                              `json:"enabled"`
 	Event               string                            `json:"event_type,omitempty"`

--- a/pkg/alerts/infrastructure_conditions_test.go
+++ b/pkg/alerts/infrastructure_conditions_test.go
@@ -6,15 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
-	"github.com/newrelic/newrelic-client-go/internal/serialization"
 	"github.com/stretchr/testify/require"
 )
 
 var (
 	testInfrastructureConditionPolicyId  = 111111
-	testInfrastructureConditionTimestamp = serialization.EpochTime(time.Unix(1490996713872, 0))
+	testInfrastructureConditionTimestamp = 1490996713872 // 2017-03-31T21:45:13.000Z
 	testInfrastructureCriticalThreshold  = InfrastructureConditionThreshold{
 		Duration: 6,
 		Function: "all",

--- a/pkg/alerts/policies_test.go
+++ b/pkg/alerts/policies_test.go
@@ -5,14 +5,12 @@ package alerts
 import (
 	"net/http"
 	"testing"
-	"time"
 
-	"github.com/newrelic/newrelic-client-go/internal/serialization"
 	"github.com/stretchr/testify/require"
 )
 
 var (
-	testTimestamp = serialization.EpochTime(time.Unix(1575438237690, 0))
+	testTimestamp = 1575438237690 // 2019-12-04T05:43:57.000Z
 
 	testPoliciesResponseJSON = `{
 		"policies": [


### PR DESCRIPTION
resolves: #121

Two types represent timestamps as serialization.EpochTime types, one
type represents them as `int`s. This change uses the int versions
everywhere. See issue for more details.