### PR TITLE
fix: allow string representations of JSON for alert channel webhook and payload

### DIFF
--- a/pkg/alerts/alerts_types.go
+++ b/pkg/alerts/alerts_types.go
@@ -2,6 +2,8 @@ package alerts
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 
 	"github.com/newrelic/newrelic-client-go/internal/serialization"
 )
@@ -201,9 +203,21 @@ type mapStringInterfaceProxy MapStringInterface
 func (c *MapStringInterface) UnmarshalJSON(data []byte) error {
 	var mapStrInterface mapStringInterfaceProxy
 
+	str := string(data)
+
 	// Check for empty JSON string
-	if string(data) == `""` {
+	if str == `""` {
 		return nil
+	}
+
+	// Remove quotes if this is a string representation of JSON
+	if strings.HasPrefix(str, "\"") && strings.HasSuffix(str, "\"") {
+		s, err := strconv.Unquote(str)
+		if err != nil {
+			return nil
+		}
+
+		data = []byte(s)
 	}
 
 	err := json.Unmarshal(data, &mapStrInterface)

--- a/pkg/alerts/channels_test.go
+++ b/pkg/alerts/channels_test.go
@@ -95,6 +95,20 @@ var (
 			},
 			{
 				"id": 2,
+				"name": "webhook-ESCAPED-STRING-headers-and-payload",
+				"type": "webhook",
+				"configuration": {
+					"base_url": "http://example.com",
+					"headers": "{\"key\":\"value\"}",
+					"payload": "{\"key\":\"value\"}",
+					"payload_type": "application/json"
+				},
+				"links": {
+					"policy_ids": []
+				}
+			},
+			{
+				"id": 3,
 				"name": "webhook-WEIRD-headers-and-payload",
 				"type": "webhook",
 				"configuration": {
@@ -112,7 +126,7 @@ var (
 				}
 			},
 			{
-				"id": 3,
+				"id": 4,
 				"name": "webhook-COMPLEX-payload",
 				"type": "webhook",
 				"configuration": {
@@ -195,6 +209,24 @@ func TestListChannelsWebhookWithComplexHeadersAndPayload(t *testing.T) {
 		},
 		{
 			ID:   2,
+			Name: "webhook-ESCAPED-STRING-headers-and-payload",
+			Type: "webhook",
+			Configuration: ChannelConfiguration{
+				BaseURL:     "http://example.com",
+				PayloadType: "application/json",
+				Headers: MapStringInterface{
+					"key": "value",
+				},
+				Payload: MapStringInterface{
+					"key": "value",
+				},
+			},
+			Links: ChannelLinks{
+				PolicyIDs: []int{},
+			},
+		},
+		{
+			ID:   3,
 			Name: "webhook-WEIRD-headers-and-payload",
 			Type: "webhook",
 			Configuration: ChannelConfiguration{
@@ -212,7 +244,7 @@ func TestListChannelsWebhookWithComplexHeadersAndPayload(t *testing.T) {
 			},
 		},
 		{
-			ID:   3,
+			ID:   4,
 			Name: "webhook-COMPLEX-payload",
 			Type: "webhook",
 			Configuration: ChannelConfiguration{


### PR DESCRIPTION
This PR fixes unmarshaling of alert channel webhook headers and payload when the API returns string representations of JSON objects, like so:

```json
"configuration": {
   "headers": "{\"key\":\"value\"}",
   "payload": "{\"key\":\"value\"}",
},
```