### PR TITLE
feat(http): add trace logging with additional request info

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -3,7 +3,8 @@ package logging
 // Logger interface implements a simple logger.
 type Logger interface {
 	Error(string, ...interface{})
+	Warn(string, ...interface{})
 	Info(string, ...interface{})
 	Debug(string, ...interface{})
-	Warn(string, ...interface{})
+	Trace(string, ...interface{})
 }

--- a/internal/logging/structured_logger.go
+++ b/internal/logging/structured_logger.go
@@ -57,6 +57,11 @@ func (l StructuredLogger) Error(msg string, fields ...interface{}) {
 	log.WithFields(createFieldMap(fields)).Error(msg)
 }
 
+// Warn logs an warning message.
+func (l StructuredLogger) Warn(msg string, fields ...interface{}) {
+	log.WithFields(createFieldMap(fields)).Warn(msg)
+}
+
 // Info logs an info message.
 func (l StructuredLogger) Info(msg string, fields ...interface{}) {
 	log.WithFields(createFieldMap(fields)).Info(msg)
@@ -67,9 +72,9 @@ func (l StructuredLogger) Debug(msg string, fields ...interface{}) {
 	log.WithFields(createFieldMap(fields)).Debug(msg)
 }
 
-// Warn logs an warning message.
-func (l StructuredLogger) Warn(msg string, fields ...interface{}) {
-	log.WithFields(createFieldMap(fields)).Warn(msg)
+// Trace logs a trace message.
+func (l StructuredLogger) Trace(msg string, fields ...interface{}) {
+	log.WithFields(createFieldMap(fields)).Trace(msg)
 }
 
 func createFieldMap(fields ...interface{}) map[string]interface{} {

--- a/newrelic/newrelic_test.go
+++ b/newrelic/newrelic_test.go
@@ -174,9 +174,10 @@ func TestNew_optionLogJSON(t *testing.T) {
 type TestLogger struct{}
 
 func (t *TestLogger) Error(s string, a ...interface{}) {}
+func (t *TestLogger) Warn(s string, a ...interface{})  {}
 func (t *TestLogger) Info(s string, a ...interface{})  {}
 func (t *TestLogger) Debug(s string, a ...interface{}) {}
-func (t *TestLogger) Warn(s string, a ...interface{})  {}
+func (t *TestLogger) Trace(s string, a ...interface{}) {}
 
 func TestNew_optionLogger(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This PR introduces trace level logging for lower level request information such as request and response body and headers.  It disables the default debug-level request logging of go-retryablehttp and moves it instead into the client's `do` method.

Related to terraform-providers/terraform-provider-newrelic#377.