### PR TITLE
feat(synthetics): implement label monitor support

### DIFF
--- a/pkg/synthetics/monitor_labels.go
+++ b/pkg/synthetics/monitor_labels.go
@@ -1,0 +1,53 @@
+package synthetics
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetMonitorLabels is used to retrieve all labels for a given Synthetics monitor.
+func (s *Synthetics) GetMonitorLabels(monitorID string) ([]*MonitorLabel, error) {
+	url := fmt.Sprintf("/monitors/%s/labels", monitorID)
+
+	resp := getMonitorLabelsResponse{}
+
+	_, err := s.client.Get(url, nil, &resp)
+	if err != nil {
+		return []*MonitorLabel{}, err
+	}
+
+	return resp.Labels, nil
+}
+
+// AddMonitorLabel is used to add a label to a given monitor.
+func (s *Synthetics) AddMonitorLabel(monitorID, labelKey, labelValue string) error {
+	url := fmt.Sprintf("/monitors/%s/labels", monitorID)
+
+	data := fmt.Sprintf("%s:%s", strings.Title(labelKey), strings.Title(labelValue))
+
+	// We use RawPost here due to the Syntheics API's lack of support for JSON on
+	// this call.  The values must be POSTed as bare key:value word string.
+	_, err := s.client.RawPost(url, nil, data, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteMonitorLabel deletes a key:value label from the given Syntheics monitor.
+func (s *Synthetics) DeleteMonitorLabel(monitorID, labelKey, labelValue string) error {
+	url := fmt.Sprintf("/monitors/%s/labels/%s:%s", monitorID, strings.Title(labelKey), strings.Title(labelValue))
+
+	_, err := s.client.Delete(url, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type getMonitorLabelsResponse struct {
+	Labels []*MonitorLabel `json:"labels"`
+	Count  int             `json:"count"`
+}

--- a/pkg/synthetics/monitor_labels_integration_test.go
+++ b/pkg/synthetics/monitor_labels_integration_test.go
@@ -1,0 +1,83 @@
+// +build integration
+
+package synthetics
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	nr "github.com/newrelic/newrelic-client-go/internal/testing"
+	"github.com/newrelic/newrelic-client-go/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testIntegrationLabeledMonitor = Monitor{
+		Type:         MonitorTypes.APITest,
+		Frequency:    15,
+		URI:          "https://google.com",
+		Locations:    []string{"AWS_US_EAST_1"},
+		Status:       MonitorStatus.Disabled,
+		SLAThreshold: 7,
+		UserID:       0,
+		APIVersion:   "LATEST",
+		Options:      MonitorOptions{},
+	}
+)
+
+func TestIntegrationGetMonitorLabels(t *testing.T) {
+	t.Parallel()
+
+	apiKey := os.Getenv("NEWRELIC_API_KEY")
+
+	if apiKey == "" {
+		t.Skipf("acceptance testing requires an API key")
+	}
+
+	synthetics := New(config.Config{
+		APIKey:   apiKey,
+		LogLevel: "debug",
+	})
+
+	// Setup
+	rand := nr.RandSeq(5)
+	testIntegrationLabeledMonitor.Name = fmt.Sprintf("test-synthetics-monitor-%s", rand)
+	monitor, err := synthetics.CreateMonitor(testIntegrationLabeledMonitor)
+	require.NoError(t, err)
+
+	labels, err := synthetics.GetMonitorLabels(monitor.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, len(labels), 0)
+
+	// Test: Add
+	err = synthetics.AddMonitorLabel(monitor.ID, "testing", rand)
+	require.NoError(t, err)
+
+	labels, err = synthetics.GetMonitorLabels(monitor.ID)
+	require.NoError(t, err)
+	assert.Equal(t, len(labels), 1)
+	assert.Equal(t, (*labels[0]).Type, "Testing")
+	assert.Equal(t, (*labels[0]).Value, strings.Title(rand))
+
+	// Test: Delete
+	err = synthetics.DeleteMonitorLabel(monitor.ID, "testing", rand)
+	require.NoError(t, err)
+
+	// Verify Delete
+	labels, err = synthetics.GetMonitorLabels(monitor.ID)
+	require.NoError(t, err)
+	assert.Equal(t, len(labels), 0)
+
+	// Deferred teardown
+	defer func() {
+		err = synthetics.DeleteMonitor(monitor.ID)
+
+		if err != nil {
+			t.Logf("error cleaning up monitor %s (%s): %s", monitor.ID, monitor.Name, err)
+		}
+	}()
+}

--- a/pkg/synthetics/monitor_labels_test.go
+++ b/pkg/synthetics/monitor_labels_test.go
@@ -1,0 +1,50 @@
+// +build unit
+
+package synthetics
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testGetMonitorLabelsJson = `
+	{
+	"labels": [{
+		"type": "Testing",
+		"value": "Mbnhl",
+		"href": "https://synthetics.newrelic.com/synthetics/api/v4/monitors/labels/Testing:Mbnhl"
+	}],
+	"count": 1
+}
+	`
+)
+
+func TestGetMonitorLabel(t *testing.T) {
+	t.Parallel()
+	synthetics := newMockResponse(t, testGetMonitorLabelsJson, http.StatusOK)
+
+	r, err := synthetics.GetMonitorLabels(testMonitorID)
+	assert.NoError(t, err)
+	assert.Equal(t, len(r), 1)
+	assert.Equal(t, r[0].Type, "Testing")
+	assert.Equal(t, r[0].Value, "Mbnhl")
+}
+
+func TestAddMonitorLabel(t *testing.T) {
+	t.Parallel()
+	synthetics := newMockResponse(t, "", http.StatusOK)
+
+	err := synthetics.AddMonitorLabel(testMonitorID, "test", "test")
+	assert.NoError(t, err)
+}
+
+func TestDeleteMonitorLabel(t *testing.T) {
+	t.Parallel()
+	synthetics := newMockResponse(t, "", http.StatusOK)
+
+	err := synthetics.DeleteMonitorLabel(testMonitorID, "test", "test")
+	assert.NoError(t, err)
+}

--- a/pkg/synthetics/synthetics.go
+++ b/pkg/synthetics/synthetics.go
@@ -11,9 +11,9 @@ import (
 
 // BaseURLs represents the base API URLs for the different environments of the Synthetics API.
 var BaseURLs = map[region.Region]string{
-	region.US:      "https://synthetics.newrelic.com/synthetics/api/v3",
-	region.EU:      "https://synthetics.eu.newrelic.com/synthetics/api/v3",
-	region.Staging: "https://staging-synthetics.newrelic.com/synthetics/api/v3",
+	region.US:      "https://synthetics.newrelic.com/synthetics/api/v4",
+	region.EU:      "https://synthetics.eu.newrelic.com/synthetics/api/v4",
+	region.Staging: "https://staging-synthetics.newrelic.com/synthetics/api/v4",
 }
 
 // Synthetics is used to communicate with the New Relic Synthetics product.

--- a/pkg/synthetics/synthetics_test.go
+++ b/pkg/synthetics/synthetics_test.go
@@ -18,9 +18,9 @@ func TestBaseURLs(t *testing.T) {
 	t.Parallel()
 
 	pairs := map[region.Region]string{
-		region.US:      "https://synthetics.newrelic.com/synthetics/api/v3",
-		region.EU:      "https://synthetics.eu.newrelic.com/synthetics/api/v3",
-		region.Staging: "https://staging-synthetics.newrelic.com/synthetics/api/v3",
+		region.US:      "https://synthetics.newrelic.com/synthetics/api/v4",
+		region.EU:      "https://synthetics.eu.newrelic.com/synthetics/api/v4",
+		region.Staging: "https://staging-synthetics.newrelic.com/synthetics/api/v4",
 	}
 
 	// Default should be region.US

--- a/pkg/synthetics/synthetics_types.go
+++ b/pkg/synthetics/synthetics_types.go
@@ -68,3 +68,10 @@ type Monitor struct {
 	CreatedAt    *Time             `json:"createdAt,omitempty"`
 	Options      MonitorOptions    `json:"options,omitempty"`
 }
+
+// MonitorLabel represents a single label for a New Relic Synthetics monitor.
+type MonitorLabel struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+	Href  string `json:"href"`
+}


### PR DESCRIPTION
resolves: #129

This change bumps the version of the synthetics API in use to support the label
management that is included in this change.