### PR TITLE
chore(tests): improve http client tests

### DIFF
--- a/internal/http/test_helpers.go
+++ b/internal/http/test_helpers.go
@@ -8,8 +8,9 @@ import (
 )
 
 var (
-	testAPIKey    = "apiKey"
-	testUserAgent = "userAgent"
+	testAPIKey         = "apiKey"
+	testPersonalAPIKey = "personalAPIKey"
+	testUserAgent      = "userAgent"
 )
 
 // NewTestAPIClient returns a test NewRelicClient instance that is configured to communicate with a mock server.
@@ -17,9 +18,10 @@ func NewTestAPIClient(handler http.Handler) NewRelicClient {
 	ts := httptest.NewServer(handler)
 
 	c := NewClient(config.Config{
-		APIKey:    testAPIKey,
-		BaseURL:   ts.URL,
-		UserAgent: testUserAgent,
+		APIKey:         testAPIKey,
+		BaseURL:        ts.URL,
+		PersonalAPIKey: testPersonalAPIKey,
+		UserAgent:      testUserAgent,
 	})
 
 	return c

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	SyntheticsBaseURL     string
 	InfrastructureBaseURL string
 	NerdGraphBaseURL      string
+	ServiceName           string
 
 	// LogLevel can be one of the following values:
 	// "panic", "fatal", "error", "warn", "info", "debug", "trace"


### PR DESCRIPTION
This PR adds some additional test coverage to the internal http client implementation including:

* RawPost type detection (to prevent panic)
* RawPost unit tests
* additional header tests (all set headers)
* Allows consuming app to set the service name header