### PR TITLE
fix(newrelic): Add option to set ServiceName in Config

### DIFF
--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -119,6 +119,17 @@ func ConfigUserAgent(ua string) ConfigOption {
 	}
 }
 
+// ConfigServiceName sets the service name logged
+func ConfigServiceName(name string) ConfigOption {
+	return func(cfg *config.Config) error {
+		if name != "" {
+			cfg.ServiceName = name
+		}
+
+		return nil
+	}
+}
+
 // ConfigBaseURL sets the base URL used to make requests to the REST API V2.
 func ConfigBaseURL(url string) ConfigOption {
 	return func(cfg *config.Config) error {

--- a/newrelic/newrelic_test.go
+++ b/newrelic/newrelic_test.go
@@ -98,6 +98,14 @@ func TestNew_optionUserAgent(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNew_optionServiceName(t *testing.T) {
+	t.Parallel()
+
+	nr, err := New(ConfigAPIKey(testAPIkey), ConfigServiceName("my-service"))
+	assert.NotNil(t, nr)
+	assert.NoError(t, err)
+}
+
 func TestNew_optionBaseURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Added ServiceName config option, but did not allow it to be set.  This adds a ConfigOption to set ServiceName so it can be used in the future for logging.