### PR TITLE
chore: add stale bot config for auto-management of stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,50 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 30
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - enhancement
+  - help wanted
+  - priority:low
+  - priority:medium
+  - priority:high
+  - priority:blocker
+  - good first issue
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  any recent activity. It will be closed if no further activity occurs.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  This issue has been automatically closed due to a lack of activity
+  for an extended period of time.
+
+# Limit to only `issues` or `pulls`
+only: issues

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ coverage/*
 vendor/*
 
 *.csv
-*.yml
-*.yaml
 
 .vscode/
 .DS_Store


### PR DESCRIPTION
This PR configures the [Stale](https://probot.github.io/apps/stale/) GItHub app for this repo. This GH app facilitates automatically closing stale issues and pull requests (we're only configuring this for issues for now). 