### PR TITLE
feat(entities): implement raw graphql entity search methods

### DIFF
--- a/pkg/entities/entities_integration_test.go
+++ b/pkg/entities/entities_integration_test.go
@@ -3,6 +3,7 @@
 package entities
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -23,6 +24,80 @@ func TestIntegrationSearchEntities(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Greater(t, len(actual), 0)
+}
+
+func TestIntegrationSearchEntitiesRaw(t *testing.T) {
+	t.Parallel()
+
+	client := newIntegrationTestClient(t)
+
+	params := SearchEntitiesParams{
+		Name: "Dummy App",
+	}
+
+	actual, err := client.SearchEntitiesRaw(params, []string{"guid", "name"})
+
+	require.NoError(t, err)
+	require.Greater(t, len(actual), 0)
+
+	for _, entity := range actual {
+		// Ensure these fields are populated since we
+		// specified these fields to be returned in the query
+		require.NotEmpty(t, entity.GUID)
+		require.NotEmpty(t, entity.Name)
+
+		// Ensure this field is not returned populated
+		// since we didn't specify this field to be returned
+		require.Empty(t, entity.Domain)
+	}
+}
+
+func TestIntegrationSearchEntitiesRawQuery(t *testing.T) {
+	t.Parallel()
+
+	client := newIntegrationTestClient(t)
+
+	params := SearchEntitiesParams{
+		Name:   "Dummy App",
+		Domain: "BROWSER",
+	}
+
+	graphqlQuery := `
+		query($queryBuilder: EntitySearchQueryBuilder, $cursor: String) {
+				actor {
+						entitySearch(queryBuilder: $queryBuilder)  {
+								results(cursor: $cursor) {
+										nextCursor
+										entities {
+											guid
+											name
+										}
+								}
+						}
+				}
+		}
+	`
+	var nextCursor *string
+	variables := map[string]interface{}{
+		"queryBuilder": params,
+		"cursor":       nextCursor,
+	}
+
+	actual, err := client.SearchEntitiesRawQuery(graphqlQuery, variables)
+
+	require.NoError(t, err)
+	require.Greater(t, len(actual), 0)
+
+	for _, entity := range actual {
+		// Ensure these fields are populated since we
+		// specified these fields to be returned in the query
+		require.NotEmpty(t, entity.GUID)
+		require.NotEmpty(t, entity.Name)
+
+		// Ensure this field is not returned populated
+		// since we didn't specify this field to be returned
+		require.Empty(t, entity.Domain)
+	}
 }
 
 func TestIntegrationSearchEntitiesByTags(t *testing.T) {

--- a/pkg/entities/entities_types.go
+++ b/pkg/entities/entities_types.go
@@ -14,14 +14,14 @@ type TagValue struct {
 
 // Entity represents a New Relic One entity.
 type Entity struct {
-	AccountID  int
-	Domain     EntityDomainType
-	EntityType EntityType
-	GUID       string
-	Name       string
-	Permalink  string
-	Reporting  bool
-	Type       string
+	AccountID  int              `json:"accountId,omitempty"`
+	Domain     EntityDomainType `json:"domain,omitempty"`
+	EntityType EntityType       `json:"entityType,omitempty"`
+	GUID       string           `json:"guid,omitempty"`
+	Name       string           `json:"name,omitempty"`
+	Permalink  string           `json:"permalink,omitempty"`
+	Reporting  bool             `json:"reporting,omitempty"`
+	Type       string           `json:"type,omitempty"`
 }
 
 // EntityType represents a New Relic One entity type.


### PR DESCRIPTION
## Proof of Concept 

Putting this up for review and feedback. This could facilitate which fields we were return for a given entity (in the CLI and other consumers of the client).

The new method names were not thought out and are kind of inaccurate at the moment, but this is just for show and tell right now. 