### PR TITLE
feat(http): allow personal API keys to be used for alerts and APM resources

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -1,0 +1,40 @@
+package http
+
+import (
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+	"github.com/newrelic/newrelic-client-go/pkg/config"
+)
+
+// RequestAuthorizer is an interface that allows customizatino of how a request is authorized.
+type RequestAuthorizer interface {
+	AuthorizeRequest(*retryablehttp.Request, *config.Config)
+}
+
+// NerdGraphAuthorizer authorizes calls to NerdGraph.
+type NerdGraphAuthorizer struct{}
+
+// AuthorizeRequest is responsible for setting up auth for a request.
+func (a *NerdGraphAuthorizer) AuthorizeRequest(req *retryablehttp.Request, c *config.Config) {
+	req.Header.Set("Api-Key", c.PersonalAPIKey)
+}
+
+// PersonalAPIKeyCapableV2Authorizer authorizes V2 endpoints that can use a personal API key.
+type PersonalAPIKeyCapableV2Authorizer struct{}
+
+// AuthorizeRequest is responsible for setting up auth for a request.
+func (a *PersonalAPIKeyCapableV2Authorizer) AuthorizeRequest(req *retryablehttp.Request, c *config.Config) {
+	if c.PersonalAPIKey != "" {
+		req.Header.Set("Api-Key", c.PersonalAPIKey)
+		req.Header.Set("Auth-Type", "User-Api-Key")
+	} else {
+		req.Header.Set("X-Api-Key", c.APIKey)
+	}
+}
+
+// ClassicV2Authorizer authorizes V2 endpoints that cannot use a personal API key.
+type ClassicV2Authorizer struct{}
+
+// AuthorizeRequest is responsible for setting up auth for a request.
+func (a *ClassicV2Authorizer) AuthorizeRequest(req *retryablehttp.Request, c *config.Config) {
+	req.Header.Set("X-Api-Key", c.APIKey)
+}

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -32,8 +32,15 @@ var (
 
 // NewRelicClient represents a client for communicating with the New Relic APIs.
 type NewRelicClient struct {
-	Client     *retryablehttp.Client
-	Config     config.Config
+	// Client represents the underlying HTTP client.
+	Client *retryablehttp.Client
+
+	// Config is the HTTP client configuration.
+	Config config.Config
+
+	// UsePersonalAPIKeyCompatability is for internal use only.
+	UsePersonalAPIKeyCompatibility bool
+
 	errorValue ErrorResponse
 }
 
@@ -202,6 +209,10 @@ func (c *NewRelicClient) setHeaders(req *retryablehttp.Request) {
 
 	if c.Config.PersonalAPIKey != "" {
 		req.Header.Set("Api-Key", c.Config.PersonalAPIKey)
+
+		if c.UsePersonalAPIKeyCompatibility {
+			req.Header.Set("Auth-Type", "User-Api-Key")
+		}
 	}
 }
 

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -242,6 +242,41 @@ func TestHeaders(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestUsePersonalAPIKeyCompatibilityEnabled(t *testing.T) {
+	t.Parallel()
+	c := NewTestAPIClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		assert.Equal(t, testPersonalAPIKey, r.Header.Get("api-key"))
+		assert.Equal(t, "User-Api-Key", r.Header.Get("auth-type"))
+	}))
+
+	c.UsePersonalAPIKeyCompatibility = true
+
+	_, err := c.Get("/path", nil, nil)
+
+	assert.Nil(t, err)
+}
+
+func TestUsePersonalAPIKeyCompatibilityDisabled(t *testing.T) {
+	t.Parallel()
+	c := NewTestAPIClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		assert.Equal(t, "", r.Header.Get("auth-type"))
+	}))
+
+	_, err := c.Get("/path", nil, nil)
+	assert.Nil(t, err)
+
+	c.UsePersonalAPIKeyCompatibility = true
+	c.Config.PersonalAPIKey = ""
+
+	_, err = c.Get("/path", nil, nil)
+	assert.Nil(t, err)
+}
 func TestErrNotFound(t *testing.T) {
 	t.Parallel()
 	c := NewTestAPIClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/graphql_client.go
+++ b/internal/http/graphql_client.go
@@ -24,6 +24,7 @@ func NewGraphQLClient(cfg config.Config) *GraphQLClient {
 	cfg.BaseURL = cfg.NerdGraphBaseURL
 
 	c := NewClient(cfg)
+	c.AuthStrategy = &NerdGraphAuthorizer{}
 	c.SetErrorValue(&graphQLErrorResponse{})
 
 	return &GraphQLClient{

--- a/pkg/alerts/alerts.go
+++ b/pkg/alerts/alerts.go
@@ -29,8 +29,11 @@ func New(config config.Config) Alerts {
 	infraClient := http.NewClient(infraConfig)
 	infraClient.SetErrorValue(&infrastructure.ErrorResponse{})
 
+	client := http.NewClient(config)
+	client.AuthStrategy = &http.PersonalAPIKeyCapableV2Authorizer{}
+
 	pkg := Alerts{
-		client:      http.NewClient(config),
+		client:      client,
 		infraClient: infraClient,
 		logger:      config.GetLogger(),
 		pager:       &http.LinkHeaderPager{},

--- a/pkg/alerts/alerts_test.go
+++ b/pkg/alerts/alerts_test.go
@@ -48,7 +48,7 @@ func newIntegrationTestClient(t *testing.T) Alerts {
 	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
 
 	if apiKey == "" && personalAPIKey == "" {
-		t.Skipf("acceptance testing requires an API key")
+		t.Skipf("acceptance testing requires NEWRELIC_API_KEY and NEWRELIC_PERSONAL_API_KEY")
 	}
 
 	client := New(config.Config{
@@ -56,8 +56,6 @@ func newIntegrationTestClient(t *testing.T) Alerts {
 		PersonalAPIKey: personalAPIKey,
 		LogLevel:       "debug",
 	})
-
-	client.client.UsePersonalAPIKeyCompatibility = true
 
 	return client
 }

--- a/pkg/alerts/alerts_test.go
+++ b/pkg/alerts/alerts_test.go
@@ -45,15 +45,21 @@ func newMockResponse(
 // nolint
 func newIntegrationTestClient(t *testing.T) Alerts {
 	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
 
-	if apiKey == "" {
+	if apiKey == "" && personalAPIKey == "" {
 		t.Skipf("acceptance testing requires an API key")
 	}
 
-	return New(config.Config{
-		APIKey:   apiKey,
-		LogLevel: "debug",
+	client := New(config.Config{
+		APIKey:         apiKey,
+		PersonalAPIKey: personalAPIKey,
+		LogLevel:       "debug",
 	})
+
+	client.client.UsePersonalAPIKeyCompatibility = true
+
+	return client
 }
 
 func TestSetBaseURL(t *testing.T) {

--- a/pkg/apm/apm.go
+++ b/pkg/apm/apm.go
@@ -16,12 +16,13 @@ type APM struct {
 
 // New is used to create a new APM client instance.
 func New(config config.Config) APM {
+	client := http.NewClient(config)
+	client.AuthStrategy = &http.PersonalAPIKeyCapableV2Authorizer{}
+
 	pkg := APM{
-		client: http.NewClient(config),
+		client: client,
 		pager:  &http.LinkHeaderPager{},
 	}
-
-	pkg.client.UsePersonalAPIKeyCompatibility = true
 
 	return pkg
 }

--- a/pkg/apm/apm.go
+++ b/pkg/apm/apm.go
@@ -18,9 +18,10 @@ type APM struct {
 func New(config config.Config) APM {
 	pkg := APM{
 		client: http.NewClient(config),
-		logger: config.GetLogger(),
 		pager:  &http.LinkHeaderPager{},
 	}
+
+	pkg.client.UsePersonalAPIKeyCompatibility = true
 
 	return pkg
 }

--- a/pkg/apm/apm_test.go
+++ b/pkg/apm/apm_test.go
@@ -45,7 +45,7 @@ func newIntegrationTestClient(t *testing.T) APM {
 	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
 
 	if apiKey == "" && personalAPIKey == "" {
-		t.Skipf("acceptance testing requires an API key")
+		t.Skipf("acceptance testing requires NEWRELIC_API_KEY and NEWRELIC_PERSONAL_API_KEY")
 	}
 
 	client := New(config.Config{
@@ -53,8 +53,6 @@ func newIntegrationTestClient(t *testing.T) APM {
 		PersonalAPIKey: personalAPIKey,
 		LogLevel:       "debug",
 	})
-
-	client.client.UsePersonalAPIKeyCompatibility = true
 
 	return client
 }

--- a/pkg/apm/apm_test.go
+++ b/pkg/apm/apm_test.go
@@ -42,13 +42,19 @@ func newMockResponse(
 // nolint
 func newIntegrationTestClient(t *testing.T) APM {
 	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
 
-	if apiKey == "" {
+	if apiKey == "" && personalAPIKey == "" {
 		t.Skipf("acceptance testing requires an API key")
 	}
 
-	return New(config.Config{
-		APIKey:   apiKey,
-		LogLevel: "debug",
+	client := New(config.Config{
+		APIKey:         apiKey,
+		PersonalAPIKey: personalAPIKey,
+		LogLevel:       "debug",
 	})
+
+	client.client.UsePersonalAPIKeyCompatibility = true
+
+	return client
 }

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -45,15 +45,19 @@ func newMockResponse(
 // nolint
 func newIntegrationTestClient(t *testing.T) Plugins {
 	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
 
-	if apiKey == "" {
+	if apiKey == "" && personalAPIKey == "" {
 		t.Skipf("acceptance testing requires an API key")
 	}
 
-	return New(config.Config{
-		APIKey:   apiKey,
-		LogLevel: "debug",
+	client := New(config.Config{
+		APIKey:         apiKey,
+		PersonalAPIKey: personalAPIKey,
+		LogLevel:       "debug",
 	})
+
+	return client
 }
 
 var (

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -48,7 +48,7 @@ func newIntegrationTestClient(t *testing.T) Plugins {
 	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
 
 	if apiKey == "" && personalAPIKey == "" {
-		t.Skipf("acceptance testing requires an API key")
+		t.Skipf("acceptance testing requires NEWRELIC_API_KEY and NEWRELIC_PERSONAL_API_KEY")
 	}
 
 	client := New(config.Config{


### PR DESCRIPTION
This PR allows Personal API keys to be used for authentication in the V2 endpoints that allow it (currently only the resources defined in the `apm` and `alerts` packages).

Compatibility mode will be enabled if a personal API key has been provided and the mode has been enabled within the package instantiating the client.