### PR TITLE
feat(nerdgraph): implement ability to make raw GraphQL query

### DIFF
--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -11,6 +11,7 @@ import (
 	"github.com/newrelic/newrelic-client-go/pkg/config"
 	"github.com/newrelic/newrelic-client-go/pkg/dashboards"
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
+	"github.com/newrelic/newrelic-client-go/pkg/nerdgraph"
 	"github.com/newrelic/newrelic-client-go/pkg/plugins"
 	"github.com/newrelic/newrelic-client-go/pkg/synthetics"
 )
@@ -23,6 +24,7 @@ type NewRelic struct {
 	Entities   entities.Entities
 	Plugins    plugins.Plugins
 	Synthetics synthetics.Synthetics
+	NerdGraph  nerdgraph.NerdGraph
 }
 
 // New returns a collection of New Relic APIs.
@@ -49,6 +51,7 @@ func New(opts ...ConfigOption) (*NewRelic, error) {
 		Entities:   entities.New(config),
 		Plugins:    plugins.New(config),
 		Synthetics: synthetics.New(config),
+		NerdGraph:  nerdgraph.New(config),
 	}
 
 	return nr, nil

--- a/pkg/nerdgraph/nerdgraph.go
+++ b/pkg/nerdgraph/nerdgraph.go
@@ -1,0 +1,39 @@
+package nerdgraph
+
+import (
+	"github.com/newrelic/newrelic-client-go/internal/http"
+	"github.com/newrelic/newrelic-client-go/internal/logging"
+	"github.com/newrelic/newrelic-client-go/pkg/config"
+)
+
+// NerdGraph is used to communicate with the New Relic's GraphQL API, NerdGraph.
+type NerdGraph struct {
+	client *http.GraphQLClient
+	logger logging.Logger
+}
+
+// New returns a new GraphQL client for interacting with New Relic's GraphQL API, NerdGraph.
+func New(config config.Config) NerdGraph {
+	return NerdGraph{
+		client: http.NewGraphQLClient(config),
+		logger: config.GetLogger(),
+	}
+}
+
+// Query facilitates making a NerdGraph request with a raw GraphQL query. Variables may be provided
+// in the form of a map. The response's data structure will vary based on the query provided.
+func (n *NerdGraph) Query(query string, variables map[string]interface{}) (interface{}, error) {
+	respBody := queryResponse{}
+
+	if err := n.client.Query(query, variables, &respBody); err != nil {
+		return nil, err
+	}
+
+	return respBody, nil
+}
+
+type queryResponse struct {
+	Actor          interface{} `json:"actor,omitempty"`
+	Docs           interface{} `json:"docs,omitempty"`
+	RequestContext interface{} `json:"requestContext,omitempty"`
+}

--- a/pkg/nerdgraph/nerdgraph_integration_test.go
+++ b/pkg/nerdgraph/nerdgraph_integration_test.go
@@ -1,0 +1,76 @@
+// +build integration
+
+package nerdgraph
+
+import (
+	"os"
+	"testing"
+
+	"github.com/newrelic/newrelic-client-go/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationQuery(t *testing.T) {
+	t.Parallel()
+
+	client := newNerdGraphIntegrationTestClient(t)
+
+	query := `{
+		actor {
+			user {
+				email
+				id
+				name
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{}
+
+	actual, err := client.Query(query, variables)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+}
+
+func TestIntegrationQueryWithVariables(t *testing.T) {
+	t.Parallel()
+
+	gqlClient := newNerdGraphIntegrationTestClient(t)
+
+	query := `
+		query($guid: EntityGuid!) {
+			actor {
+				entity(guid: $guid) {
+					guid
+					name
+					domain
+					entityType
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"guid": "MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1",
+	}
+
+	actual, err := gqlClient.Query(query, variables)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+}
+
+// nolint
+func newNerdGraphIntegrationTestClient(t *testing.T) NerdGraph {
+	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
+
+	if personalAPIKey == "" {
+		t.Skipf("acceptance testing for NerdGraph requires your personal API key")
+	}
+
+	return New(config.Config{
+		PersonalAPIKey: personalAPIKey,
+		UserAgent:      "newrelic/newrelic-client-go",
+	})
+}


### PR DESCRIPTION
Resolves: #149 

### POC for raw GraphQL via client

First pass at adding the ability to pass raw GraphQL queries directly via a client method. 

This facilitates being able to execute a CLI command that passes a raw GraphQL query to the client.

#### CLI command example (basic query, no variables)
```
newrelic graphql query "{ actor { user { email id name } } }"
```

#### CLI command example (complex, with variables)
```
newrelic graphql query 'query($guid: EntityGuid!) { actor { entity(guid: $guid) { guid name domain entityType } } }' --variables '{"guid": "MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"}'
```