### PR TITLE
BREAKING CHANGE: Change API Key field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import (
 )
 
 func main() {
-	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 	nr := newrelic.New(ConfigAPIKey(apiKey))
 
 	params := apm.ListApplicationsParams{

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -27,7 +27,7 @@ func (a *PersonalAPIKeyCapableV2Authorizer) AuthorizeRequest(req *retryablehttp.
 		req.Header.Set("Api-Key", c.PersonalAPIKey)
 		req.Header.Set("Auth-Type", "User-Api-Key")
 	} else {
-		req.Header.Set("X-Api-Key", c.APIKey)
+		req.Header.Set("X-Api-Key", c.AdminAPIKey)
 	}
 }
 
@@ -36,5 +36,5 @@ type ClassicV2Authorizer struct{}
 
 // AuthorizeRequest is responsible for setting up auth for a request.
 func (a *ClassicV2Authorizer) AuthorizeRequest(req *retryablehttp.Request, c *config.Config) {
-	req.Header.Set("X-Api-Key", c.APIKey)
+	req.Header.Set("X-Api-Key", c.AdminAPIKey)
 }

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -38,7 +38,7 @@ type NewRelicClient struct {
 	// Config is the HTTP client configuration.
 	Config config.Config
 
-	// UsePersonalAPIKeyCompatability is for internal use only.
+	// AuthStrategy allows us to use multiple authentication methods for API calls
 	AuthStrategy RequestAuthorizer
 
 	errorValue ErrorResponse

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -27,12 +27,12 @@ func TestConfig(t *testing.T) {
 	testTransport := http.DefaultTransport
 
 	c := NewClient(config.Config{
-		APIKey:        testAPIKey,
-		BaseURL:       testBaseURL,
-		HTTPTransport: testTransport,
-		ServiceName:   testServiceName,
-		Timeout:       &testTimeout,
-		UserAgent:     testUserAgent,
+		PersonalAPIKey: testPersonalAPIKey,
+		BaseURL:        testBaseURL,
+		HTTPTransport:  testTransport,
+		ServiceName:    testServiceName,
+		Timeout:        &testTimeout,
+		UserAgent:      testUserAgent,
 	})
 
 	assert.Equal(t, &testTimeout, c.Config.Timeout)
@@ -46,7 +46,7 @@ func TestConfig(t *testing.T) {
 func TestConfigDefaults(t *testing.T) {
 	t.Parallel()
 	c := NewClient(config.Config{
-		APIKey: testAPIKey,
+		PersonalAPIKey: testPersonalAPIKey,
 	})
 
 	assert.Equal(t, region.DefaultBaseURLs[region.Parse(c.Config.Region)], c.Config.BaseURL)
@@ -247,13 +247,13 @@ func TestAdminAPIKeyHeader(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		assert.Equal(t, testAPIKey, r.Header.Get("x-api-key"))
+		assert.Equal(t, testAdminAPIKey, r.Header.Get("x-api-key"))
 	}))
 
 	c := NewClient(config.Config{
-		APIKey:    testAPIKey,
-		BaseURL:   ts.URL,
-		UserAgent: testUserAgent,
+		AdminAPIKey: testAdminAPIKey,
+		BaseURL:     ts.URL,
+		UserAgent:   testUserAgent,
 	})
 
 	_, err := c.Get("/path", nil, nil)

--- a/internal/http/test_helpers.go
+++ b/internal/http/test_helpers.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	testAPIKey         = "apiKey"
-	testPersonalAPIKey = "personalAPIKey"
+	testPersonalAPIKey = "apiKey"
+	testAdminAPIKey    = "adminAPIKey"
 	testUserAgent      = "userAgent"
 )
 
@@ -18,9 +18,9 @@ func NewTestAPIClient(handler http.Handler) NewRelicClient {
 	ts := httptest.NewServer(handler)
 
 	c := NewClient(config.Config{
-		APIKey:         testAPIKey,
-		BaseURL:        ts.URL,
 		PersonalAPIKey: testPersonalAPIKey,
+		AdminAPIKey:    testAdminAPIKey,
+		BaseURL:        ts.URL,
 		UserAgent:      testUserAgent,
 	})
 

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -40,8 +40,8 @@ func New(opts ...ConfigOption) (*NewRelic, error) {
 		}
 	}
 
-	if config.APIKey == "" && config.PersonalAPIKey == "" {
-		return nil, errors.New("use of ConfigAPIKey and/or ConfigPersonalAPIKey is required")
+	if config.PersonalAPIKey == "" && config.AdminAPIKey == "" {
+		return nil, errors.New("use of ConfigPersonalAPIKey and/or ConfigAdminAPIKey is required")
 	}
 
 	nr := &NewRelic{
@@ -61,22 +61,22 @@ func New(opts ...ConfigOption) (*NewRelic, error) {
 // https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
 type ConfigOption func(*config.Config) error
 
-// ConfigAPIKey sets the New Relic Admin API key this client will use.
-// One of ConfigAPIKey or ConfigPersonalAPIKey must be used to create a client.
+// ConfigPersonalAPIKey sets the New Relic Admin API key this client will use.
+// One of ConfigPersonalAPIKey or ConfigAdminAPIKey must be used to create a client.
 // https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-func ConfigAPIKey(apiKey string) ConfigOption {
+func ConfigPersonalAPIKey(apiKey string) ConfigOption {
 	return func(cfg *config.Config) error {
-		cfg.APIKey = apiKey
+		cfg.PersonalAPIKey = apiKey
 		return nil
 	}
 }
 
-// ConfigPersonalAPIKey sets the New Relic Personal API key this client will use.
-// One of ConfigAPIKey or ConfigPersonalAPIKey must be used to create a client.
+// ConfigAdminAPIKey sets the New Relic Admin API key this client will use.
+// One of ConfigAPIKey or ConfigAdminAPIKey must be used to create a client.
 // https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-func ConfigPersonalAPIKey(personalAPIKey string) ConfigOption {
+func ConfigAdminAPIKey(adminAPIKey string) ConfigOption {
 	return func(cfg *config.Config) error {
-		cfg.PersonalAPIKey = personalAPIKey
+		cfg.AdminAPIKey = adminAPIKey
 		return nil
 	}
 }

--- a/newrelic/newrelic_test.go
+++ b/newrelic/newrelic_test.go
@@ -18,7 +18,7 @@ var testAPIkey = "asdf1234"
 func TestNew_invalid(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(""))
+	nr, err := New(ConfigPersonalAPIKey(""))
 
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("apiKey required"), err)
@@ -27,7 +27,7 @@ func TestNew_invalid(t *testing.T) {
 func TestNew_basic(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -37,16 +37,16 @@ func TestNew_configOptionError(t *testing.T) {
 	t.Parallel()
 
 	badOption := func(cfg *config.Config) error { return errors.New("option with error") }
-	nr, err := New(ConfigAPIKey(testAPIkey), badOption)
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), badOption)
 
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("option with error"), err)
 }
 
-func TestNew_setPersonalAPIKey(t *testing.T) {
+func TestNew_setAdminAPIKey(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigPersonalAPIKey(testAPIkey))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigAdminAPIKey(testAPIkey))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -55,7 +55,7 @@ func TestNew_setPersonalAPIKey(t *testing.T) {
 func TestNew_setRegion(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigRegion("US"))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigRegion("US"))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -65,7 +65,7 @@ func TestNew_optionTimeout(t *testing.T) {
 	t.Parallel()
 
 	timeout := time.Second * 30
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigHTTPTimeout(timeout))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigHTTPTimeout(timeout))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -74,12 +74,12 @@ func TestNew_optionTimeout(t *testing.T) {
 func TestNew_optionTransport(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigHTTPTransport(nil))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigHTTPTransport(nil))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("HTTP Transport can not be nil"), err)
 
 	transport := http.DefaultTransport
-	nr, err = New(ConfigAPIKey(testAPIkey), ConfigHTTPTransport(transport))
+	nr, err = New(ConfigPersonalAPIKey(testAPIkey), ConfigHTTPTransport(transport))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -88,11 +88,11 @@ func TestNew_optionTransport(t *testing.T) {
 func TestNew_optionUserAgent(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigUserAgent(""))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigUserAgent(""))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("user-agent can not be empty"), err)
 
-	nr, err = New(ConfigAPIKey(testAPIkey), ConfigUserAgent("my-user-agent"))
+	nr, err = New(ConfigPersonalAPIKey(testAPIkey), ConfigUserAgent("my-user-agent"))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -101,7 +101,7 @@ func TestNew_optionUserAgent(t *testing.T) {
 func TestNew_optionServiceName(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigServiceName("my-service"))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigServiceName("my-service"))
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
 }
@@ -109,11 +109,11 @@ func TestNew_optionServiceName(t *testing.T) {
 func TestNew_optionBaseURL(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigBaseURL(""))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigBaseURL(""))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("base URL can not be empty"), err)
 
-	nr, err = New(ConfigAPIKey(testAPIkey), ConfigBaseURL("http://localhost/"))
+	nr, err = New(ConfigPersonalAPIKey(testAPIkey), ConfigBaseURL("http://localhost/"))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -122,11 +122,11 @@ func TestNew_optionBaseURL(t *testing.T) {
 func TestNew_optionInfrastructureBaseURL(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigInfrastructureBaseURL(""))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigInfrastructureBaseURL(""))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("infrastructure base URL can not be empty"), err)
 
-	nr, err = New(ConfigAPIKey(testAPIkey), ConfigInfrastructureBaseURL("http://localhost/"))
+	nr, err = New(ConfigPersonalAPIKey(testAPIkey), ConfigInfrastructureBaseURL("http://localhost/"))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -135,11 +135,11 @@ func TestNew_optionInfrastructureBaseURL(t *testing.T) {
 func TestNew_optionSyntheticsBaseURL(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigSyntheticsBaseURL(""))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigSyntheticsBaseURL(""))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("synthetics base URL can not be empty"), err)
 
-	nr, err = New(ConfigAPIKey(testAPIkey), ConfigSyntheticsBaseURL("http://localhost/"))
+	nr, err = New(ConfigPersonalAPIKey(testAPIkey), ConfigSyntheticsBaseURL("http://localhost/"))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -147,11 +147,11 @@ func TestNew_optionSyntheticsBaseURL(t *testing.T) {
 func TestNew_optionNerdGraphBaseURL(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigNerdGraphBaseURL(""))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigNerdGraphBaseURL(""))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("nerdgraph base URL can not be empty"), err)
 
-	nr, err = New(ConfigAPIKey(testAPIkey), ConfigNerdGraphBaseURL("http://localhost/"))
+	nr, err = New(ConfigPersonalAPIKey(testAPIkey), ConfigNerdGraphBaseURL("http://localhost/"))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -160,11 +160,11 @@ func TestNew_optionNerdGraphBaseURL(t *testing.T) {
 func TestNew_optionLogLevel(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigLogLevel(""))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigLogLevel(""))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("log level can not be empty"), err)
 
-	nr, err = New(ConfigAPIKey(testAPIkey), ConfigLogLevel("debug"))
+	nr, err = New(ConfigPersonalAPIKey(testAPIkey), ConfigLogLevel("debug"))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -173,7 +173,7 @@ func TestNew_optionLogLevel(t *testing.T) {
 func TestNew_optionLogJSON(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigLogJSON(true))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigLogJSON(true))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)
@@ -190,13 +190,13 @@ func (t *TestLogger) Trace(s string, a ...interface{}) {}
 func TestNew_optionLogger(t *testing.T) {
 	t.Parallel()
 
-	nr, err := New(ConfigAPIKey(testAPIkey), ConfigLogger(nil))
+	nr, err := New(ConfigPersonalAPIKey(testAPIkey), ConfigLogger(nil))
 	assert.Nil(t, nr)
 	assert.Error(t, errors.New("logger can not be nil"), err)
 
 	testLogger := TestLogger{}
 
-	nr, err = New(ConfigAPIKey(testAPIkey), ConfigLogger(&testLogger))
+	nr, err = New(ConfigPersonalAPIKey(testAPIkey), ConfigLogger(&testLogger))
 
 	assert.NotNil(t, nr)
 	assert.NoError(t, err)

--- a/pkg/alerts/alerts_test.go
+++ b/pkg/alerts/alerts_test.go
@@ -17,7 +17,7 @@ func newTestClient(handler http.Handler) Alerts {
 	ts := httptest.NewServer(handler)
 
 	c := New(config.Config{
-		APIKey:                "abc123",
+		AdminAPIKey:           "abc123",
 		BaseURL:               ts.URL,
 		InfrastructureBaseURL: ts.URL,
 		UserAgent:             "newrelic/newrelic-client-go",
@@ -35,7 +35,7 @@ func newMockResponse(
 	ts := mock.NewMockServer(t, mockJSONResponse, statusCode)
 
 	return New(config.Config{
-		APIKey:                "abc123",
+		AdminAPIKey:           "abc123",
 		BaseURL:               ts.URL,
 		InfrastructureBaseURL: ts.URL,
 		UserAgent:             "newrelic/newrelic-client-go",
@@ -44,15 +44,15 @@ func newMockResponse(
 
 // nolint
 func newIntegrationTestClient(t *testing.T) Alerts {
-	apiKey := os.Getenv("NEWRELIC_API_KEY")
-	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
+	personalAPIKey := os.Getenv("NEW_RELIC_API_KEY")
+	adminAPIKey := os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 
-	if apiKey == "" && personalAPIKey == "" {
-		t.Skipf("acceptance testing requires NEWRELIC_API_KEY and NEWRELIC_PERSONAL_API_KEY")
+	if personalAPIKey == "" && adminAPIKey == "" {
+		t.Skipf("acceptance testing requires NEW_RELIC_API_KEY and NEW_RELIC_ADMIN_API_KEY")
 	}
 
 	client := New(config.Config{
-		APIKey:         apiKey,
+		AdminAPIKey:    adminAPIKey,
 		PersonalAPIKey: personalAPIKey,
 		LogLevel:       "debug",
 	})

--- a/pkg/alerts/synthetics_conditions_integration_test.go
+++ b/pkg/alerts/synthetics_conditions_integration_test.go
@@ -37,7 +37,7 @@ func TestIntegrationSyntheticsConditions(t *testing.T) {
 
 	alerts := newIntegrationTestClient(t)
 	synth := synthetics.New(config.Config{
-		APIKey: os.Getenv("NEWRELIC_API_KEY"),
+		AdminAPIKey: os.Getenv("NEW_RELIC_ADMIN_API_KEY"),
 	})
 
 	// Setup

--- a/pkg/apm/apm_test.go
+++ b/pkg/apm/apm_test.go
@@ -15,10 +15,10 @@ func newTestClient(handler http.Handler) APM {
 	ts := httptest.NewServer(handler)
 
 	c := New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
-		UserAgent: "newrelic/newrelic-client-go",
-		LogLevel:  "debug",
+		PersonalAPIKey: "abc123",
+		BaseURL:        ts.URL,
+		UserAgent:      "newrelic/newrelic-client-go",
+		LogLevel:       "debug",
 	})
 
 	return c
@@ -33,23 +33,23 @@ func newMockResponse(
 	ts := mock.NewMockServer(t, mockJSONResponse, statusCode)
 
 	return New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
-		UserAgent: "newrelic/newrelic-client-go",
+		PersonalAPIKey: "abc123",
+		BaseURL:        ts.URL,
+		UserAgent:      "newrelic/newrelic-client-go",
 	})
 }
 
 // nolint
 func newIntegrationTestClient(t *testing.T) APM {
-	apiKey := os.Getenv("NEWRELIC_API_KEY")
-	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
+	personalAPIKey := os.Getenv("NEW_RELIC_API_KEY")
+	adminAPIKey := os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 
-	if apiKey == "" && personalAPIKey == "" {
-		t.Skipf("acceptance testing requires NEWRELIC_API_KEY and NEWRELIC_PERSONAL_API_KEY")
+	if personalAPIKey == "" && adminAPIKey == "" {
+		t.Skipf("acceptance testing requires NEW_RELIC_API_KEY and NEW_RELIC_ADMIN_API_KEY")
 	}
 
 	client := New(config.Config{
-		APIKey:         apiKey,
+		AdminAPIKey:    adminAPIKey,
 		PersonalAPIKey: personalAPIKey,
 		LogLevel:       "debug",
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,11 +10,14 @@ import (
 
 // Config contains all the configuration data for the API Client.
 type Config struct {
-	// APIKey to authenticate API requests
-	APIKey string
-
 	// PersonalAPIKey to authenticate API requests
+	// see: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key
 	PersonalAPIKey string
+
+	// AdminAPIKey to authenticate API requests
+	// Note this will be deprecated in the future!
+	// see: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#admin
+	AdminAPIKey string
 
 	// Region of the New Relic platform to use
 	// Valid values are: US, EU

--- a/pkg/dashboards/dashboard_integration_test.go
+++ b/pkg/dashboards/dashboard_integration_test.go
@@ -13,15 +13,15 @@ import (
 func TestIntegrationDashboards(t *testing.T) {
 	t.Parallel()
 
-	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	apiKey := os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 
 	if apiKey == "" {
-		t.Skipf("acceptance testing requires an API key")
+		t.Skipf("acceptance testing requires NEW_RELIC_ADMIN_API_KEY to be set")
 	}
 
 	dashboards := New(config.Config{
-		APIKey:   apiKey,
-		LogLevel: "debug",
+		AdminAPIKey: apiKey,
+		LogLevel:    "debug",
 	})
 
 	d := Dashboard{

--- a/pkg/dashboards/dashboards_test.go
+++ b/pkg/dashboards/dashboards_test.go
@@ -19,10 +19,10 @@ func newTestClient(handler http.Handler) Dashboards {
 	ts := httptest.NewServer(handler)
 
 	return New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
-		UserAgent: "newrelic/newrelic-client-go",
-		LogLevel:  "debug",
+		AdminAPIKey: "abc123",
+		BaseURL:     ts.URL,
+		UserAgent:   "newrelic/newrelic-client-go",
+		LogLevel:    "debug",
 	})
 }
 
@@ -34,9 +34,9 @@ func newMockResponse(
 	ts := mock.NewMockServer(t, mockJSONResponse, statusCode)
 
 	return New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
-		UserAgent: "newrelic/newrelic-client-go",
+		AdminAPIKey: "abc123",
+		BaseURL:     ts.URL,
+		UserAgent:   "newrelic/newrelic-client-go",
 	})
 }
 

--- a/pkg/entities/entity.go
+++ b/pkg/entities/entity.go
@@ -6,14 +6,15 @@ import (
 
 // Entity represents a New Relic One entity.
 type Entity struct {
-	AccountID  int
-	Domain     EntityDomainType
-	EntityType EntityType
-	GUID       string
-	Name       string
-	Permalink  string
-	Reporting  bool
-	Type       string
+	AccountID     int
+	ApplicationID int
+	Domain        EntityDomainType
+	EntityType    EntityType
+	GUID          string
+	Name          string
+	Permalink     string
+	Reporting     bool
+	Type          string
 }
 
 // EntityType represents a New Relic One entity type.
@@ -143,40 +144,8 @@ func (e *Entities) GetEntity(guid string) (*Entity, error) {
 	return resp.Actor.Entity, nil
 }
 
-var searchEntitiesQuery = `
-    query($queryBuilder: EntitySearchQueryBuilder, $cursor: String) {
-        actor {
-            entitySearch(queryBuilder: $queryBuilder)  {
-                results(cursor: $cursor) {
-                    nextCursor
-                    entities {
-						accountId
-						domain
-						entityType
-						guid
-						name
-						permalink
-						reporting
-						type
-                    }
-                }
-            }
-        }
-    }
-`
-
-type searchEntitiesResponse struct {
-	Actor struct {
-		EntitySearch struct {
-			Results struct {
-				NextCursor *string
-				Entities   []*Entity
-			}
-		}
-	}
-}
-
-var getEntitiesQuery = `
+const (
+	getEntitiesQuery = `
     query($guids: [String!]!) {
         actor {
             entities(guids: $guids)  {
@@ -192,14 +161,7 @@ var getEntitiesQuery = `
         }
     }
 `
-
-type getEntitiesResponse struct {
-	Actor struct {
-		Entities []*Entity
-	}
-}
-
-var getEntityQuery = `
+	getEntityQuery = `
     query($guid: String!) {
         actor {
             entity(guid: $guid)  {
@@ -215,6 +177,47 @@ var getEntityQuery = `
         }
     }
 `
+	searchEntitiesQuery = `
+query($queryBuilder: EntitySearchQueryBuilder, $cursor: String) {
+  actor {
+    entitySearch(queryBuilder: $queryBuilder)  {
+      results(cursor: $cursor) {
+        nextCursor
+        entities {
+          accountId
+          domain
+          entityType
+          guid
+          name
+          permalink
+          reporting
+          type
+          ... on ApmApplicationEntityOutline {
+              applicationId
+          }
+        }
+      }
+    }
+  }
+}`
+)
+
+type searchEntitiesResponse struct {
+	Actor struct {
+		EntitySearch struct {
+			Results struct {
+				NextCursor *string
+				Entities   []*Entity
+			}
+		}
+	}
+}
+
+type getEntitiesResponse struct {
+	Actor struct {
+		Entities []*Entity
+	}
+}
 
 type getEntityResponse struct {
 	Actor struct {

--- a/pkg/entities/entity_integration_test.go
+++ b/pkg/entities/entity_integration_test.go
@@ -68,14 +68,14 @@ func TestIntegrationGetEntity(t *testing.T) {
 
 // nolint
 func newIntegrationTestClient(t *testing.T) Entities {
-	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
+	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 
-	if personalAPIKey == "" {
+	if apiKey == "" {
 		t.Skipf("acceptance testing for graphql requires your personal API key")
 	}
 
 	return New(config.Config{
-		PersonalAPIKey: personalAPIKey,
+		PersonalAPIKey: apiKey,
 		UserAgent:      "newrelic/newrelic-client-go",
 		LogLevel:       "debug",
 	})

--- a/pkg/nerdgraph/nerdgraph_integration_test.go
+++ b/pkg/nerdgraph/nerdgraph_integration_test.go
@@ -63,14 +63,14 @@ func TestIntegrationQueryWithVariables(t *testing.T) {
 
 // nolint
 func newNerdGraphIntegrationTestClient(t *testing.T) NerdGraph {
-	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
+	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 
-	if personalAPIKey == "" {
-		t.Skipf("acceptance testing for NerdGraph requires your personal API key")
+	if apiKey == "" {
+		t.Skipf("acceptance testing for NerdGraph requires NEW_RELIC_API_KEY to be set")
 	}
 
 	return New(config.Config{
-		PersonalAPIKey: personalAPIKey,
+		PersonalAPIKey: apiKey,
 		UserAgent:      "newrelic/newrelic-client-go",
 	})
 }

--- a/pkg/plugins/components_integration_test.go
+++ b/pkg/plugins/components_integration_test.go
@@ -13,20 +13,25 @@ import (
 func TestIntegrationComponents(t *testing.T) {
 	t.Parallel()
 
-	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	apiKey := os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 
 	if apiKey == "" {
-		t.Skipf("acceptance testing requires an API key")
+		t.Skipf("acceptance testing requires NEW_RELIC_ADMIN_API_KEY to be set")
 	}
 
 	api := New(config.Config{
-		APIKey:   apiKey,
-		LogLevel: "debug",
+		AdminAPIKey: apiKey,
+		LogLevel:    "debug",
 	})
 
 	a, err := api.ListComponents(nil)
 
 	require.NoError(t, err)
+	require.NotNil(t, a)
+
+	if len(a) < 1 {
+		t.Skipf("Skipping `GetComponent` integration test due to zero plugins found")
+	}
 
 	c, err := api.GetComponent(a[0].ID)
 

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -18,10 +18,10 @@ func newTestClient(handler http.Handler) Plugins {
 	ts := httptest.NewServer(handler)
 
 	c := New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
-		UserAgent: "newrelic/newrelic-client-go",
-		LogLevel:  "debug",
+		PersonalAPIKey: "abc123",
+		BaseURL:        ts.URL,
+		UserAgent:      "newrelic/newrelic-client-go",
+		LogLevel:       "debug",
 	})
 
 	return c
@@ -36,24 +36,24 @@ func newMockResponse(
 	ts := mock.NewMockServer(t, mockJSONResponse, statusCode)
 
 	return New(config.Config{
-		APIKey:    "abc123",
-		BaseURL:   ts.URL,
-		UserAgent: "newrelic/newrelic-client-go",
+		PersonalAPIKey: "abc123",
+		BaseURL:        ts.URL,
+		UserAgent:      "newrelic/newrelic-client-go",
 	})
 }
 
 // nolint
 func newIntegrationTestClient(t *testing.T) Plugins {
-	apiKey := os.Getenv("NEWRELIC_API_KEY")
-	personalAPIKey := os.Getenv("NEWRELIC_PERSONAL_API_KEY")
+	personalAPIKey := os.Getenv("NEW_RELIC_API_KEY")
+	adminAPIKey := os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 
-	if apiKey == "" && personalAPIKey == "" {
-		t.Skipf("acceptance testing requires NEWRELIC_API_KEY and NEWRELIC_PERSONAL_API_KEY")
+	if personalAPIKey == "" && adminAPIKey == "" {
+		t.Skipf("acceptance testing requires NEW_RELIC_API_KEY and NEW_RELIC_ADMIN_API_KEY")
 	}
 
 	client := New(config.Config{
-		APIKey:         apiKey,
 		PersonalAPIKey: personalAPIKey,
+		AdminAPIKey:    adminAPIKey,
 		LogLevel:       "debug",
 	})
 

--- a/pkg/synthetics/monitor_labels_integration_test.go
+++ b/pkg/synthetics/monitor_labels_integration_test.go
@@ -31,15 +31,15 @@ var (
 func TestIntegrationGetMonitorLabels(t *testing.T) {
 	t.Parallel()
 
-	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	apiKey := os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 
 	if apiKey == "" {
-		t.Skipf("acceptance testing requires an API key")
+		t.Skipf("acceptance testing requires NEW_RELIC_ADMIN_API_KEY to be set")
 	}
 
 	synthetics := New(config.Config{
-		APIKey:   apiKey,
-		LogLevel: "debug",
+		AdminAPIKey: apiKey,
+		LogLevel:    "debug",
 	})
 
 	// Setup

--- a/pkg/synthetics/monitor_scripts_integration_test.go
+++ b/pkg/synthetics/monitor_scripts_integration_test.go
@@ -39,15 +39,15 @@ var (
 func TestIntegrationMonitorScripts(t *testing.T) {
 	t.Parallel()
 
-	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	apiKey := os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 
 	if apiKey == "" {
-		t.Skipf("acceptance testing requires an API key")
+		t.Skipf("acceptance testing requires NEW_RELIC_ADMIN_API_KEY to be set")
 	}
 
 	synthetics := New(config.Config{
-		APIKey:   apiKey,
-		LogLevel: "debug",
+		AdminAPIKey: apiKey,
+		LogLevel:    "debug",
 	})
 
 	// Setup

--- a/pkg/synthetics/monitors_integration_test.go
+++ b/pkg/synthetics/monitors_integration_test.go
@@ -29,15 +29,15 @@ var (
 func TestIntegrationMonitors(t *testing.T) {
 	t.Parallel()
 
-	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	apiKey := os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 
 	if apiKey == "" {
-		t.Skipf("acceptance testing requires an API key")
+		t.Skipf("acceptance testing requires NEW_RELIC_ADMIN_API_KEY to be set")
 	}
 
 	synthetics := New(config.Config{
-		APIKey:   apiKey,
-		LogLevel: "debug",
+		AdminAPIKey: apiKey,
+		LogLevel:    "debug",
 	})
 
 	rand := nr.RandSeq(5)

--- a/pkg/synthetics/secure_credentials_integration_test.go
+++ b/pkg/synthetics/secure_credentials_integration_test.go
@@ -26,15 +26,15 @@ var (
 func TestIntegrationSecureCredentials(t *testing.T) {
 	t.Parallel()
 
-	apiKey := os.Getenv("NEWRELIC_API_KEY")
+	apiKey := os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 
 	if apiKey == "" {
-		t.Skipf("acceptance testing requires an API key")
+		t.Skipf("acceptance testing requires NEW_RELIC_ADMIN_API_KEY")
 	}
 
 	synthetics := New(config.Config{
-		APIKey:   apiKey,
-		LogLevel: "debug",
+		AdminAPIKey: apiKey,
+		LogLevel:    "debug",
 	})
 
 	// Setup

--- a/pkg/synthetics/synthetics_test.go
+++ b/pkg/synthetics/synthetics_test.go
@@ -67,7 +67,7 @@ func newTestClient(handler http.Handler) Synthetics {
 	ts := httptest.NewServer(handler)
 
 	c := New(config.Config{
-		APIKey:            "abc123",
+		AdminAPIKey:       "abc123",
 		SyntheticsBaseURL: ts.URL,
 		UserAgent:         "newrelic/newrelic-client-go",
 		LogLevel:          "debug",


### PR DESCRIPTION
Align API key names with our public docs.

This breaks:
* `ConfigAPIKey` as it becomes `ConfigAdminAPIKey`
* `NEWRELIC_PERSONAL_API_KEY` becomes `NEW_RELIC_API_KEY` <= Personal API Key
* `NEWRELIC_API_KEY` becomes `NEW_RELIC_ADMIN_API_KEY` <= Admin API Key