### PR TITLE
fix(http): create a new errorValue for every request

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -299,11 +299,11 @@ func (c *NewRelicClient) do(
 
 	c.Config.GetLogger().Trace("request completed", "method", method, "url", req.URL, "status_code", resp.StatusCode, "headers", string(logHeaders), "body", string(body))
 
-	errorValue := c.errorValue
+	errorValue := c.errorValue.New()
 	_ = json.Unmarshal(body, &errorValue)
 
 	if !isResponseSuccess(resp) {
-		return nil, nrErrors.NewUnexpectedStatusCode(resp.StatusCode, c.errorValue.Error())
+		return nil, nrErrors.NewUnexpectedStatusCode(resp.StatusCode, errorValue.Error())
 	}
 
 	if errorValue.Error() != "" {

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -71,6 +71,10 @@ type CustomErrorResponse struct {
 	CustomError string `json:"custom"`
 }
 
+func (c *CustomErrorResponse) New() ErrorResponse {
+	return &CustomErrorResponse{}
+}
+
 func (c *CustomErrorResponse) Error() string {
 	return c.CustomError
 }

--- a/internal/http/errors.go
+++ b/internal/http/errors.go
@@ -9,6 +9,7 @@ import (
 // a single error message from an error response object.
 type ErrorResponse interface {
 	Error() string
+	New() ErrorResponse
 }
 
 // DefaultErrorResponse represents the default error response from New Relic.
@@ -29,4 +30,9 @@ func (e *DefaultErrorResponse) Error() string {
 	}
 
 	return m
+}
+
+// New creates a new instance of the DefaultErrorResponse struct.
+func (e *DefaultErrorResponse) New() ErrorResponse {
+	return &DefaultErrorResponse{}
 }

--- a/internal/http/graphql_client.go
+++ b/internal/http/graphql_client.go
@@ -80,3 +80,7 @@ func (r *graphQLErrorResponse) Error() string {
 
 	return ""
 }
+
+func (r *graphQLErrorResponse) New() ErrorResponse {
+	return &graphQLErrorResponse{}
+}

--- a/pkg/infrastructure/infrastructure.go
+++ b/pkg/infrastructure/infrastructure.go
@@ -1,6 +1,7 @@
 package infrastructure
 
 import (
+	"github.com/newrelic/newrelic-client-go/internal/http"
 	"github.com/newrelic/newrelic-client-go/internal/region"
 )
 
@@ -34,4 +35,9 @@ func (e *ErrorResponse) Error() string {
 	}
 
 	return ""
+}
+
+// New creates a new instance of ErrorResponse.
+func (e *ErrorResponse) New() http.ErrorResponse {
+	return &ErrorResponse{}
 }

--- a/pkg/synthetics/synthetics.go
+++ b/pkg/synthetics/synthetics.go
@@ -56,6 +56,11 @@ func (e *ErrorResponse) Error() string {
 	return ""
 }
 
+// New creates a new instance of ErrorResponse.
+func (e *ErrorResponse) New() http.ErrorResponse {
+	return &ErrorResponse{}
+}
+
 // New is used to create a new Synthetics client instance.
 func New(config config.Config) Synthetics {
 


### PR DESCRIPTION
Resolves #161.

This PR ensures that the `errrorValue` instance is not shared among multiple requests, eliminating shared state for concurrent requests.