### PR TITLE
chore(nerdgraph): export nerdgraph query response struct

### DIFF
--- a/pkg/nerdgraph/nerdgraph.go
+++ b/pkg/nerdgraph/nerdgraph.go
@@ -12,6 +12,14 @@ type NerdGraph struct {
 	logger logging.Logger
 }
 
+// QueryResponse represents the top-level GraphQL response object returned
+// from a NerdGraph query request.
+type QueryResponse struct {
+	Actor          interface{} `json:"actor,omitempty"`
+	Docs           interface{} `json:"docs,omitempty"`
+	RequestContext interface{} `json:"requestContext,omitempty"`
+}
+
 // New returns a new GraphQL client for interacting with New Relic's GraphQL API, NerdGraph.
 func New(config config.Config) NerdGraph {
 	return NerdGraph{
@@ -23,17 +31,11 @@ func New(config config.Config) NerdGraph {
 // Query facilitates making a NerdGraph request with a raw GraphQL query. Variables may be provided
 // in the form of a map. The response's data structure will vary based on the query provided.
 func (n *NerdGraph) Query(query string, variables map[string]interface{}) (interface{}, error) {
-	respBody := queryResponse{}
+	respBody := QueryResponse{}
 
 	if err := n.client.Query(query, variables, &respBody); err != nil {
 		return nil, err
 	}
 
 	return respBody, nil
-}
-
-type queryResponse struct {
-	Actor          interface{} `json:"actor,omitempty"`
-	Docs           interface{} `json:"docs,omitempty"`
-	RequestContext interface{} `json:"requestContext,omitempty"`
 }


### PR DESCRIPTION
This facilitates encoding the query result in the CLI (newrelic-cli PR [#58](https://github.com/newrelic/newrelic-cli/pull/58)), which is will be returning a raw string to ensure integers are parsed correctly.