### PR TITLE
refactor(http): configurable requests

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -1,33 +1,32 @@
 package http
 
 import (
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/newrelic/newrelic-client-go/pkg/config"
 )
 
 // RequestAuthorizer is an interface that allows customizatino of how a request is authorized.
 type RequestAuthorizer interface {
-	AuthorizeRequest(*retryablehttp.Request, *config.Config)
+	AuthorizeRequest(r *Request, c *config.Config)
 }
 
 // NerdGraphAuthorizer authorizes calls to NerdGraph.
 type NerdGraphAuthorizer struct{}
 
 // AuthorizeRequest is responsible for setting up auth for a request.
-func (a *NerdGraphAuthorizer) AuthorizeRequest(req *retryablehttp.Request, c *config.Config) {
-	req.Header.Set("Api-Key", c.PersonalAPIKey)
+func (a *NerdGraphAuthorizer) AuthorizeRequest(r *Request, c *config.Config) {
+	r.SetHeader("Api-Key", c.PersonalAPIKey)
 }
 
 // PersonalAPIKeyCapableV2Authorizer authorizes V2 endpoints that can use a personal API key.
 type PersonalAPIKeyCapableV2Authorizer struct{}
 
 // AuthorizeRequest is responsible for setting up auth for a request.
-func (a *PersonalAPIKeyCapableV2Authorizer) AuthorizeRequest(req *retryablehttp.Request, c *config.Config) {
+func (a *PersonalAPIKeyCapableV2Authorizer) AuthorizeRequest(r *Request, c *config.Config) {
 	if c.PersonalAPIKey != "" {
-		req.Header.Set("Api-Key", c.PersonalAPIKey)
-		req.Header.Set("Auth-Type", "User-Api-Key")
+		r.SetHeader("Api-Key", c.PersonalAPIKey)
+		r.SetHeader("Auth-Type", "User-Api-Key")
 	} else {
-		req.Header.Set("X-Api-Key", c.AdminAPIKey)
+		r.SetHeader("X-Api-Key", c.AdminAPIKey)
 	}
 }
 
@@ -35,6 +34,6 @@ func (a *PersonalAPIKeyCapableV2Authorizer) AuthorizeRequest(req *retryablehttp.
 type ClassicV2Authorizer struct{}
 
 // AuthorizeRequest is responsible for setting up auth for a request.
-func (a *ClassicV2Authorizer) AuthorizeRequest(req *retryablehttp.Request, c *config.Config) {
-	req.Header.Set("X-Api-Key", c.AdminAPIKey)
+func (a *ClassicV2Authorizer) AuthorizeRequest(r *Request, c *config.Config) {
+	r.SetHeader("X-Api-Key", c.AdminAPIKey)
 }

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	neturl "net/url"
 	"time"
 
-	"github.com/google/go-querystring/query"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 
 	"github.com/newrelic/newrelic-client-go/internal/region"
@@ -108,7 +106,12 @@ func (c *NewRelicClient) Get(
 	queryParams interface{},
 	respBody interface{},
 ) (*http.Response, error) {
-	return c.do(http.MethodGet, url, queryParams, nil, respBody)
+	req, err := c.NewRequest(http.MethodGet, url, queryParams, nil, respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req)
 }
 
 // Post represents an HTTP POST request to a New Relic API.
@@ -122,16 +125,16 @@ func (c *NewRelicClient) Post(
 	reqBody interface{},
 	respBody interface{},
 ) (*http.Response, error) {
-
-	reqBody, err := makeRequestBody(reqBody)
+	req, err := c.NewRequest(http.MethodPost, url, queryParams, reqBody, respBody)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.do(http.MethodPost, url, queryParams, reqBody, respBody)
+	return c.Do(req)
 }
 
-// RawPost behaves the same as Post, but without marshaling the body into JSON before making the request.  This is required at least in the case of Syntheics Labels, since the POST doesn't handle JSON.
+// RawPost behaves the same as Post, but without marshaling the body into JSON before making the request.
+// This is required at least in the case of Synthetics Labels, since the POST doesn't handle JSON.
 func (c *NewRelicClient) RawPost(
 	url string,
 	queryParams interface{},
@@ -139,18 +142,23 @@ func (c *NewRelicClient) RawPost(
 	respBody interface{},
 ) (*http.Response, error) {
 
+	var requestBody []byte
+
 	switch val := reqBody.(type) {
 	case []byte:
-		return c.do(http.MethodPost, url, queryParams, reqBody, respBody)
-
+		requestBody = val
 	case string:
-		requestBody := []byte(val)
-		return c.do(http.MethodPost, url, queryParams, requestBody, respBody)
-
+		requestBody = []byte(val)
 	default:
 		return nil, errors.New("invalid request body")
 	}
 
+	req, err := c.NewRequest(http.MethodPost, url, queryParams, requestBody, respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req)
 }
 
 // Put represents an HTTP PUT request to a New Relic API.
@@ -164,13 +172,12 @@ func (c *NewRelicClient) Put(
 	reqBody interface{},
 	respBody interface{},
 ) (*http.Response, error) {
-
-	reqBody, err := makeRequestBody(reqBody)
+	req, err := c.NewRequest(http.MethodPut, url, queryParams, reqBody, respBody)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.do(http.MethodPut, url, queryParams, reqBody, respBody)
+	return c.Do(req)
 }
 
 // Delete represents an HTTP DELETE request to a New Relic API.
@@ -181,102 +188,81 @@ func (c *NewRelicClient) Delete(url string,
 	queryParams interface{},
 	respBody interface{},
 ) (*http.Response, error) {
-	return c.do(http.MethodDelete, url, queryParams, nil, respBody)
+	req, err := c.NewRequest(http.MethodDelete, url, queryParams, nil, respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req)
 }
 
-func makeRequestBody(reqBody interface{}) (*bytes.Buffer, error) {
-	b := bytes.NewBuffer([]byte{})
-	if reqBody != nil {
-		j, err := json.Marshal(reqBody)
+// NewRequest creates a new Request struct.
+func (c *NewRelicClient) NewRequest(method string, url string, params interface{}, reqBody interface{}, value interface{}) (*Request, error) {
+	// Make a copy of the client's config
+	cfg := c.Config
 
+	req := &Request{
+		method:       method,
+		url:          url,
+		params:       params,
+		reqBody:      reqBody,
+		value:        value,
+		authStrategy: c.AuthStrategy,
+	}
+
+	req.config = cfg
+
+	u, err := req.makeURL()
+	if err != nil {
+		return nil, err
+	}
+
+	var r *retryablehttp.Request
+	if reqBody != nil {
+		if _, ok := reqBody.([]byte); !ok {
+			reqBody, err = makeRequestBodyReader(reqBody)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		r, err = retryablehttp.NewRequest(req.method, u.String(), reqBody)
 		if err != nil {
 			return nil, err
 		}
-
-		b = bytes.NewBuffer(j)
+	} else {
+		r, err = retryablehttp.NewRequest(req.method, u.String(), nil)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return b, nil
+	req.request = r
+
+	req.SetHeader(defaultNewRelicRequestingServiceHeader, defaultServiceName)
+	req.SetHeader("Content-Type", "application/json")
+	req.SetHeader("User-Agent", cfg.UserAgent)
+
+	return req, nil
 }
 
-func (c *NewRelicClient) setHeaders(req *retryablehttp.Request) {
-	req.Header.Set(defaultNewRelicRequestingServiceHeader, defaultServiceName)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", c.Config.UserAgent)
-}
-
-func setQueryParams(req *retryablehttp.Request, params interface{}) error {
-	if params == nil || len(req.URL.Query()) > 0 {
-		return nil
-	}
-
-	q, err := query.Values(params)
-
-	if err != nil {
-		return err
-	}
-
-	req.URL.RawQuery = q.Encode()
-
-	return nil
-}
-
-func (c *NewRelicClient) makeURL(url string) (*neturl.URL, error) {
-	u, err := neturl.Parse(url)
-
+// Do initiates an HTTP request as configured by the passed Request struct.
+func (c *NewRelicClient) Do(req *Request) (*http.Response, error) {
+	r, err := req.makeRequest()
 	if err != nil {
 		return nil, err
 	}
 
-	if u.Host != "" {
-		return u, nil
-	}
+	c.Config.GetLogger().Debug("performing request", "method", req.method, "url", r.URL)
 
-	u, err = neturl.Parse(c.Config.BaseURL + u.Path)
-
+	logHeaders, err := json.Marshal(r.Header)
 	if err != nil {
 		return nil, err
 	}
 
-	return u, err
-}
+	c.Config.GetLogger().Trace("request details", "headers", string(logHeaders), "body", req.reqBody)
 
-func (c *NewRelicClient) do(
-	method string,
-	url string,
-	params interface{},
-	reqBody interface{},
-	value interface{},
-) (*http.Response, error) {
-
-	u, err := c.makeURL(url)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := retryablehttp.NewRequest(method, u.String(), reqBody)
-	if err != nil {
-		return nil, err
-	}
-
-	c.setHeaders(req)
-	c.AuthStrategy.AuthorizeRequest(req, &c.Config)
-
-	err = setQueryParams(req, params)
-	if err != nil {
-		return nil, err
-	}
-
-	c.Config.GetLogger().Debug("performing request", "method", method, "url", req.URL)
-
-	logHeaders, err := json.Marshal(req.Header)
-	if err != nil {
-		return nil, err
-	}
-
-	c.Config.GetLogger().Trace("request details", "headers", string(logHeaders), "body", reqBody)
-
-	resp, retryErr := c.Client.Do(req)
+	resp, retryErr := c.Client.Do(r)
 	if retryErr != nil {
 		return nil, retryErr
 	}
@@ -297,7 +283,7 @@ func (c *NewRelicClient) do(
 		return nil, err
 	}
 
-	c.Config.GetLogger().Trace("request completed", "method", method, "url", req.URL, "status_code", resp.StatusCode, "headers", string(logHeaders), "body", string(body))
+	c.Config.GetLogger().Trace("request completed", "method", req.method, "url", r.URL, "status_code", resp.StatusCode, "headers", string(logHeaders), "body", string(body))
 
 	errorValue := c.errorValue.New()
 	_ = json.Unmarshal(body, &errorValue)
@@ -310,11 +296,11 @@ func (c *NewRelicClient) do(
 		return nil, errors.New(errorValue.Error())
 	}
 
-	if value == nil {
+	if req.value == nil {
 		return resp, nil
 	}
 
-	jsonErr := json.Unmarshal(body, value)
+	jsonErr := json.Unmarshal(body, req.value)
 	if jsonErr != nil {
 		return nil, jsonErr
 	}
@@ -328,4 +314,19 @@ func isResponseSuccess(resp *http.Response) bool {
 	statusCode := resp.StatusCode
 
 	return statusCode >= http.StatusOK && statusCode <= 299
+}
+
+func makeRequestBodyReader(reqBody interface{}) (*bytes.Buffer, error) {
+	if reqBody == nil {
+		return nil, nil
+	}
+
+	j, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	b := bytes.NewBuffer(j)
+
+	return b, nil
 }

--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -1,0 +1,78 @@
+package http
+
+import (
+	neturl "net/url"
+
+	"github.com/google/go-querystring/query"
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+	"github.com/newrelic/newrelic-client-go/pkg/config"
+)
+
+// Request represents a configurable HTTP request.
+type Request struct {
+	method       string
+	url          string
+	params       interface{}
+	reqBody      interface{}
+	value        interface{}
+	config       config.Config
+	authStrategy RequestAuthorizer
+	request      *retryablehttp.Request
+}
+
+// SetHeader sets a header on the underlying request.
+func (r *Request) SetHeader(key string, value string) {
+	r.request.Header.Set(key, value)
+}
+
+// SetAuthStrategy sets the authentication strategy for the request.
+func (r *Request) SetAuthStrategy(ra RequestAuthorizer) {
+	r.authStrategy = ra
+}
+
+func (r *Request) makeURL() (*neturl.URL, error) {
+	u, err := neturl.Parse(r.url)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Host != "" {
+		return u, nil
+	}
+
+	u, err = neturl.Parse(r.config.BaseURL + u.Path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return u, err
+}
+
+func (r *Request) makeRequest() (*retryablehttp.Request, error) {
+	r.authStrategy.AuthorizeRequest(r, &r.config)
+
+	err := r.setQueryParams()
+	if err != nil {
+		return nil, err
+	}
+
+	return r.request, nil
+}
+
+func (r *Request) setQueryParams() error {
+	if r.params == nil || len(r.request.URL.Query()) > 0 {
+		return nil
+	}
+
+	q, err := query.Values(r.params)
+
+	if err != nil {
+		return err
+	}
+
+	r.request.URL.RawQuery = q.Encode()
+
+	return nil
+}

--- a/pkg/apm/apm.go
+++ b/pkg/apm/apm.go
@@ -17,7 +17,6 @@ type APM struct {
 // New is used to create a new APM client instance.
 func New(config config.Config) APM {
 	client := http.NewClient(config)
-	client.AuthStrategy = &http.PersonalAPIKeyCapableV2Authorizer{}
 
 	pkg := APM{
 		client: client,

--- a/pkg/apm/deployments.go
+++ b/pkg/apm/deployments.go
@@ -2,6 +2,8 @@ package apm
 
 import (
 	"fmt"
+
+	"github.com/newrelic/newrelic-client-go/internal/http"
 )
 
 // Deployment represents information about a New Relic application deployment.
@@ -27,7 +29,14 @@ func (apm *APM) ListDeployments(applicationID int) ([]*Deployment, error) {
 
 	for nextURL != "" {
 		response := deploymentsResponse{}
-		resp, err := apm.client.Get(nextURL, nil, &response)
+		req, err := apm.client.NewRequest("GET", nextURL, nil, nil, &response)
+		if err != nil {
+			return nil, err
+		}
+
+		req.SetAuthStrategy(&http.PersonalAPIKeyCapableV2Authorizer{})
+
+		resp, err := apm.client.Do(req)
 
 		if err != nil {
 			return nil, err
@@ -50,7 +59,14 @@ func (apm *APM) CreateDeployment(applicationID int, deployment Deployment) (*Dep
 	resp := deploymentResponse{}
 
 	u := fmt.Sprintf("/applications/%d/deployments.json", applicationID)
-	_, err := apm.client.Post(u, nil, &reqBody, &resp)
+	req, err := apm.client.NewRequest("POST", u, nil, &reqBody, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetAuthStrategy(&http.PersonalAPIKeyCapableV2Authorizer{})
+
+	_, err = apm.client.Do(req)
 
 	if err != nil {
 		return nil, err
@@ -64,7 +80,14 @@ func (apm *APM) DeleteDeployment(applicationID int, deploymentID int) (*Deployme
 	resp := deploymentResponse{}
 	u := fmt.Sprintf("/applications/%d/deployments/%d.json", applicationID, deploymentID)
 
-	_, err := apm.client.Delete(u, nil, &resp)
+	req, err := apm.client.NewRequest("DELETE", u, nil, nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetAuthStrategy(&http.PersonalAPIKeyCapableV2Authorizer{})
+
+	_, err = apm.client.Do(req)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Resolves #156 .

This PR refactors the client to a request-scoped API and removes personal key auth for APM resources aside from deployments.