### PR TITLE
feat(newrelic): add types for fields with well known values

### DIFF
--- a/pkg/alerts/channels.go
+++ b/pkg/alerts/channels.go
@@ -8,11 +8,35 @@ import (
 	"github.com/newrelic/newrelic-client-go/internal/serialization"
 )
 
+// ChannelType specifies the channel type used when creating the alert channel.
+type ChannelType string
+
+var (
+	// ChannelTypes enumerates the possible channel types for an alert channel.
+	ChannelTypes = struct {
+		Email     ChannelType
+		OpsGenie  ChannelType
+		PagerDuty ChannelType
+		Slack     ChannelType
+		User      ChannelType
+		VictorOps ChannelType
+		Webhook   ChannelType
+	}{
+		Email:     "email",
+		OpsGenie:  "opsgenie",
+		PagerDuty: "pagerduty",
+		Slack:     "slack",
+		User:      "user",
+		VictorOps: "victorops",
+		Webhook:   "webhook",
+	}
+)
+
 // Channel represents a New Relic alert notification channel
 type Channel struct {
 	ID            int                  `json:"id,omitempty"`
 	Name          string               `json:"name,omitempty"`
-	Type          string               `json:"type,omitempty"`
+	Type          ChannelType          `json:"type,omitempty"`
 	Configuration ChannelConfiguration `json:"configuration,omitempty"`
 	Links         ChannelLinks         `json:"links,omitempty"`
 }

--- a/pkg/alerts/channels_integration_test.go
+++ b/pkg/alerts/channels_integration_test.go
@@ -16,7 +16,7 @@ func TestIntegrationChannel(t *testing.T) {
 	var (
 		testChannelEmail = Channel{
 			Name: "integration-test-email",
-			Type: "email",
+			Type: ChannelTypes.Email,
 			Configuration: ChannelConfiguration{
 				Recipients:            "devtoolkittest@newrelic.com",
 				IncludeJSONAttachment: "true",
@@ -28,7 +28,7 @@ func TestIntegrationChannel(t *testing.T) {
 
 		testChannelOpsGenie = Channel{
 			Name: "integration-test-opsgenie",
-			Type: "opsgenie",
+			Type: ChannelTypes.OpsGenie,
 			Configuration: ChannelConfiguration{
 				APIKey:     "abc123",
 				Teams:      "dev-toolkit",
@@ -42,7 +42,7 @@ func TestIntegrationChannel(t *testing.T) {
 
 		testChannelSlack = Channel{
 			Name: "integration-test-slack",
-			Type: "slack",
+			Type: ChannelTypes.Slack,
 			Configuration: ChannelConfiguration{
 				URL:     "https://example-org.slack.com",
 				Channel: "test-channel",
@@ -54,7 +54,7 @@ func TestIntegrationChannel(t *testing.T) {
 
 		testChannelVictorops = Channel{
 			Name: "integration-test-victorops",
-			Type: "victorops",
+			Type: ChannelTypes.VictorOps,
 			Configuration: ChannelConfiguration{
 				Key:      "abc123",
 				RouteKey: "/route-name",
@@ -66,7 +66,7 @@ func TestIntegrationChannel(t *testing.T) {
 
 		testChannelWebhook = Channel{
 			Name: "integration-test-webhook",
-			Type: "webhook",
+			Type: ChannelTypes.Webhook,
 			Configuration: ChannelConfiguration{
 				BaseURL:     "https://test.com",
 				PayloadType: "application/json",
@@ -84,7 +84,7 @@ func TestIntegrationChannel(t *testing.T) {
 
 		testChannelWebhookEmptyHeadersAndPayload = Channel{
 			Name: "integration-test-webhook-empty-headers-and-payload",
-			Type: "webhook",
+			Type: ChannelTypes.Webhook,
 			Configuration: ChannelConfiguration{
 				BaseURL: "https://test.com",
 			},
@@ -95,7 +95,7 @@ func TestIntegrationChannel(t *testing.T) {
 
 		testChannelWebhookWeirdHeadersAndPayload = Channel{
 			Name: "integration-test-webhook-weird-headers-and-payload",
-			Type: "webhook",
+			Type: ChannelTypes.Webhook,
 			Configuration: ChannelConfiguration{
 				BaseURL: "https://test.com",
 				Headers: serialization.MapStringInterface{
@@ -116,7 +116,7 @@ func TestIntegrationChannel(t *testing.T) {
 		// as many scenarios as possible.
 		testChannelWebhookComplexHeadersPayload = Channel{
 			Name: "integration-test-webhook",
-			Type: "webhook",
+			Type: ChannelTypes.Webhook,
 			Configuration: ChannelConfiguration{
 				BaseURL:     "https://test.com",
 				PayloadType: "application/json",

--- a/pkg/alerts/channels_test.go
+++ b/pkg/alerts/channels_test.go
@@ -163,7 +163,7 @@ func TestListChannels(t *testing.T) {
 		{
 			ID:   2803426,
 			Name: "unit-test-alert-channel",
-			Type: "user",
+			Type: ChannelTypes.User,
 			Configuration: ChannelConfiguration{
 				UserID: "2680539",
 			},
@@ -174,7 +174,7 @@ func TestListChannels(t *testing.T) {
 		{
 			ID:   2932511,
 			Name: "test@testing.com",
-			Type: "email",
+			Type: ChannelTypes.Email,
 			Configuration: ChannelConfiguration{
 				Recipients:            "test@testing.com",
 				IncludeJSONAttachment: "true",
@@ -200,7 +200,7 @@ func TestListChannelsWebhookWithComplexHeadersAndPayload(t *testing.T) {
 		{
 			ID:   1,
 			Name: "webhook-EMPTY-headers-and-payload",
-			Type: "webhook",
+			Type: ChannelTypes.Webhook,
 			Configuration: ChannelConfiguration{
 				BaseURL:     "http://example.com",
 				PayloadType: "",
@@ -212,7 +212,7 @@ func TestListChannelsWebhookWithComplexHeadersAndPayload(t *testing.T) {
 		{
 			ID:   2,
 			Name: "webhook-ESCAPED-STRING-headers-and-payload",
-			Type: "webhook",
+			Type: ChannelTypes.Webhook,
 			Configuration: ChannelConfiguration{
 				BaseURL:     "http://example.com",
 				PayloadType: "application/json",
@@ -230,7 +230,7 @@ func TestListChannelsWebhookWithComplexHeadersAndPayload(t *testing.T) {
 		{
 			ID:   3,
 			Name: "webhook-WEIRD-headers-and-payload",
-			Type: "webhook",
+			Type: ChannelTypes.Webhook,
 			Configuration: ChannelConfiguration{
 				BaseURL: "http://example.com",
 				Headers: serialization.MapStringInterface{
@@ -248,7 +248,7 @@ func TestListChannelsWebhookWithComplexHeadersAndPayload(t *testing.T) {
 		{
 			ID:   4,
 			Name: "webhook-COMPLEX-payload",
-			Type: "webhook",
+			Type: ChannelTypes.Webhook,
 			Configuration: ChannelConfiguration{
 				BaseURL: "http://example.com",
 				Headers: serialization.MapStringInterface{
@@ -285,7 +285,7 @@ func TestGetChannel(t *testing.T) {
 	expected := &Channel{
 		ID:   2803426,
 		Name: "unit-test-alert-channel",
-		Type: "user",
+		Type: ChannelTypes.User,
 		Configuration: ChannelConfiguration{
 			UserID: "2680539",
 		},
@@ -318,7 +318,7 @@ func TestCreateChannel(t *testing.T) {
 
 	channel := Channel{
 		Name: "test@example.com",
-		Type: "email",
+		Type: ChannelTypes.Email,
 		Configuration: ChannelConfiguration{
 			Recipients:            "test@example.com",
 			IncludeJSONAttachment: "true",
@@ -328,7 +328,7 @@ func TestCreateChannel(t *testing.T) {
 	expected := &Channel{
 		ID:   2932701,
 		Name: "test@example.com",
-		Type: "email",
+		Type: ChannelTypes.Email,
 		Configuration: ChannelConfiguration{
 			Recipients:            "test@example.com",
 			IncludeJSONAttachment: "true",
@@ -372,7 +372,7 @@ func TestDeleteChannel(t *testing.T) {
 	expected := &Channel{
 		ID:   2932511,
 		Name: "test@example.com",
-		Type: "email",
+		Type: ChannelTypes.Email,
 		Configuration: ChannelConfiguration{
 			Recipients:            "test@example.com",
 			IncludeJSONAttachment: "true",

--- a/pkg/alerts/conditions.go
+++ b/pkg/alerts/conditions.go
@@ -6,16 +6,147 @@ import (
 	"github.com/newrelic/newrelic-client-go/pkg/errors"
 )
 
+// ConditionType specifies the condition type used when creating the alert condition.
+type ConditionType string
+
+var (
+	// ConditionTypes enumerates the possible condition types for an alert condition.
+	ConditionTypes = struct {
+		APMApplicationMetric    ConditionType
+		APMKeyTransactionMetric ConditionType
+		ServersMetric           ConditionType
+		BrowserMetric           ConditionType
+		MobileMetric            ConditionType
+	}{
+		APMApplicationMetric:    "apm_app_metric",
+		APMKeyTransactionMetric: "apm_kt_metric",
+		ServersMetric:           "servers_metric",
+		BrowserMetric:           "browser_metric",
+		MobileMetric:            "mobile_metric",
+	}
+)
+
+// MetricType specifies the metric type used when creating the alert condition.
+type MetricType string
+
+var (
+	// MetricTypes enumerates the possible metric types for an alert condition.
+	// Not all metric types are valid for all condition types.  See the docuentation for more details.
+	MetricTypes = struct {
+		AjaxResponseTime       MetricType
+		AjaxThroughput         MetricType
+		Apdex                  MetricType
+		CPUPercentage          MetricType
+		Database               MetricType
+		DiskIOPercentage       MetricType
+		DomProcessing          MetricType
+		EndUserApdex           MetricType
+		ErrorCount             MetricType
+		ErrorPercentage        MetricType
+		FullestDiskPercentage  MetricType
+		Images                 MetricType
+		JSON                   MetricType
+		LoadAverageOneMinute   MetricType
+		MemoryPercentage       MetricType
+		MobileCrashRate        MetricType
+		Network                MetricType
+		NetworkErrorPercentage MetricType
+		PageRendering          MetricType
+		PageViewThroughput     MetricType
+		PageViewsWithJsErrors  MetricType
+		RequestQueuing         MetricType
+		ResponseTime           MetricType
+		ResponseTimeBackground MetricType
+		ResponseTimeWeb        MetricType
+		StatusErrorPercentage  MetricType
+		Throughput             MetricType
+		ThroughputBackground   MetricType
+		ThroughputWeb          MetricType
+		TotalPageLoad          MetricType
+		UserDefined            MetricType
+		ViewLoading            MetricType
+		WebApplication         MetricType
+	}{
+		AjaxResponseTime:       "ajax_response_time",
+		AjaxThroughput:         "ajax_throughput",
+		Apdex:                  "apdex",
+		CPUPercentage:          "cpu_percentage",
+		Database:               "database",
+		DiskIOPercentage:       "disk_io_percentage",
+		DomProcessing:          "dom_processing",
+		EndUserApdex:           "end_user_apdex",
+		ErrorCount:             "error_count",
+		ErrorPercentage:        "error_percentage",
+		FullestDiskPercentage:  "fullest_disk_percentage",
+		Images:                 "images",
+		JSON:                   "json",
+		LoadAverageOneMinute:   "load_average_one_minute",
+		MemoryPercentage:       "memory_percentage",
+		MobileCrashRate:        "mobile_crash_rate",
+		Network:                "network",
+		NetworkErrorPercentage: "network_error_percentage",
+		PageRendering:          "page_rendering",
+		PageViewThroughput:     "page_view_throughput",
+		PageViewsWithJsErrors:  "page_views_with_js_errors",
+		RequestQueuing:         "request_queuing",
+		ResponseTime:           "response_time",
+		ResponseTimeBackground: "response_time_background",
+		ResponseTimeWeb:        "response_time_web",
+		StatusErrorPercentage:  "status_error_percentage",
+		Throughput:             "throughput",
+		ThroughputBackground:   "throughput_background",
+		ThroughputWeb:          "throughput_web",
+		TotalPageLoad:          "total_page_load",
+		UserDefined:            "user_defined",
+		ViewLoading:            "view_loading",
+		WebApplication:         "web_application",
+	}
+)
+
+// TimeFunctionType specifies the time function to be used for alert condition terms.
+type TimeFunctionType string
+
+var (
+	// TimeFunctionTypes enumerates the possible time function types for alert condition terms.
+	TimeFunctionTypes = struct {
+		All TimeFunctionType
+		Any TimeFunctionType
+	}{
+		All: "all",
+		Any: "any",
+	}
+)
+
+// ValueFunctionType specifies the value function to be used for returning custom metric data.
+type ValueFunctionType string
+
+var (
+	// ValueFunctionTypes enumerates the possible value function types for custom metrics.
+	ValueFunctionTypes = struct {
+		Average    ValueFunctionType
+		Min        ValueFunctionType
+		Max        ValueFunctionType
+		Total      ValueFunctionType
+		SampleSize ValueFunctionType
+	}{
+		Average:    "average",
+		Min:        "min",
+		Max:        "max",
+		Total:      "total",
+		SampleSize: "sample_size",
+	}
+)
+
 // Condition represents a New Relic alert condition.
 // TODO: custom unmarshal entities to ints?
 type Condition struct {
 	PolicyID            int                  `json:"-"`
 	ID                  int                  `json:"id,omitempty"`
-	Type                string               `json:"type,omitempty"`
+	Type                ConditionType        `json:"type,omitempty"`
 	Name                string               `json:"name,omitempty"`
 	Enabled             bool                 `json:"enabled"`
 	Entities            []string             `json:"entities,omitempty"`
-	Metric              string               `json:"metric,omitempty"`
+	Metric              MetricType           `json:"metric,omitempty"`
 	RunbookURL          string               `json:"runbook_url,omitempty"`
 	Terms               []ConditionTerm      `json:"terms,omitempty"`
 	UserDefined         ConditionUserDefined `json:"user_defined,omitempty"`
@@ -26,17 +157,17 @@ type Condition struct {
 
 // ConditionUserDefined represents user defined metrics for the New Relic alert condition.
 type ConditionUserDefined struct {
-	Metric        string `json:"metric,omitempty"`
-	ValueFunction string `json:"value_function,omitempty"`
+	Metric        string            `json:"metric,omitempty"`
+	ValueFunction ValueFunctionType `json:"value_function,omitempty"`
 }
 
 // ConditionTerm represents the terms of a New Relic alert condition.
 type ConditionTerm struct {
-	Duration     int     `json:"duration,string,omitempty"`
-	Operator     string  `json:"operator,omitempty"`
-	Priority     string  `json:"priority,omitempty"`
-	Threshold    float64 `json:"threshold,string"`
-	TimeFunction string  `json:"time_function,omitempty"`
+	Duration     int              `json:"duration,string,omitempty"`
+	Operator     string           `json:"operator,omitempty"`
+	Priority     string           `json:"priority,omitempty"`
+	Threshold    float64          `json:"threshold,string"`
+	TimeFunction TimeFunctionType `json:"time_function,omitempty"`
 }
 
 // ListConditions returns alert conditions for a specified policy.

--- a/pkg/alerts/conditions_integration_test.go
+++ b/pkg/alerts/conditions_integration_test.go
@@ -18,14 +18,14 @@ func TestIntegrationConditions(t *testing.T) {
 		testConditionPolicy  = Policy{
 			Name: fmt.Sprintf("test-integration-alert-conditions-%s",
 				testConditionRandStr),
-			IncidentPreference: "PER_POLICY",
+			IncidentPreference: IncidentPreferenceTypes.PerPolicy,
 		}
 		testCondition = Condition{
-			Type:       "apm_app_metric",
+			Type:       ConditionTypes.APMApplicationMetric,
 			Name:       "Adpex (High)",
 			Enabled:    true,
 			Entities:   []string{},
-			Metric:     "apdex",
+			Metric:     MetricTypes.Apdex,
 			RunbookURL: "",
 			Terms: []ConditionTerm{
 				{
@@ -33,7 +33,7 @@ func TestIntegrationConditions(t *testing.T) {
 					Operator:     "above",
 					Priority:     "critical",
 					Threshold:    0.9,
-					TimeFunction: "all",
+					TimeFunction: TimeFunctionTypes.All,
 				},
 			},
 			UserDefined: ConditionUserDefined{

--- a/pkg/alerts/conditions_test.go
+++ b/pkg/alerts/conditions_test.go
@@ -90,11 +90,11 @@ func TestListConditions(t *testing.T) {
 		{
 			PolicyID:   333,
 			ID:         123,
-			Type:       "apm_app_metric",
+			Type:       ConditionTypes.APMApplicationMetric,
 			Name:       "Apdex (High)",
 			Enabled:    true,
 			Entities:   []string{"321"},
-			Metric:     "apdex",
+			Metric:     MetricTypes.Apdex,
 			RunbookURL: "",
 			Terms: []ConditionTerm{
 				{
@@ -102,7 +102,7 @@ func TestListConditions(t *testing.T) {
 					Operator:     "above",
 					Priority:     "critical",
 					Threshold:    0.9,
-					TimeFunction: "all",
+					TimeFunction: TimeFunctionTypes.All,
 				},
 			},
 			UserDefined: ConditionUserDefined{
@@ -129,11 +129,11 @@ func TestGetCondition(t *testing.T) {
 	expected := &Condition{
 		PolicyID:   333,
 		ID:         123,
-		Type:       "apm_app_metric",
+		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Apdex (High)",
 		Enabled:    true,
 		Entities:   []string{"321"},
-		Metric:     "apdex",
+		Metric:     MetricTypes.Apdex,
 		RunbookURL: "",
 		Terms: []ConditionTerm{
 			{
@@ -141,7 +141,7 @@ func TestGetCondition(t *testing.T) {
 				Operator:     "above",
 				Priority:     "critical",
 				Threshold:    0.9,
-				TimeFunction: "all",
+				TimeFunction: TimeFunctionTypes.All,
 			},
 		},
 		UserDefined: ConditionUserDefined{
@@ -166,11 +166,11 @@ func TestCreateCondition(t *testing.T) {
 
 	condition := Condition{
 		PolicyID:   333,
-		Type:       "apm_app_metric",
+		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Adpex (High)",
 		Enabled:    true,
 		Entities:   []string{"321"},
-		Metric:     "apdex",
+		Metric:     MetricTypes.Apdex,
 		RunbookURL: "",
 		Terms: []ConditionTerm{
 			{
@@ -178,7 +178,7 @@ func TestCreateCondition(t *testing.T) {
 				Operator:     "above",
 				Priority:     "critical",
 				Threshold:    0.9,
-				TimeFunction: "all",
+				TimeFunction: TimeFunctionTypes.All,
 			},
 		},
 		UserDefined: ConditionUserDefined{
@@ -193,11 +193,11 @@ func TestCreateCondition(t *testing.T) {
 	expected := &Condition{
 		PolicyID:   333,
 		ID:         123,
-		Type:       "apm_app_metric",
+		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Apdex (High)",
 		Enabled:    true,
 		Entities:   []string{"321"},
-		Metric:     "apdex",
+		Metric:     MetricTypes.Apdex,
 		RunbookURL: "",
 		Terms: []ConditionTerm{
 			{
@@ -205,7 +205,7 @@ func TestCreateCondition(t *testing.T) {
 				Operator:     "above",
 				Priority:     "critical",
 				Threshold:    0.9,
-				TimeFunction: "all",
+				TimeFunction: TimeFunctionTypes.All,
 			},
 		},
 		UserDefined: ConditionUserDefined{
@@ -230,11 +230,11 @@ func TestUpdateCondition(t *testing.T) {
 
 	condition := Condition{
 		PolicyID:   333,
-		Type:       "apm_app_metric",
+		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Adpex (High)",
 		Enabled:    true,
 		Entities:   []string{"321"},
-		Metric:     "apdex",
+		Metric:     MetricTypes.Apdex,
 		RunbookURL: "",
 		Terms: []ConditionTerm{
 			{
@@ -242,7 +242,7 @@ func TestUpdateCondition(t *testing.T) {
 				Operator:     "above",
 				Priority:     "critical",
 				Threshold:    0.9,
-				TimeFunction: "all",
+				TimeFunction: TimeFunctionTypes.All,
 			},
 		},
 		UserDefined: ConditionUserDefined{
@@ -257,11 +257,11 @@ func TestUpdateCondition(t *testing.T) {
 	expected := &Condition{
 		PolicyID:   333,
 		ID:         123,
-		Type:       "apm_app_metric",
+		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Apdex (High)",
 		Enabled:    true,
 		Entities:   []string{"321"},
-		Metric:     "apdex",
+		Metric:     MetricTypes.Apdex,
 		RunbookURL: "",
 		Terms: []ConditionTerm{
 			{
@@ -269,7 +269,7 @@ func TestUpdateCondition(t *testing.T) {
 				Operator:     "below",
 				Priority:     "warning",
 				Threshold:    0.5,
-				TimeFunction: "all",
+				TimeFunction: TimeFunctionTypes.All,
 			},
 		},
 		UserDefined: ConditionUserDefined{
@@ -294,11 +294,11 @@ func TestDeleteCondition(t *testing.T) {
 
 	expected := &Condition{
 		ID:         123,
-		Type:       "apm_app_metric",
+		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Apdex (High)",
 		Enabled:    true,
 		Entities:   []string{"321"},
-		Metric:     "apdex",
+		Metric:     MetricTypes.Apdex,
 		RunbookURL: "",
 		Terms: []ConditionTerm{
 			{
@@ -306,7 +306,7 @@ func TestDeleteCondition(t *testing.T) {
 				Operator:     "above",
 				Priority:     "critical",
 				Threshold:    0.9,
-				TimeFunction: "all",
+				TimeFunction: TimeFunctionTypes.All,
 			},
 		},
 		UserDefined: ConditionUserDefined{

--- a/pkg/alerts/policies.go
+++ b/pkg/alerts/policies.go
@@ -8,10 +8,26 @@ import (
 	"github.com/newrelic/newrelic-client-go/internal/serialization"
 )
 
+// IncidentPreferenceType specifies rollup settings for alert policies.
+type IncidentPreferenceType string
+
+var (
+	// IncidentPreferenceTypes specifies the possible incident preferenece types for an alert policy.
+	IncidentPreferenceTypes = struct {
+		PerPolicy             IncidentPreferenceType
+		PerCondition          IncidentPreferenceType
+		PerConditionAndTarget IncidentPreferenceType
+	}{
+		PerPolicy:             "PER_POLICY",
+		PerCondition:          "PER_CONDITION",
+		PerConditionAndTarget: "PER_CONDITION_AND_TARGET",
+	}
+)
+
 // Policy represents a New Relic alert policy.
 type Policy struct {
 	ID                 int                      `json:"id,omitempty"`
-	IncidentPreference string                   `json:"incident_preference,omitempty"`
+	IncidentPreference IncidentPreferenceType   `json:"incident_preference,omitempty"`
 	Name               string                   `json:"name,omitempty"`
 	CreatedAt          *serialization.EpochTime `json:"created_at,omitempty"`
 	UpdatedAt          *serialization.EpochTime `json:"updated_at,omitempty"`

--- a/pkg/alerts/policies_integration_test.go
+++ b/pkg/alerts/policies_integration_test.go
@@ -17,7 +17,7 @@ func TestIntegrationPolicy(t *testing.T) {
 
 	testIntegrationPolicyNameRandStr := nr.RandSeq(5)
 	policy := Policy{
-		IncidentPreference: "PER_POLICY",
+		IncidentPreference: IncidentPreferenceTypes.PerPolicy,
 		Name:               fmt.Sprintf("test-alert-policy-%s", testIntegrationPolicyNameRandStr),
 	}
 

--- a/pkg/alerts/policies_test.go
+++ b/pkg/alerts/policies_test.go
@@ -60,7 +60,7 @@ func TestGetPolicy(t *testing.T) {
 
 	expected := &Policy{
 		ID:                 579506,
-		IncidentPreference: "PER_POLICY",
+		IncidentPreference: IncidentPreferenceTypes.PerPolicy,
 		Name:               "test-alert-policy-1",
 		CreatedAt:          &testTimestamp,
 		UpdatedAt:          &testTimestamp,
@@ -80,14 +80,14 @@ func TestListPolicies(t *testing.T) {
 	expected := []Policy{
 		{
 			ID:                 579506,
-			IncidentPreference: "PER_POLICY",
+			IncidentPreference: IncidentPreferenceTypes.PerPolicy,
 			Name:               "test-alert-policy-1",
 			CreatedAt:          &testTimestamp,
 			UpdatedAt:          &testTimestamp,
 		},
 		{
 			ID:                 579509,
-			IncidentPreference: "PER_POLICY",
+			IncidentPreference: IncidentPreferenceTypes.PerPolicy,
 			Name:               "test-alert-policy-2",
 			CreatedAt:          &testTimestamp,
 			UpdatedAt:          &testTimestamp,
@@ -135,13 +135,13 @@ func TestCreatePolicy(t *testing.T) {
 	alerts := newMockResponse(t, testPolicyResponseJSON, http.StatusOK)
 
 	policy := Policy{
-		IncidentPreference: "PER_POLICY",
+		IncidentPreference: IncidentPreferenceTypes.PerPolicy,
 		Name:               "test-alert-policy-1",
 	}
 
 	expected := &Policy{
 		ID:                 579506,
-		IncidentPreference: "PER_POLICY",
+		IncidentPreference: IncidentPreferenceTypes.PerPolicy,
 		Name:               "test-alert-policy-1",
 		CreatedAt:          &testTimestamp,
 		UpdatedAt:          &testTimestamp,
@@ -160,13 +160,13 @@ func TestUpdatePolicy(t *testing.T) {
 
 	policy := Policy{
 		ID:                 579506,
-		IncidentPreference: "PER_POLICY",
+		IncidentPreference: IncidentPreferenceTypes.PerPolicy,
 		Name:               "test-alert-policy-1",
 	}
 
 	expected := &Policy{
 		ID:                 579506,
-		IncidentPreference: "PER_CONDITION",
+		IncidentPreference: IncidentPreferenceTypes.PerCondition,
 		Name:               "test-alert-policy-updated",
 		CreatedAt:          &testTimestamp,
 		UpdatedAt:          &testTimestamp,
@@ -185,7 +185,7 @@ func TestDeletePolicy(t *testing.T) {
 
 	expected := &Policy{
 		ID:                 579506,
-		IncidentPreference: "PER_POLICY",
+		IncidentPreference: IncidentPreferenceTypes.PerPolicy,
 		Name:               "test-alert-policy-1",
 		CreatedAt:          &testTimestamp,
 		UpdatedAt:          &testTimestamp,


### PR DESCRIPTION
Resolves #130 .

This PR adds enum-style, `string`-backed types for resource fields that have well-known values.