### PR TITLE
refactor: remove transient PolicyID on conditions structs for 1:1 mapping to API responses

### DIFF
--- a/pkg/alerts/conditions.go
+++ b/pkg/alerts/conditions.go
@@ -140,7 +140,6 @@ var (
 // Condition represents a New Relic alert condition.
 // TODO: custom unmarshal entities to ints?
 type Condition struct {
-	PolicyID            int                  `json:"-"`
 	ID                  int                  `json:"id,omitempty"`
 	Type                ConditionType        `json:"type,omitempty"`
 	Name                string               `json:"name,omitempty"`
@@ -187,10 +186,6 @@ func (alerts *Alerts) ListConditions(policyID int) ([]*Condition, error) {
 			return nil, err
 		}
 
-		for _, c := range response.Conditions {
-			c.PolicyID = policyID
-		}
-
 		alertConditions = append(alertConditions, response.Conditions...)
 
 		paging := alerts.pager.Parse(resp)
@@ -217,20 +212,18 @@ func (alerts *Alerts) GetCondition(policyID int, id int) (*Condition, error) {
 }
 
 // CreateCondition creates an alert condition for a specified policy.
-func (alerts *Alerts) CreateCondition(condition Condition) (*Condition, error) {
+func (alerts *Alerts) CreateCondition(policyID int, condition Condition) (*Condition, error) {
 	reqBody := alertConditionRequestBody{
 		Condition: condition,
 	}
 	resp := alertConditionResponse{}
 
-	u := fmt.Sprintf("/alerts_conditions/policies/%d.json", condition.PolicyID)
+	u := fmt.Sprintf("/alerts_conditions/policies/%d.json", policyID)
 	_, err := alerts.client.Post(u, nil, &reqBody, &resp)
 
 	if err != nil {
 		return nil, err
 	}
-
-	resp.Condition.PolicyID = condition.PolicyID
 
 	return &resp.Condition, nil
 }
@@ -248,8 +241,6 @@ func (alerts *Alerts) UpdateCondition(condition Condition) (*Condition, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	resp.Condition.PolicyID = condition.PolicyID
 
 	return &resp.Condition, nil
 }

--- a/pkg/alerts/conditions_integration_test.go
+++ b/pkg/alerts/conditions_integration_test.go
@@ -53,7 +53,7 @@ func TestIntegrationConditions(t *testing.T) {
 
 	require.NoError(t, err)
 
-	testCondition.PolicyID = policy.ID
+	// testCondition.PolicyID = policy.ID
 
 	// Deferred teardown
 	defer func() {
@@ -65,19 +65,19 @@ func TestIntegrationConditions(t *testing.T) {
 	}()
 
 	// Test: Create
-	createResult, err := client.CreateCondition(testCondition)
+	createResult, err := client.CreateCondition(policy.ID, testCondition)
 
 	require.NoError(t, err)
 	require.NotNil(t, createResult)
 
 	// Test: Get
-	listResult, err := client.ListConditions(createResult.PolicyID)
+	listResult, err := client.ListConditions(policy.ID)
 
 	require.NoError(t, err)
 	require.Greater(t, len(listResult), 0)
 
 	// Test: Get
-	readResult, err := client.GetCondition(createResult.PolicyID, createResult.ID)
+	readResult, err := client.GetCondition(policy.ID, createResult.ID)
 
 	require.NoError(t, err)
 	require.NotNil(t, readResult)

--- a/pkg/alerts/conditions_integration_test.go
+++ b/pkg/alerts/conditions_integration_test.go
@@ -53,8 +53,6 @@ func TestIntegrationConditions(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// testCondition.PolicyID = policy.ID
-
 	// Deferred teardown
 	defer func() {
 		_, err := client.DeletePolicy(policy.ID)

--- a/pkg/alerts/conditions_test.go
+++ b/pkg/alerts/conditions_test.go
@@ -88,7 +88,6 @@ func TestListConditions(t *testing.T) {
 
 	expected := []*Condition{
 		{
-			PolicyID:   333,
 			ID:         123,
 			Type:       ConditionTypes.APMApplicationMetric,
 			Name:       "Apdex (High)",
@@ -127,7 +126,6 @@ func TestGetCondition(t *testing.T) {
 	alerts := newMockResponse(t, testListConditionsResponseJSON, http.StatusOK)
 
 	expected := &Condition{
-		PolicyID:   333,
 		ID:         123,
 		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Apdex (High)",
@@ -163,9 +161,9 @@ func TestGetCondition(t *testing.T) {
 func TestCreateCondition(t *testing.T) {
 	t.Parallel()
 	alerts := newMockResponse(t, testConditionJSON, http.StatusCreated)
+	policyID := 333
 
 	condition := Condition{
-		PolicyID:   333,
 		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Adpex (High)",
 		Enabled:    true,
@@ -191,7 +189,6 @@ func TestCreateCondition(t *testing.T) {
 	}
 
 	expected := &Condition{
-		PolicyID:   333,
 		ID:         123,
 		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Apdex (High)",
@@ -217,7 +214,7 @@ func TestCreateCondition(t *testing.T) {
 		ViolationCloseTimer: 0,
 	}
 
-	actual, err := alerts.CreateCondition(condition)
+	actual, err := alerts.CreateCondition(policyID, condition)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, actual)
@@ -229,7 +226,6 @@ func TestUpdateCondition(t *testing.T) {
 	alerts := newMockResponse(t, testConditionUpdateJSON, http.StatusCreated)
 
 	condition := Condition{
-		PolicyID:   333,
 		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Adpex (High)",
 		Enabled:    true,
@@ -255,7 +251,6 @@ func TestUpdateCondition(t *testing.T) {
 	}
 
 	expected := &Condition{
-		PolicyID:   333,
 		ID:         123,
 		Type:       ConditionTypes.APMApplicationMetric,
 		Name:       "Apdex (High)",

--- a/pkg/alerts/nrql_conditions.go
+++ b/pkg/alerts/nrql_conditions.go
@@ -14,7 +14,6 @@ type NrqlCondition struct {
 	Name                string          `json:"name,omitempty"`
 	RunbookURL          string          `json:"runbook_url,omitempty"`
 	ValueFunction       string          `json:"value_function,omitempty"`
-	PolicyID            int             `json:"-"`
 	ID                  int             `json:"id,omitempty"`
 	ViolationCloseTimer int             `json:"violation_time_limit_seconds,omitempty"`
 	ExpectedGroups      int             `json:"expected_groups,omitempty"`
@@ -45,10 +44,6 @@ func (alerts *Alerts) ListNrqlConditions(policyID int) ([]*NrqlCondition, error)
 			return nil, err
 		}
 
-		for _, c := range response.NrqlConditions {
-			c.PolicyID = policyID
-		}
-
 		conditions = append(conditions, response.NrqlConditions...)
 
 		paging := alerts.pager.Parse(resp)
@@ -76,20 +71,18 @@ func (alerts *Alerts) GetNrqlCondition(policyID int, id int) (*NrqlCondition, er
 }
 
 // CreateNrqlCondition creates a NRQL alert condition.
-func (alerts *Alerts) CreateNrqlCondition(condition NrqlCondition) (*NrqlCondition, error) {
+func (alerts *Alerts) CreateNrqlCondition(policyID int, condition NrqlCondition) (*NrqlCondition, error) {
 	reqBody := nrqlConditionRequestBody{
 		NrqlCondition: condition,
 	}
 	resp := nrqlConditionResponse{}
 
-	u := fmt.Sprintf("/alerts_nrql_conditions/policies/%d.json", condition.PolicyID)
+	u := fmt.Sprintf("/alerts_nrql_conditions/policies/%d.json", policyID)
 	_, err := alerts.client.Post(u, nil, &reqBody, &resp)
 
 	if err != nil {
 		return nil, err
 	}
-
-	resp.NrqlCondition.PolicyID = condition.PolicyID
 
 	return &resp.NrqlCondition, nil
 }
@@ -107,8 +100,6 @@ func (alerts *Alerts) UpdateNrqlCondition(condition NrqlCondition) (*NrqlConditi
 	if err != nil {
 		return nil, err
 	}
-
-	resp.NrqlCondition.PolicyID = condition.PolicyID
 
 	return &resp.NrqlCondition, nil
 }

--- a/pkg/alerts/nrql_conditions_integration_test.go
+++ b/pkg/alerts/nrql_conditions_integration_test.go
@@ -51,8 +51,6 @@ func TestIntegrationNrqlConditions(t *testing.T) {
 
 	require.NoError(t, err)
 
-	nrqlCondition.PolicyID = policy.ID
-
 	// Deferred teardown
 	defer func() {
 		_, err := client.DeletePolicy(policy.ID)
@@ -63,19 +61,19 @@ func TestIntegrationNrqlConditions(t *testing.T) {
 	}()
 
 	// Test: Create
-	createResult, err := client.CreateNrqlCondition(nrqlCondition)
+	createResult, err := client.CreateNrqlCondition(policy.ID, nrqlCondition)
 
 	require.NoError(t, err)
 	require.NotNil(t, createResult)
 
 	// Test: List
-	listResult, err := client.ListNrqlConditions(createResult.PolicyID)
+	listResult, err := client.ListNrqlConditions(policy.ID)
 
 	require.NoError(t, err)
 	require.Greater(t, len(listResult), 0)
 
 	// Test: Get
-	readResult, err := client.GetNrqlCondition(createResult.PolicyID, createResult.ID)
+	readResult, err := client.GetNrqlCondition(policy.ID, createResult.ID)
 
 	require.NoError(t, err)
 	require.NotNil(t, readResult)

--- a/pkg/alerts/nrql_conditions_test.go
+++ b/pkg/alerts/nrql_conditions_test.go
@@ -109,7 +109,6 @@ func TestListNrqlConditions(t *testing.T) {
 			Name:                "NRQL Test Alert",
 			RunbookURL:          "",
 			ValueFunction:       "single_value",
-			PolicyID:            123,
 			ID:                  12345,
 			ViolationCloseTimer: 3600,
 			Enabled:             true,
@@ -145,7 +144,6 @@ func TestGetNrqlCondition(t *testing.T) {
 		Name:                "NRQL Test Alert",
 		RunbookURL:          "",
 		ValueFunction:       "single_value",
-		PolicyID:            123,
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             true,
@@ -161,6 +159,7 @@ func TestGetNrqlCondition(t *testing.T) {
 func TestCreateNrqlCondition(t *testing.T) {
 	t.Parallel()
 	alerts := newMockResponse(t, testNrqlConditionJSON, http.StatusCreated)
+	policyID := 333
 
 	condition := NrqlCondition{
 		Nrql: NrqlQuery{
@@ -180,7 +179,6 @@ func TestCreateNrqlCondition(t *testing.T) {
 		Name:                "NRQL Test Alert",
 		RunbookURL:          "",
 		ValueFunction:       "single_value",
-		PolicyID:            123,
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             true,
@@ -188,7 +186,7 @@ func TestCreateNrqlCondition(t *testing.T) {
 
 	expected := &condition
 
-	actual, err := alerts.CreateNrqlCondition(condition)
+	actual, err := alerts.CreateNrqlCondition(policyID, condition)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, actual)
@@ -217,7 +215,6 @@ func TestUpdateNrqlCondition(t *testing.T) {
 		Name:                "NRQL Test Alert",
 		RunbookURL:          "",
 		ValueFunction:       "single_value",
-		PolicyID:            123,
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             true,
@@ -241,7 +238,6 @@ func TestUpdateNrqlCondition(t *testing.T) {
 		Name:                "NRQL Test Alert Updated",
 		RunbookURL:          "https://www.example.com/docs",
 		ValueFunction:       "single_value",
-		PolicyID:            123,
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             false,

--- a/pkg/alerts/plugins_conditions.go
+++ b/pkg/alerts/plugins_conditions.go
@@ -8,7 +8,6 @@ import (
 
 // PluginsCondition represents an alert condition for New Relic Plugins.
 type PluginsCondition struct {
-	PolicyID          int             `json:"-"`
 	ID                int             `json:"id,omitempty"`
 	Name              string          `json:"name,omitempty"`
 	Enabled           bool            `json:"enabled"`
@@ -44,10 +43,6 @@ func (alerts *Alerts) ListPluginsConditions(policyID int) ([]*PluginsCondition, 
 			return nil, err
 		}
 
-		for _, c := range response.PluginsConditions {
-			c.PolicyID = policyID
-		}
-
 		conditions = append(conditions, response.PluginsConditions...)
 
 		paging := alerts.pager.Parse(resp)
@@ -76,20 +71,18 @@ func (alerts *Alerts) GetPluginsCondition(policyID int, pluginID int) (*PluginsC
 }
 
 // CreatePluginsCondition creates an alert condition for a plugin.
-func (alerts *Alerts) CreatePluginsCondition(condition PluginsCondition) (*PluginsCondition, error) {
+func (alerts *Alerts) CreatePluginsCondition(policyID int, condition PluginsCondition) (*PluginsCondition, error) {
 	reqBody := pluginConditionRequestBody{
 		PluginsCondition: condition,
 	}
 	resp := pluginConditionResponse{}
 
-	u := fmt.Sprintf("/alerts_plugins_conditions/policies/%d.json", condition.PolicyID)
+	u := fmt.Sprintf("/alerts_plugins_conditions/policies/%d.json", policyID)
 	_, err := alerts.client.Post(u, nil, &reqBody, &resp)
 
 	if err != nil {
 		return nil, err
 	}
-
-	resp.PluginsCondition.PolicyID = condition.PolicyID
 
 	return &resp.PluginsCondition, nil
 }
@@ -107,8 +100,6 @@ func (alerts *Alerts) UpdatePluginsCondition(condition PluginsCondition) (*Plugi
 	if err != nil {
 		return nil, err
 	}
-
-	resp.PluginsCondition.PolicyID = condition.PolicyID
 
 	return &resp.PluginsCondition, nil
 }

--- a/pkg/alerts/plugins_conditions_integration_test.go
+++ b/pkg/alerts/plugins_conditions_integration_test.go
@@ -52,8 +52,6 @@ func TestIntegrationPluginsConditions(t *testing.T) {
 
 	require.NoError(t, err)
 
-	condition.PolicyID = policy.ID
-
 	// Deferred teardown
 	defer func() {
 		_, err := client.DeletePolicy(policy.ID)
@@ -64,19 +62,19 @@ func TestIntegrationPluginsConditions(t *testing.T) {
 	}()
 
 	// Test: Create
-	createResult, err := client.CreatePluginsCondition(condition)
+	createResult, err := client.CreatePluginsCondition(policy.ID, condition)
 
 	require.NoError(t, err)
 	require.NotNil(t, createResult)
 
 	// Test: List
-	listResult, err := client.ListPluginsConditions(createResult.PolicyID)
+	listResult, err := client.ListPluginsConditions(policy.ID)
 
 	require.NoError(t, err)
 	require.Greater(t, len(listResult), 0)
 
 	// Test: Get
-	readResult, err := client.GetPluginsCondition(createResult.PolicyID, createResult.ID)
+	readResult, err := client.GetPluginsCondition(policy.ID, createResult.ID)
 
 	require.NoError(t, err)
 	require.NotNil(t, readResult)

--- a/pkg/alerts/plugins_conditions_test.go
+++ b/pkg/alerts/plugins_conditions_test.go
@@ -38,7 +38,6 @@ var (
 	}`
 
 	testPluginsCondition = PluginsCondition{
-		PolicyID:          123,
 		ID:                333444,
 		Name:              "Connected Clients (High)",
 		Enabled:           true,
@@ -96,7 +95,7 @@ func TestCreatePluginsCondition(t *testing.T) {
 	responseJSON := fmt.Sprintf(`{"plugins_condition": %s}`, testPluginsConditionJSON)
 	client := newMockResponse(t, responseJSON, http.StatusCreated)
 
-	actual, err := client.CreatePluginsCondition(testPluginsCondition)
+	actual, err := client.CreatePluginsCondition(123, testPluginsCondition)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, actual)


### PR DESCRIPTION
Resolves: #120 

Downstream changes will need to be made in [terraform-providers/terraform-provider-newrelic](https://github.com/terraform-providers/terraform-provider-newrelic).