### PR TITLE
fix(http): allow overriding of service name

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -239,7 +239,7 @@ func (c *NewRelicClient) NewRequest(method string, url string, params interface{
 
 	req.request = r
 
-	req.SetHeader(defaultNewRelicRequestingServiceHeader, defaultServiceName)
+	req.SetHeader(defaultNewRelicRequestingServiceHeader, cfg.ServiceName)
 	req.SetHeader("Content-Type", "application/json")
 	req.SetHeader("User-Agent", cfg.UserAgent)
 

--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	neturl "net/url"
 
 	"github.com/google/go-querystring/query"
@@ -28,6 +29,12 @@ func (r *Request) SetHeader(key string, value string) {
 // SetAuthStrategy sets the authentication strategy for the request.
 func (r *Request) SetAuthStrategy(ra RequestAuthorizer) {
 	r.authStrategy = ra
+}
+
+// SetServiceName sets the service name for the request.
+func (r *Request) SetServiceName(serviceName string) {
+	serviceName = fmt.Sprintf("%s|%s", serviceName, defaultServiceName)
+	r.SetHeader(defaultNewRelicRequestingServiceHeader, serviceName)
 }
 
 func (r *Request) makeURL() (*neturl.URL, error) {


### PR DESCRIPTION
Resolves #175 .

This PR fixes overriding of the service name header.