### PR TITLE
fix(build): Force pull tags after each checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
       - image: circleci/golang:1.14
     steps:
       - checkout
+      - run: git fetch --tags
       - save_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
           paths:


### PR DESCRIPTION
On release merge to master, `checkout` in CircleCI appears not to update a cache as expected, and the tags are not pulled in.  This should force the tags to be fetch after checkout every new run