### PR TITLE
Expand data returned by `entity`, make search/fetch consistent

### DIFF
--- a/pkg/entities/entity.go
+++ b/pkg/entities/entity.go
@@ -13,19 +13,22 @@ type Entity struct {
 	Name       string           `json:"name,omitempty"`
 	Permalink  string           `json:"permalink,omitempty"`
 	Reporting  bool             `json:"reporting,omitempty"`
-	Type       EntityType       `json:"type,omitempty"`
+	Type       Type             `json:"type,omitempty"`
 
 	// ApmApplicationEntity, BrowserApplicationEntity
 	AlertSeverity *EntityAlertSeverityType `json:"alertSeverity,omitempty"`
 	ApplicationID *int                     `json:"applicationId,omitempty"`
 
-	// ApmApplicationEntity
+	// Stitch in other structs
+	ApmApplicationEntity
+	BrowserApplicationEntity
+}
+
+// ApmApplicationEntity represents the unique fields returned on the ApmApplicationEntity interface
+type ApmApplicationEntity struct {
 	Language             *string                                          `json:"language,omitempty"`
 	RunningAgentVersions *ApmApplicationEntityOutlineRunningAgentVersions `json:"runningAgentVersions,omitempty"`
 	Settings             *ApmApplicationEntityOutlineSettings             `json:"settings,omitempty"`
-
-	// BrowserApplicationEntity
-	ServingApmApplicationID *int `json:"servingApmApplicationId,omitempty"`
 }
 
 type ApmApplicationEntityOutlineSettings struct {
@@ -38,21 +41,52 @@ type ApmApplicationEntityOutlineRunningAgentVersions struct {
 	MinVersion *string `json:"minVersion,omitempty"`
 }
 
-// EntityType represents a New Relic One entity type.
+// BrowserApplicationEntity represents the unique fields returned on the BrowserApplicationEntity interface
+type BrowserApplicationEntity struct {
+	ServingApmApplicationID *int `json:"servingApmApplicationId,omitempty"`
+}
+
+// EntityType represents a New Relic One entity type (full)
 type EntityType string
 
+// Type represents a New Relic One entity type (short)
+type Type string
+
 var (
-	// EntityTypes specifies the possible types for a New Relic One entity.
-	EntityTypes = struct {
-		Application EntityType
-		Dashboard   EntityType
-		Host        EntityType
-		Monitor     EntityType
+	// Types specifies the possible types for a New Relic One entity.
+	Types = struct {
+		Application Type
+		Dashboard   Type
+		Host        Type
+		Monitor     Type
+		Workload    Type
 	}{
 		Application: "APPLICATION",
 		Dashboard:   "DASHBOARD",
 		Host:        "HOST",
 		Monitor:     "MONITOR",
+		Workload:    "WORKLOAD",
+	}
+)
+
+var (
+	// EntityTypes specifies the possible types for a New Relic One entity.
+	EntityTypes = struct {
+		Application EntityType
+		Browser     EntityType
+		Dashboard   EntityType
+		Host        EntityType
+		Mobile      EntityType
+		Monitor     EntityType
+		Workload    EntityType
+	}{
+		Application: "APM_APPLICATION_ENTITY",
+		Browser:     "BROWSER_APPLICATION_ENTITY",
+		Dashboard:   "DASHBOARD_ENTITY",
+		Host:        "INFRASTRUCTURE_HOST_ENTITY",
+		Mobile:      "MOBILE_APPLICATION_ENTITY",
+		Monitor:     "SYNTHETIC_MONITOR_ENTITY",
+		Workload:    "WORKLOAD_ENTITY",
 	}
 )
 
@@ -66,13 +100,17 @@ var (
 		Browser        EntityDomainType
 		Infrastructure EntityDomainType
 		Mobile         EntityDomainType
+		Nr1            EntityDomainType
 		Synthetics     EntityDomainType
+		Visualization  EntityDomainType
 	}{
 		APM:            "APM",
 		Browser:        "BROWSER",
 		Infrastructure: "INFRA",
 		Mobile:         "MOBILE",
+		Nr1:            "NR1",
 		Synthetics:     "SYNTH",
+		Visualization:  "VIZ",
 	}
 )
 

--- a/pkg/entities/entity_integration_test.go
+++ b/pkg/entities/entity_integration_test.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/newrelic/newrelic-client-go/pkg/config"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/newrelic/newrelic-client-go/pkg/config"
 )
 
 func TestIntegrationSearchEntities(t *testing.T) {
@@ -58,12 +60,49 @@ func TestIntegrationGetEntities(t *testing.T) {
 func TestIntegrationGetEntity(t *testing.T) {
 	t.Parallel()
 
+	entityGUID := "MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"
+	client := newIntegrationTestClient(t)
+
+	actual, err := client.GetEntity(entityGUID)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+
+	// These are a bit fragile, if the above GUID ever changes...
+	assert.Equal(t, 2520528, actual.AccountID)
+	assert.Equal(t, EntityDomainType("APM"), actual.Domain)
+	assert.Equal(t, EntityType("APM_APPLICATION_ENTITY"), actual.EntityType)
+	assert.Equal(t, "APPLICATION", actual.Type)
+	assert.Equal(t, entityGUID, actual.GUID)
+	assert.Equal(t, "Dummy App", actual.Name)
+	assert.Equal(t, "https://one.newrelic.com/redirect/entity/"+entityGUID, actual.Permalink)
+	assert.Equal(t, true, actual.Reporting)
+	assert.Equal(t, "APPLICATION", actual.Type)
+}
+
+// Looking at an APM Application, and the result set here.
+func TestIntegrationGetEntity_ApmEntityOutline(t *testing.T) {
+	t.Parallel()
+
 	client := newIntegrationTestClient(t)
 
 	actual, err := client.GetEntity("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
 
 	require.NoError(t, err)
 	require.NotNil(t, actual)
+
+	// These are a bit fragile, if the above GUID ever changes...
+	// from ApmApplicationEntity / ApmApplicationEntityOutline
+	assert.Equal(t, 215037795, *actual.ApplicationID)
+	assert.Equal(t, EntityAlertSeverityType("NOT_ALERTING"), *actual.AlertSeverity)
+	assert.Equal(t, "nodejs", *actual.Language)
+	assert.NotNil(t, actual.RunningAgentVersions)
+	assert.NotNil(t, actual.RunningAgentVersions.MinVersion)
+	assert.NotNil(t, actual.RunningAgentVersions.MaxVersion)
+	assert.NotNil(t, actual.Settings)
+	assert.NotNil(t, actual.Settings.ApdexTarget)
+	assert.NotNil(t, actual.Settings.ServerSideConfig)
+
 }
 
 // nolint

--- a/pkg/entities/entity_integration_test.go
+++ b/pkg/entities/entity_integration_test.go
@@ -76,7 +76,7 @@ func TestIntegrationGetEntity(t *testing.T) {
 	assert.Equal(t, "Dummy App", actual.Name)
 	assert.Equal(t, "https://one.newrelic.com/redirect/entity/"+entityGUID, actual.Permalink)
 	assert.Equal(t, true, actual.Reporting)
-	assert.Equal(t, EntityType("APPLICATION"), actual.Type)
+	assert.Equal(t, Type("APPLICATION"), actual.Type)
 }
 
 // Looking at an APM Application, and the result set here.

--- a/pkg/entities/entity_integration_test.go
+++ b/pkg/entities/entity_integration_test.go
@@ -72,12 +72,11 @@ func TestIntegrationGetEntity(t *testing.T) {
 	assert.Equal(t, 2520528, actual.AccountID)
 	assert.Equal(t, EntityDomainType("APM"), actual.Domain)
 	assert.Equal(t, EntityType("APM_APPLICATION_ENTITY"), actual.EntityType)
-	assert.Equal(t, "APPLICATION", actual.Type)
 	assert.Equal(t, entityGUID, actual.GUID)
 	assert.Equal(t, "Dummy App", actual.Name)
 	assert.Equal(t, "https://one.newrelic.com/redirect/entity/"+entityGUID, actual.Permalink)
 	assert.Equal(t, true, actual.Reporting)
-	assert.Equal(t, "APPLICATION", actual.Type)
+	assert.Equal(t, EntityType("APPLICATION"), actual.Type)
 }
 
 // Looking at an APM Application, and the result set here.


### PR DESCRIPTION
* Change the way we generate the GraphQL queries to be composable, and consistent between fetching (GetEntity/GetEntities, and Entity Search)
* Increase the amount of data Entity returns for `ApmApplicationEntity`.
* Add Integration tests for returning additional fields
* Add Integration tests for base Entity fields
* Add a few more fields for `BrowserApplicationEntity`

This does change the type of `entities.Entity.Type` from `string` to `EntityType` which is a breaking change.