### PR TITLE
fix(workloads): use epoch time for EntitySearchQuery.CreatedAt

### DIFF
--- a/pkg/workloads/workload.go
+++ b/pkg/workloads/workload.go
@@ -1,8 +1,6 @@
 package workloads
 
 import (
-	"time"
-
 	"github.com/newrelic/newrelic-client-go/internal/serialization"
 	"github.com/newrelic/newrelic-client-go/pkg/errors"
 	"github.com/newrelic/newrelic-client-go/pkg/nerdgraph"
@@ -31,7 +29,7 @@ type EntityRef struct {
 
 // EntitySearchQuery represents an entity search used by this workload.
 type EntitySearchQuery struct {
-	CreatedAt time.Time                `json:"createdAt,omitempty"`
+	CreatedAt serialization.EpochTime  `json:"createdAt,omitempty"`
 	CreatedBy UserReference            `json:"createdBy,omitempty"`
 	ID        int                      `json:"id,omitempty"`
 	Name      string                   `json:"name,omitempty"`

--- a/pkg/workloads/workload_integration_test.go
+++ b/pkg/workloads/workload_integration_test.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/newrelic/newrelic-client-go/pkg/config"
 	"github.com/stretchr/testify/require"
+
+	"github.com/newrelic/newrelic-client-go/pkg/config"
 )
 
 var (


### PR DESCRIPTION
This PR updates the underlying type for `EntitySearchQuery.CreatedAt` in response to a recent change to the underlying API.