### PR TITLE
fix(alerts) add custom unmarshaling for ConditionTerm

### DIFF
--- a/pkg/alerts/conditions_test.go
+++ b/pkg/alerts/conditions_test.go
@@ -74,7 +74,7 @@ var (
 					"duration": "10",
 					"operator": "below",
 					"priority": "warning",
-					"threshold": "0.5",
+					"threshold": ".5",
 					"time_function": "all"
 				}
 			]

--- a/pkg/alerts/serialization.go
+++ b/pkg/alerts/serialization.go
@@ -1,0 +1,32 @@
+package alerts
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// UnmarshalJSON is responsible for unmarshaling the ConditionTerm type.
+func (c *ConditionTerm) UnmarshalJSON(data []byte) error {
+	var v map[string]interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	threshold, err := strconv.ParseFloat(v["threshold"].(string), 64)
+	if err != nil {
+		return err
+	}
+
+	duration, err := strconv.ParseInt(v["duration"].(string), 10, 32)
+	if err != nil {
+		return err
+	}
+
+	c.Threshold = threshold
+	c.Duration = int(duration)
+	c.Operator = OperatorType(v["operator"].(string))
+	c.Priority = PriorityType(v["priority"].(string))
+	c.TimeFunction = TimeFunctionType(v["time_function"].(string))
+
+	return nil
+}


### PR DESCRIPTION
This PR introduces custom unmarshaling for the `ConditionTerm` struct to allow for unmarshaling of a broader set of values.