### PR TITLE
fix(workloads): remove nullable struct fields unless necessary

### DIFF
--- a/pkg/workloads/example_basic_test.go
+++ b/pkg/workloads/example_basic_test.go
@@ -44,7 +44,7 @@ func Example_basic() {
 		EntityGUIDs: []string{entityGUID},
 		EntitySearchQueries: []EntitySearchQueryInput{
 			{
-				Name:  &queryName,
+				Name:  queryName,
 				Query: fmt.Sprintf("(accountId IN ('%d')) AND (((name like 'Example application' or id = 'Example application' or domainId = 'Example application')))", accountID),
 			},
 		},
@@ -64,7 +64,7 @@ func Example_basic() {
 	// Update an existing workload.
 	workloadName := "Example updated workload"
 	updateInput := UpdateInput{
-		Name:                &workloadName,
+		Name:                workloadName,
 		EntityGUIDs:         createInput.EntityGUIDs,
 		EntitySearchQueries: createInput.EntitySearchQueries,
 	}

--- a/pkg/workloads/workload.go
+++ b/pkg/workloads/workload.go
@@ -24,7 +24,7 @@ type Workload struct {
 
 // EntityRef represents an entity referenced by this workload.
 type EntityRef struct {
-	GUID *string `json:"guid,omitempty"`
+	GUID string `json:"guid,omitempty"`
 }
 
 // EntitySearchQuery represents an entity search used by this workload.
@@ -39,10 +39,10 @@ type EntitySearchQuery struct {
 
 // UserReference represents a user referenced by this workload's search query.
 type UserReference struct {
-	Email    *string `json:"email,omitempty"`
-	Gravatar *string `json:"gravatar,omitempty"`
-	ID       *int    `json:"id,omitempty"`
-	Name     *string `json:"name,omitempty"`
+	Email    string `json:"email,omitempty"`
+	Gravatar string `json:"gravatar,omitempty"`
+	ID       int    `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
 }
 
 // ScopeAccounts represents the accounts used to scope this workload.
@@ -60,13 +60,13 @@ type CreateInput struct {
 
 // EntitySearchQueryInput represents an entity search query for creating or updating a workload.
 type EntitySearchQueryInput struct {
-	Name  *string `json:"name,omitempty"`
-	Query string  `json:"query,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Query string `json:"query,omitempty"`
 }
 
 // UpdateCollectionEntitySearchQueryInput represents an entity search query for creating or updating a workload.
 type UpdateCollectionEntitySearchQueryInput struct {
-	ID *int `json:"id,omitempty"`
+	ID int `json:"id,omitempty"`
 	EntitySearchQueryInput
 }
 
@@ -77,14 +77,14 @@ type ScopeAccountsInput struct {
 
 // DuplicateInput represents the input object used to identify the workload to be duplicated.
 type DuplicateInput struct {
-	Name *string `json:"name,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // UpdateInput represents the input object used to identify the workload to be updated and its new changes.
 type UpdateInput struct {
 	EntityGUIDs         []string                 `json:"entityGuids,omitempty"`
 	EntitySearchQueries []EntitySearchQueryInput `json:"entitySearchQueries,omitempty"`
-	Name                *string                  `json:"name,omitempty"`
+	Name                string                   `json:"name,omitempty"`
 	ScopeAccountsInput  *ScopeAccountsInput      `json:"scopeAccounts,omitempty"`
 }
 

--- a/pkg/workloads/workload_integration_test.go
+++ b/pkg/workloads/workload_integration_test.go
@@ -25,19 +25,19 @@ var (
 		},
 		EntitySearchQueries: []EntitySearchQueryInput{
 			{
-				Name:  &testQueryName,
+				Name:  testQueryName,
 				Query: testWorkloadQuery,
 			},
 		},
 	}
 	testUpdateInput = UpdateInput{
-		Name: &testUpdatedWorkloadName,
+		Name: testUpdatedWorkloadName,
 		ScopeAccountsInput: &ScopeAccountsInput{
 			AccountIDs: []int{testAccountID},
 		},
 		EntitySearchQueries: []EntitySearchQueryInput{
 			{
-				Name:  &testQueryName,
+				Name:  testQueryName,
 				Query: testWorkloadQuery,
 			},
 		},
@@ -79,7 +79,7 @@ func TestIntegrationWorkload(t *testing.T) {
 
 	// Test: Duplicate
 	duplicateInput := DuplicateInput{
-		Name: &testDuplicateWorkloadName,
+		Name: testDuplicateWorkloadName,
 	}
 	duplicate, err := client.DuplicateWorkload(testAccountID, created.GUID, &duplicateInput)
 


### PR DESCRIPTION
This PR removes the unnecessary use of nullable struct fields for structs that map to NerdGraph types.