### PR TITLE
refactor(workloads): remove deprecated fields

### DIFF
--- a/pkg/workloads/example_basic_test.go
+++ b/pkg/workloads/example_basic_test.go
@@ -37,13 +37,11 @@ func Example_basic() {
 	}
 
 	// Create a new workload.
-	queryName := "Example query"
 	createInput := CreateInput{
 		Name:        "Example workload",
 		EntityGUIDs: []string{entityGUID},
 		EntitySearchQueries: []EntitySearchQueryInput{
 			{
-				Name:  queryName,
 				Query: fmt.Sprintf("(accountId IN ('%d')) AND (((name like 'Example application' or id = 'Example application' or domainId = 'Example application')))", accountID),
 			},
 		},

--- a/pkg/workloads/workload.go
+++ b/pkg/workloads/workload.go
@@ -32,7 +32,6 @@ type EntitySearchQuery struct {
 	CreatedAt serialization.EpochTime  `json:"createdAt,omitempty"`
 	CreatedBy UserReference            `json:"createdBy,omitempty"`
 	ID        int                      `json:"id,omitempty"`
-	Name      string                   `json:"name,omitempty"`
 	Query     string                   `json:"query,omitempty"`
 	UpdatedAt *serialization.EpochTime `json:"updatedAt,omitempty"`
 }
@@ -60,7 +59,6 @@ type CreateInput struct {
 
 // EntitySearchQueryInput represents an entity search query for creating or updating a workload.
 type EntitySearchQueryInput struct {
-	Name  string `json:"name,omitempty"`
 	Query string `json:"query,omitempty"`
 }
 

--- a/pkg/workloads/workload_integration_test.go
+++ b/pkg/workloads/workload_integration_test.go
@@ -24,7 +24,6 @@ var (
 		},
 		EntitySearchQueries: []EntitySearchQueryInput{
 			{
-				Name:  testQueryName,
 				Query: testWorkloadQuery,
 			},
 		},
@@ -36,7 +35,6 @@ var (
 		},
 		EntitySearchQueries: []EntitySearchQueryInput{
 			{
-				Name:  testQueryName,
 				Query: testWorkloadQuery,
 			},
 		},
@@ -61,18 +59,14 @@ func TestIntegrationWorkload(t *testing.T) {
 	require.NotNil(t, workload)
 
 	// Test: List
-	// There is currently a upstream issue with this API.
-	// TODO: re-enable once fixed in the upstream API
-	//
-	// workloads, err := client.ListWorkloads(testAccountID)
-
-	// require.NoError(t, err)
-	// require.Greater(t, len(workloads), 0)
+	workloads, err := client.ListWorkloads(testAccountID)
+	require.NoError(t, err)
+	require.Greater(t, len(workloads), 0)
 
 	// Test: Update
 	// There is currently a timing issue with this test.
 	// TODO: re-enable once fixed in the upstream API
-	//
+
 	// updated, err := client.UpdateWorkload(*created.GUID, &testUpdateInput)
 
 	// require.NoError(t, err)


### PR DESCRIPTION
This PR removes some deprecated fields from the Workloads resource and re-enables a previous failing test.

cc @bthemad