### PR TITLE
fix(alerts): return a NotFound error when policies are not found in NerdGraph

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -243,6 +243,10 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		return nil, nrErrors.NewUnexpectedStatusCode(resp.StatusCode, errorValue.Error())
 	}
 
+	if errorValue.IsNotFound() {
+		return nil, nrErrors.NewNotFound("resource not found")
+	}
+
 	if errorValue.Error() != "" {
 		return nil, errors.New(errorValue.Error())
 	}
@@ -314,7 +318,7 @@ func (c *Client) NewNerdGraphRequest(query string, vars map[string]interface{}, 
 	}
 
 	req.SetAuthStrategy(&NerdGraphAuthorizer{})
-	req.SetErrorValue(&graphQLErrorResponse{})
+	req.SetErrorValue(&GraphQLErrorResponse{})
 
 	return req, nil
 }

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -79,6 +79,10 @@ func (c *CustomErrorResponse) Error() string {
 	return c.CustomError
 }
 
+func (c *CustomErrorResponse) IsNotFound() bool {
+	return false
+}
+
 func TestCustomErrorValue(t *testing.T) {
 	t.Parallel()
 	c := NewTestAPIClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/errors.go
+++ b/internal/http/errors.go
@@ -8,6 +8,7 @@ import (
 // ErrorResponse provides an interface for obtaining
 // a single error message from an error response object.
 type ErrorResponse interface {
+	IsNotFound() bool
 	Error() string
 	New() ErrorResponse
 }
@@ -30,6 +31,10 @@ func (e *DefaultErrorResponse) Error() string {
 	}
 
 	return m
+}
+
+func (e *DefaultErrorResponse) IsNotFound() bool {
+	return false
 }
 
 // New creates a new instance of the DefaultErrorResponse struct.

--- a/internal/http/graphql.go
+++ b/internal/http/graphql.go
@@ -14,16 +14,26 @@ type graphQLResponse struct {
 	Data interface{} `json:"data"`
 }
 
-type graphQLError struct {
-	Message            string         `json:"message"`
-	DownstreamResponse *[]interface{} `json:"downstreamResponse,omitempty"`
+// GraphQLError represents a single error.
+type GraphQLError struct {
+	Message            string                      `json:"message"`
+	DownstreamResponse []GraphQLDownstreamResponse `json:"downstreamResponse,omitempty"`
 }
 
-type graphQLErrorResponse struct {
-	Errors []graphQLError `json:"errors"`
+// GraphQLDownstreamResponse represents an error's downstream response.
+type GraphQLDownstreamResponse struct {
+	Extensions struct {
+		Code string `json:"code,omitempty"`
+	} `json:"extensions,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
-func (r *graphQLErrorResponse) Error() string {
+// GraphQLErrorResponse represents a default error response body.
+type GraphQLErrorResponse struct {
+	Errors []GraphQLError `json:"errors"`
+}
+
+func (r *GraphQLErrorResponse) Error() string {
 	if len(r.Errors) > 0 {
 		messages := []string{}
 		for _, e := range r.Errors {
@@ -38,6 +48,12 @@ func (r *graphQLErrorResponse) Error() string {
 	return ""
 }
 
-func (r *graphQLErrorResponse) New() ErrorResponse {
-	return &graphQLErrorResponse{}
+// IsNotFound determines if the error is due to a missing resource.
+func (r *GraphQLErrorResponse) IsNotFound() bool {
+	return false
+}
+
+// New creates a new instance of GraphQLErrorRepsonse.
+func (r *GraphQLErrorResponse) New() ErrorResponse {
+	return &GraphQLErrorResponse{}
 }

--- a/pkg/infrastructure/infrastructure.go
+++ b/pkg/infrastructure/infrastructure.go
@@ -34,3 +34,7 @@ func (e *ErrorResponse) Error() string {
 func (e *ErrorResponse) New() http.ErrorResponse {
 	return &ErrorResponse{}
 }
+
+func (e *ErrorResponse) IsNotFound() bool {
+	return false
+}

--- a/pkg/synthetics/synthetics.go
+++ b/pkg/synthetics/synthetics.go
@@ -55,6 +55,10 @@ func (e *ErrorResponse) New() http.ErrorResponse {
 	return &ErrorResponse{}
 }
 
+func (e *ErrorResponse) IsNotFound() bool {
+	return false
+}
+
 // New is used to create a new Synthetics client instance.
 func New(config config.Config) Synthetics {
 	client := http.NewClient(config)


### PR DESCRIPTION
This PR returns a NotFound error when a policy can't be located in NerdGraph.