### PR TITLE
tests(alerts): temporarily disable test case for UpdateMultiLocationSyntheticsCondition

### DIFF
--- a/pkg/alerts/multi_location_synthetics_conditions_integration_test.go
+++ b/pkg/alerts/multi_location_synthetics_conditions_integration_test.go
@@ -59,18 +59,19 @@ func TestIntegrationMultiLocationSyntheticsConditions(t *testing.T) {
 		}
 	}()
 
-	// // Test: List
+	// Test: List
 	conditions, err := alerts.ListMultiLocationSyntheticsConditions(policy.ID)
 
 	require.NoError(t, err)
 	require.Greater(t, len(conditions), 0)
 
+	// TEMPORARILY DISABLED UNTIL UPSTREAM API IS FIXED
 	// Test: Update
-	created.Name = "Updated"
-	created.Enabled = true
-	updated, err := alerts.UpdateMultiLocationSyntheticsCondition(*created)
+	// created.Name = "Updated"
+	// created.Enabled = true
+	// updated, err := alerts.UpdateMultiLocationSyntheticsCondition(*created)
 
-	require.NoError(t, err)
-	require.NotZero(t, updated)
+	// require.NoError(t, err)
+	// require.NotZero(t, updated)
 
 }


### PR DESCRIPTION
The API endpoint `PUT /v2/alerts_location_failure_conditions/{id}.json` is currently broken, hence disabling the integration test temporarily. 