### PR TITLE
chore(dashboards): add enum for grid column count

### DIFF
--- a/pkg/dashboards/dashboard_integration_test.go
+++ b/pkg/dashboards/dashboard_integration_test.go
@@ -24,7 +24,7 @@ func TestIntegrationDashboards(t *testing.T) {
 		Title:           "newrelic-client-go-test",
 		Visibility:      VisibilityTypes.Owner,
 		Editable:        EditableTypes.Owner,
-		GridColumnCount: 3,
+		GridColumnCount: GridColumnCountTypes.One,
 	}
 
 	// Test: Create

--- a/pkg/dashboards/dashboards_types.go
+++ b/pkg/dashboards/dashboards_types.go
@@ -4,21 +4,36 @@ import "time"
 
 // Dashboard represents information about a New Relic dashboard.
 type Dashboard struct {
-	ID              int               `json:"id"`
-	Title           string            `json:"title,omitempty"`
-	Icon            DashboardIconType `json:"icon,omitempty"`
-	CreatedAt       time.Time         `json:"created_at,omitempty"`
-	UpdatedAt       time.Time         `json:"updated_at,omitempty"`
-	Visibility      VisibilityType    `json:"visibility,omitempty"`
-	Editable        EditableType      `json:"editable,omitempty"`
-	UIURL           string            `json:"ui_url,omitempty"`
-	APIURL          string            `json:"api_url,omitempty"`
-	OwnerEmail      string            `json:"owner_email,omitempty"`
-	Metadata        DashboardMetadata `json:"metadata"`
-	Filter          DashboardFilter   `json:"filter,omitempty"`
-	Widgets         []DashboardWidget `json:"widgets,omitempty"`
-	GridColumnCount int               `json:"grid_column_count,omitempty"`
+	ID              int                 `json:"id"`
+	Title           string              `json:"title,omitempty"`
+	Icon            DashboardIconType   `json:"icon,omitempty"`
+	CreatedAt       time.Time           `json:"created_at,omitempty"`
+	UpdatedAt       time.Time           `json:"updated_at,omitempty"`
+	Visibility      VisibilityType      `json:"visibility,omitempty"`
+	Editable        EditableType        `json:"editable,omitempty"`
+	UIURL           string              `json:"ui_url,omitempty"`
+	APIURL          string              `json:"api_url,omitempty"`
+	OwnerEmail      string              `json:"owner_email,omitempty"`
+	Metadata        DashboardMetadata   `json:"metadata"`
+	Filter          DashboardFilter     `json:"filter,omitempty"`
+	Widgets         []DashboardWidget   `json:"widgets,omitempty"`
+	GridColumnCount GridColumnCountType `json:"grid_column_count,omitempty"`
 }
+
+// GridColumnCountType represents an option for the dashboard's grid column count.
+// New Relic Insights supports a 3 column grid.
+// New Relic One supports a 12 column grid.
+type GridColumnCountType int
+
+var (
+	GridColumnCountTypes = struct {
+		Insights GridColumnCountType
+		One      GridColumnCountType
+	}{
+		Insights: 3,
+		One:      12,
+	}
+)
 
 // VisibilityType represents an option for the dashboard's visibility field.
 type VisibilityType string


### PR DESCRIPTION
This `GridColumnCountTypes` enum provides better specificity for column support per product/platform