### PR TITLE
chore(build): Cleanup release process to include GH changelog generation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,6 @@ env:
 
 before:
   hooks:
-    - make clean
     - go mod download
 
 build:

--- a/build/document.mk
+++ b/build/document.mk
@@ -7,8 +7,9 @@ GOTOOLS     += golang.org/x/tools/cmd/godoc \
 GODOC       ?= godoc
 GODOC_HTTP  ?= "localhost:6060"
 
-CHANGELOG_CMD  ?= git-chglog
-CHANGELOG_FILE ?= CHANGELOG.md
+CHANGELOG_CMD      ?= git-chglog
+CHANGELOG_FILE     ?= CHANGELOG.md
+RELEASE_NOTES_FILE ?= relnotes.md
 
 docs: tools
 	@echo "=== $(PROJECT_NAME) === [ docs             ]: Starting godoc server..."
@@ -23,5 +24,9 @@ changelog: tools
 	@echo "=== $(PROJECT_NAME) === [ changelog        ]: Generating changelog..."
 	@$(CHANGELOG_CMD) --silent -o $(CHANGELOG_FILE)
 
+release-notes: tools
+	@echo "=== $(PROJECT_NAME) === [ release-notes    ]: Generating release notes..."
+	@mkdir -p $(SRCDIR)/tmp
+	@$(CHANGELOG_CMD) --silent -o $(SRCDIR)/tmp/$(RELEASE_NOTES_FILE) v$(PROJECT_VER_TAGGED)
 
-.PHONY: docs changelog
+.PHONY: docs changelog release-notes

--- a/build/release.mk
+++ b/build/release.mk
@@ -5,17 +5,24 @@ GOTOOLS += github.com/goreleaser/goreleaser
 REL_CMD ?= goreleaser
 DIST_DIR ?= ./dist
 
+
 # Example usage: make release version=0.11.0
-release:
+release: build
 	@echo "=== $(PROJECT_NAME) === [ release          ]: Generating release."
 	$(RELEASE_SCRIPT) $(version)
 
 release-clean:
 	@echo "=== $(PROJECT_NAME) === [ release-clean    ]: distribution files..."
-	@rm -rfv $(DIST_DIR)/*
+	@rm -rfv $(DIST_DIR) $(SRCDIR)/tmp
 
-release-publish: clean tools docker-login
+release-publish: clean tools release-notes
 	@echo "=== $(PROJECT_NAME) === [ release-publish  ]: Publishing release via $(REL_CMD)"
-	$(REL_CMD)
+	$(REL_CMD) --release-notes=$(SRCDIR)/tmp/$(RELEASE_NOTES_FILE)
 
-.PHONY: release release-clean release-publish
+# Local Snapshot
+snapshot: clean tools release-notes
+	@echo "=== $(PROJECT_NAME) === [ snapshot         ]: Creating release via $(REL_CMD)"
+	@echo "=== $(PROJECT_NAME) === [ snapshot         ]:   THIS WILL NOT BE PUBLISHED!"
+	$(REL_CMD) --skip-publish --snapshot --release-notes=$(SRCDIR)/tmp/$(RELEASE_NOTES_FILE)
+
+.PHONY: release release-clean release-publish snapshot


### PR DESCRIPTION
Backport change log for the Releases page from other tooling, and a bit of cleanup to get it all working.