### PR TITLE
fix(alerts): Alerts paging was incorrectly generating URLs

### DIFF
--- a/pkg/alerts/channels.go
+++ b/pkg/alerts/channels.go
@@ -76,11 +76,11 @@ type ChannelConfiguration struct {
 // ListChannels returns all alert channels for a given account.
 func (a *Alerts) ListChannels() ([]*Channel, error) {
 	alertChannels := []*Channel{}
-	nextURL := "/alerts_channels.json"
+	nextURL := a.config.Region().RestURL("/alerts_channels.json")
 
 	for nextURL != "" {
 		response := alertChannelsResponse{}
-		resp, err := a.client.Get(a.config.Region().RestURL(nextURL), nil, &response)
+		resp, err := a.client.Get(nextURL, nil, &response)
 
 		if err != nil {
 			return nil, err

--- a/pkg/alerts/conditions.go
+++ b/pkg/alerts/conditions.go
@@ -208,11 +208,11 @@ func (a *Alerts) ListConditions(policyID int) ([]*Condition, error) {
 		PolicyID: policyID,
 	}
 
-	nextURL := "/alerts_conditions.json"
+	nextURL := a.config.Region().RestURL("/alerts_conditions.json")
 
 	for nextURL != "" {
 		response := alertConditionsResponse{}
-		resp, err := a.client.Get(a.config.Region().RestURL(nextURL), &queryParams, &response)
+		resp, err := a.client.Get(nextURL, &queryParams, &response)
 
 		if err != nil {
 			return nil, err

--- a/pkg/alerts/incidents.go
+++ b/pkg/alerts/incidents.go
@@ -29,11 +29,11 @@ func (a *Alerts) ListIncidents(onlyOpen bool, excludeViolations bool) ([]*Incide
 		ExcludeViolations: excludeViolations,
 	}
 
-	nextURL := "/alerts_incidents.json"
+	nextURL := a.config.Region().RestURL("/alerts_incidents.json")
 
 	for nextURL != "" {
 		incidentsResponse := alertIncidentsResponse{}
-		resp, err := a.client.Get(a.config.Region().RestURL(nextURL), queryParams, &incidentsResponse)
+		resp, err := a.client.Get(nextURL, queryParams, &incidentsResponse)
 
 		if err != nil {
 			return nil, err

--- a/pkg/alerts/multi_location_synthetics_conditions.go
+++ b/pkg/alerts/multi_location_synthetics_conditions.go
@@ -2,6 +2,7 @@ package alerts
 
 import (
 	"fmt"
+	"strconv"
 )
 
 // MultiLocationSyntheticsCondition represents a location-based failure condition.
@@ -35,10 +36,10 @@ func (a *Alerts) ListMultiLocationSyntheticsConditions(policyID int) ([]*MultiLo
 		PolicyID: policyID,
 	}
 
-	nextURL := fmt.Sprintf("/alerts_location_failure_conditions/policies/%d.json", policyID)
+	nextURL := a.config.Region().RestURL("/alerts_location_failure_conditions/policies/", strconv.Itoa(policyID)+".json")
 
 	for nextURL != "" {
-		resp, err := a.client.Get(a.config.Region().RestURL(nextURL), &queryParams, &response)
+		resp, err := a.client.Get(nextURL, &queryParams, &response)
 
 		if err != nil {
 			return nil, err

--- a/pkg/alerts/nrql_conditions.go
+++ b/pkg/alerts/nrql_conditions.go
@@ -205,11 +205,11 @@ func (a *Alerts) ListNrqlConditions(policyID int) ([]*NrqlCondition, error) {
 		PolicyID: policyID,
 	}
 
-	nextURL := "/alerts_nrql_conditions.json"
+	nextURL := a.config.Region().RestURL("/alerts_nrql_conditions.json")
 
 	for nextURL != "" {
 		response := nrqlConditionsResponse{}
-		resp, err := a.client.Get(a.config.Region().RestURL(nextURL), &queryParams, &response)
+		resp, err := a.client.Get(nextURL, &queryParams, &response)
 
 		if err != nil {
 			return nil, err

--- a/pkg/alerts/plugins_conditions.go
+++ b/pkg/alerts/plugins_conditions.go
@@ -33,11 +33,11 @@ func (a *Alerts) ListPluginsConditions(policyID int) ([]*PluginsCondition, error
 		PolicyID: policyID,
 	}
 
-	nextURL := "/alerts_plugins_conditions.json"
+	nextURL := a.config.Region().RestURL("/alerts_plugins_conditions.json")
 
 	for nextURL != "" {
 		response := pluginsConditionsResponse{}
-		resp, err := a.client.Get(a.config.Region().RestURL(nextURL), &queryParams, &response)
+		resp, err := a.client.Get(nextURL, &queryParams, &response)
 
 		if err != nil {
 			return nil, err

--- a/pkg/alerts/synthetics_conditions.go
+++ b/pkg/alerts/synthetics_conditions.go
@@ -18,14 +18,14 @@ type SyntheticsCondition struct {
 // ListSyntheticsConditions returns a list of Synthetics alert conditions for a given policy.
 func (a *Alerts) ListSyntheticsConditions(policyID int) ([]*SyntheticsCondition, error) {
 	conditions := []*SyntheticsCondition{}
-	nextURL := "/alerts_synthetics_conditions.json"
+	nextURL := a.config.Region().RestURL("/alerts_synthetics_conditions.json")
 	queryParams := listSyntheticsConditionsParams{
 		PolicyID: policyID,
 	}
 
 	for nextURL != "" {
 		response := syntheticsConditionsResponse{}
-		resp, err := a.client.Get(a.config.Region().RestURL(nextURL), &queryParams, &response)
+		resp, err := a.client.Get(nextURL, &queryParams, &response)
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Paging for many, but not all, of the alert data fetches were broken with region update in 0.20.0.

Linked issues:
* https://github.com/terraform-providers/terraform-provider-newrelic/issues/544
* https://github.com/terraform-providers/terraform-provider-newrelic/issues/545
* https://github.com/terraform-providers/terraform-provider-newrelic/issues/547
