### PR TITLE
fix(workloads): fix query type for entity guid

### DIFF
--- a/pkg/workloads/workload.go
+++ b/pkg/workloads/workload.go
@@ -220,7 +220,7 @@ const (
 			updatedAt
 `
 
-	getWorkloadQuery = `query($guid: EntityGuid, $accountId: Int!) { actor { account(id: $accountId) { workload { collection(guid: $guid) {` +
+	getWorkloadQuery = `query($guid: EntityGuid!, $accountId: Int!) { actor { account(id: $accountId) { workload { collection(guid: $guid) {` +
 		graphqlWorkloadStructFields +
 		` } } } } }`
 


### PR DESCRIPTION
This PR fixes a broken workloads query, probably introduced due to upstream API validation changes.