### PR TITLE
fix(alerts): allow blank runbook URL to be sent

### DIFF
--- a/pkg/alerts/conditions.go
+++ b/pkg/alerts/conditions.go
@@ -178,7 +178,7 @@ type Condition struct {
 	Enabled             bool                 `json:"enabled"`
 	Entities            []string             `json:"entities,omitempty"`
 	Metric              MetricType           `json:"metric,omitempty"`
-	RunbookURL          string               `json:"runbook_url,omitempty"`
+	RunbookURL          string               `json:"runbook_url"`
 	Terms               []ConditionTerm      `json:"terms,omitempty"`
 	UserDefined         ConditionUserDefined `json:"user_defined,omitempty"`
 	Scope               string               `json:"condition_scope,omitempty"`


### PR DESCRIPTION
Related to terraform-providers/terraform-provider-newrelic#563.

This PR allows a blank Runbook URL to be sent.  The underlying API does not remove a runbook URL on update if the passed payload omits the `runbook_url` attribute, so we will need to explicitly pass a blank string.