### PR TITLE
fix(apm): adjust MetricDataParams json tags to support lists in query params

### DIFF
--- a/pkg/apm/applications_integration_test.go
+++ b/pkg/apm/applications_integration_test.go
@@ -30,8 +30,12 @@ func TestIntegrationApplications(t *testing.T) {
 	n, err := client.GetMetricNames(a[0].ID, MetricNamesParams{})
 	require.NoError(t, err)
 
-	_, err = client.GetMetricData(a[0].ID, MetricDataParams{Names: []string{n[0].Name}})
+	metricData, err := client.GetMetricData(a[0].ID, MetricDataParams{
+		Names: []string{n[0].Name, n[1].Name, n[2].Name},
+	})
+
 	require.NoError(t, err)
+	require.Equal(t, 3, len(metricData))
 }
 
 func TestIntegrationDeleteApplication(t *testing.T) {

--- a/pkg/apm/applications_metrics.go
+++ b/pkg/apm/applications_metrics.go
@@ -42,12 +42,12 @@ type MetricTimeslice struct {
 
 //MetricTimesliceValues is the collection of metric values for a single time slice.
 type MetricTimesliceValues struct {
-	AsPercentage           float64 `json:"as_percentage"`
-	AverageTime            float64 `json:"average_time"`
-	CallsPerMinute         float64 `json:"calls_per_minute"`
-	MaxValue               float64 `json:"max_value"`
-	TotalCallTimePerMinute float64 `json:"total_call_time_per_minute"`
-	Utilization            float64 `json:"utilization"`
+	AsPercentage           float64 `json:"as_percentage,omitempty"`
+	AverageTime            float64 `json:"average_time,omitempty"`
+	CallsPerMinute         float64 `json:"calls_per_minute,omitempty"`
+	MaxValue               float64 `json:"max_value,omitempty"`
+	TotalCallTimePerMinute float64 `json:"total_call_time_per_minute,omitempty"`
+	Utilization            float64 `json:"utilization,omitempty"`
 }
 
 // GetMetricNames is used to retrieve a list of known metrics and their value names for the given resource.

--- a/pkg/apm/applications_metrics.go
+++ b/pkg/apm/applications_metrics.go
@@ -12,8 +12,8 @@ type MetricNamesParams struct {
 
 // MetricDataParams are the request parameters for the /metrics/data.json endpoint.
 type MetricDataParams struct {
-	Names     []string   `url:"names,omitempty"`
-	Values    []string   `url:"values,omitempty"`
+	Names     []string   `url:"names[],omitempty"`
+	Values    []string   `url:"values[],omitempty"`
 	From      *time.Time `url:"from,omitempty"`
 	To        *time.Time `url:"to,omitempty"`
 	Period    int        `url:"period,omitempty"`


### PR DESCRIPTION
Resolves: #292

**TL;DR**

Current params struct for MetricsDataParams

```go
type MetricDataParams struct {
	Names     []string   `url:"names,omitempty"`
	Values    []string   `url:"values,omitempty"`
  // ...
}
```

Should be the following: (notice the `[]` addition to the json tags)

```go
type MetricDataParams struct {
	Names     []string   `url:"names[],omitempty"`
	Values    []string   `url:"values[],omitempty"`
  // ...
}
```