### PR TITLE
Use default User-Agent header if none provided

### DIFF
--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -71,7 +71,12 @@ func (c *Client) NewRequest(method string, url string, params interface{}, reqBo
 
 	req.SetHeader(defaultNewRelicRequestingServiceHeader, cfg.ServiceName)
 	req.SetHeader("Content-Type", "application/json")
-	req.SetHeader("User-Agent", cfg.UserAgent)
+
+	if cfg.UserAgent != "" {
+		req.SetHeader("User-Agent", cfg.UserAgent)
+	} else {
+		req.SetHeader("User-Agent", defaultUserAgent)
+	}
 
 	return req, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,7 +59,6 @@ func New() Config {
 
 	return Config{
 		region:      reg,
-		UserAgent:   "newrelic/newrelic-client-go",
 		LogLevel:    "info",
 		Compression: Compression.None,
 	}


### PR DESCRIPTION
This addresses the issue of incomplete user-agent headers by default:

* Calls to `config.New()` set the user-agent incorrectly (does not include full user-agent info like version)
* Add check to NewRequest to ensure that either the user-agent specified of the default is added to all requests.