### PR TITLE
[fix]: EpochTime Serialization with Milliseconds

### DIFF
--- a/internal/serialization/epoch_time_test.go
+++ b/internal/serialization/epoch_time_test.go
@@ -1,0 +1,84 @@
+// +build unit
+
+package serialization
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testEpochValues = []struct {
+	Bytes  []byte
+	Epoch  EpochTime
+	String string
+	Err    error
+	Msg    string
+}{
+	{
+		Bytes:  []byte(`1587654321`), // Seconds
+		Epoch:  EpochTime(time.Unix(1587654321, 0)),
+		String: "2020-04-23 15:05:21 +0000 UTC",
+		Err:    nil,
+		Msg:    "Epoch: Seconds",
+	},
+	{
+		Bytes:  []byte(`1587654321012`), // Milliseconds
+		Epoch:  EpochTime(time.Unix(1587654321, 12*int64(time.Millisecond))),
+		String: "2020-04-23 15:05:21.012 +0000 UTC",
+		Err:    nil,
+		Msg:    "Epoch: Millieconds",
+	},
+	{
+		Bytes:  []byte(`1587654321012345678`), // Nanoseconds
+		Epoch:  EpochTime(time.Unix(1587654321, 12345000)),
+		String: "2020-04-23 15:05:21.000012345 +0000 UTC",
+		Err:    nil,
+		Msg:    "Epoch: Nanoseconds",
+	},
+	{
+		Bytes:  []byte(`asdf`), // Invalid
+		Epoch:  EpochTime(time.Unix(0, 0)),
+		String: "0001-01-01 00:00:00 +0000 UTC",
+		Err:    &strconv.NumError{},
+		Msg:    "Epoch: invalid",
+	},
+}
+
+func TestEpochUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range testEpochValues {
+		var et EpochTime
+		err := et.UnmarshalJSON(v.Bytes)
+
+		if v.Err != nil {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, v.String, time.Time(et).UTC().String(), v.Msg) // ensure to use UTC so tests work everywhere
+	}
+}
+
+func TestEpochMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range testEpochValues {
+		// MarhsalJSON never returns an error, so skip error tests
+		if v.Err == nil {
+			res, err := v.Epoch.MarshalJSON()
+
+			assert.NoError(t, err)
+
+			// Only check for millisecond resolition
+			if len(v.Bytes) > 13 {
+				assert.Equal(t, v.Bytes[0:13], []byte(res), v.Msg)
+			} else {
+				assert.Equal(t, v.Bytes, []byte(res), v.Msg)
+			}
+		}
+	}
+}

--- a/pkg/alerts/infrastructure_conditions_test.go
+++ b/pkg/alerts/infrastructure_conditions_test.go
@@ -6,17 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/newrelic/newrelic-client-go/internal/serialization"
 )
 
 var (
-	testInfrastructureConditionPolicyId  = 111111
-	testInfrastructureConditionTimestamp = serialization.EpochTime(time.Unix(1490996713872, 0))
-	testInfrastructureCriticalThreshold  = InfrastructureConditionThreshold{
+	testInfrastructureConditionPolicyId = 111111
+	testInfrastructureCriticalThreshold = InfrastructureConditionThreshold{
 		Duration: 6,
 		Function: "all",
 		Value:    12.3,
@@ -29,7 +25,7 @@ var (
 
 	testInfrastructureCondition = InfrastructureCondition{
 		Comparison:   "equal",
-		CreatedAt:    &testInfrastructureConditionTimestamp,
+		CreatedAt:    &testTimestamp,
 		Critical:     &testInfrastructureCriticalThreshold,
 		Enabled:      true,
 		ID:           13890,
@@ -37,7 +33,7 @@ var (
 		PolicyID:     testInfrastructureConditionPolicyId,
 		ProcessWhere: "(commandName = 'java')",
 		Type:         "infra_process_running",
-		UpdatedAt:    &testInfrastructureConditionTimestamp,
+		UpdatedAt:    &testTimestamp,
 		Warning:      &testInfrastructureWarningThreshold,
 		Where:        "(hostname LIKE '%cassandra%')",
 	}
@@ -48,9 +44,9 @@ var (
 			"enabled":true,
 			"where_clause":"(hostname LIKE '%cassandra%')",
 			"id":13890,
-			"created_at_epoch_millis":1490996713872,
-			"updated_at_epoch_millis":1490996713872,
-			"policy_id":111111,
+			"created_at_epoch_millis":` + testTimestampStringMs + `,
+			"updated_at_epoch_millis":` + testTimestampStringMs + `,
+			"policy_id": 111111,
 			"comparison":"equal",
 			"critical_threshold":{
 				"value":12.3,

--- a/pkg/alerts/policies_test.go
+++ b/pkg/alerts/policies_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	testTimestamp = serialization.EpochTime(time.Unix(1575438237690, 0))
+	testTimestampStringMs = "1575438237690"
+	testTimestamp         = serialization.EpochTime(time.Unix(0, 1575438237690*int64(time.Millisecond)))
 
 	testPoliciesResponseJSON = `{
 		"policies": [
@@ -21,15 +22,15 @@ var (
 				"id": 579506,
 				"incident_preference": "PER_POLICY",
 				"name": "test-alert-policy-1",
-				"created_at": 1575438237690,
-				"updated_at": 1575438237690
+				"created_at": ` + testTimestampStringMs + `,
+				"updated_at": ` + testTimestampStringMs + `
 			},
 			{
 				"id": 579509,
 				"incident_preference": "PER_POLICY",
 				"name": "test-alert-policy-2",
-				"created_at": 1575438237690,
-				"updated_at": 1575438237690
+				"created_at": ` + testTimestampStringMs + `,
+				"updated_at": ` + testTimestampStringMs + `
 			}
 		]
 	}`
@@ -39,8 +40,8 @@ var (
 			"id": 579506,
 			"incident_preference": "PER_POLICY",
 			"name": "test-alert-policy-1",
-			"created_at": 1575438237690,
-			"updated_at": 1575438237690
+			"created_at": ` + testTimestampStringMs + `,
+			"updated_at": ` + testTimestampStringMs + `
 		}
 	}`
 
@@ -49,8 +50,8 @@ var (
 			"id": 579506,
 			"incident_preference": "PER_CONDITION",
 			"name": "test-alert-policy-updated",
-			"created_at": 1575438237690,
-			"updated_at": 1575438237690
+			"created_at": ` + testTimestampStringMs + `,
+			"updated_at": ` + testTimestampStringMs + `
 		}
 	}`
 )


### PR DESCRIPTION
We currently do not correctly handle unmarshalling of Unix timestamps that have millisecond resolution, and instead count them as additional seconds projecting the timestamp out 50k years into the future.

Resolves #328 