### PR TITLE
feat(alerts): add DeleteNrqlConditionMutation as a proxy to DeleteConditionMutation

### DIFF
--- a/pkg/alerts/nrql_conditions.go
+++ b/pkg/alerts/nrql_conditions.go
@@ -467,6 +467,18 @@ func (a *Alerts) UpdateNrqlConditionOutlierMutation(
 	return &resp.AlertsNrqlConditionOutlierUpdate, nil
 }
 
+func (a *Alerts) DeleteNrqlConditionMutation(
+	accountID int,
+	conditionID string,
+) (string, error) {
+	result, err := a.DeleteConditionMutation(accountID, conditionID)
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
+}
+
 type listNrqlConditionsParams struct {
 	PolicyID int `url:"policy_id,omitempty"`
 }


### PR DESCRIPTION
This PR adds a proxy method for deleting NRQL alert conditions via NerdGraph, which also facilitates resource API consistency. 