### PR TITLE
fix(serialization): set location to UTC, fix nanosecond handling

### DIFF
--- a/internal/serialization/epoch_time.go
+++ b/internal/serialization/epoch_time.go
@@ -12,7 +12,7 @@ type EpochTime time.Time
 
 // MarshalJSON is responsible for marshaling the EpochTime type.
 func (e EpochTime) MarshalJSON() ([]byte, error) {
-	ret := strconv.FormatInt(time.Time(e).Unix(), 10)
+	ret := strconv.FormatInt(time.Time(e).UTC().Unix(), 10)
 	milli := int64(time.Time(e).Nanosecond()) / int64(time.Millisecond)
 
 	// Include milliseconds if there are some

--- a/internal/serialization/epoch_time.go
+++ b/internal/serialization/epoch_time.go
@@ -57,7 +57,7 @@ func (e *EpochTime) UnmarshalJSON(s []byte) error {
 	}
 
 	// Convert and self store
-	*(*time.Time)(e) = time.Unix(sec, nano)
+	*(*time.Time)(e) = time.Unix(sec, nano).UTC()
 
 	return nil
 }
@@ -65,4 +65,9 @@ func (e *EpochTime) UnmarshalJSON(s []byte) error {
 // Equal provides a comparator for the EpochTime type.
 func (e EpochTime) Equal(u EpochTime) bool {
 	return time.Time(e).Equal(time.Time(u))
+}
+
+// String returns the time formatted using the format string
+func (e EpochTime) String() string {
+	return time.Time(e).String()
 }

--- a/internal/serialization/epoch_time_test.go
+++ b/internal/serialization/epoch_time_test.go
@@ -19,28 +19,28 @@ var testEpochValues = []struct {
 }{
 	{
 		Bytes:  []byte(`1587654321`), // Seconds
-		Epoch:  EpochTime(time.Unix(1587654321, 0)),
+		Epoch:  EpochTime(time.Unix(1587654321, 0).UTC()),
 		String: "2020-04-23 15:05:21 +0000 UTC",
 		Err:    nil,
 		Msg:    "Epoch: Seconds",
 	},
 	{
 		Bytes:  []byte(`1587654321012`), // Milliseconds
-		Epoch:  EpochTime(time.Unix(1587654321, 12*int64(time.Millisecond))),
+		Epoch:  EpochTime(time.Unix(1587654321, 12*int64(time.Millisecond)).UTC()),
 		String: "2020-04-23 15:05:21.012 +0000 UTC",
 		Err:    nil,
 		Msg:    "Epoch: Millieconds",
 	},
 	{
 		Bytes:  []byte(`1587654321012345678`), // Nanoseconds
-		Epoch:  EpochTime(time.Unix(1587654321, 12345000)),
+		Epoch:  EpochTime(time.Unix(1587654321, 12345).UTC()),
 		String: "2020-04-23 15:05:21.000012345 +0000 UTC",
 		Err:    nil,
 		Msg:    "Epoch: Nanoseconds",
 	},
 	{
 		Bytes:  []byte(`asdf`), // Invalid
-		Epoch:  EpochTime(time.Unix(0, 0)),
+		Epoch:  EpochTime{},
 		String: "0001-01-01 00:00:00 +0000 UTC",
 		Err:    &strconv.NumError{},
 		Msg:    "Epoch: invalid",
@@ -59,7 +59,7 @@ func TestEpochUnmarshal(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 		}
-		assert.Equal(t, v.String, time.Time(et).UTC().String(), v.Msg) // ensure to use UTC so tests work everywhere
+		assert.Equal(t, v.Epoch, et, v.Msg)
 	}
 }
 
@@ -67,18 +67,25 @@ func TestEpochMarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	for _, v := range testEpochValues {
-		// MarhsalJSON never returns an error, so skip error tests
-		if v.Err == nil {
-			res, err := v.Epoch.MarshalJSON()
+		var et EpochTime
+		err := et.UnmarshalJSON(v.Bytes)
 
+		if v.Err != nil {
+			assert.Error(t, err)
+		} else {
 			assert.NoError(t, err)
+		}
+		assert.Equal(t, v.Epoch, et, v.Msg)
+	}
+}
 
-			// Only check for millisecond resolition
-			if len(v.Bytes) > 13 {
-				assert.Equal(t, v.Bytes[0:13], []byte(res), v.Msg)
-			} else {
-				assert.Equal(t, v.Bytes, []byte(res), v.Msg)
-			}
+func TestEpochString(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range testEpochValues {
+		if v.Err == nil {
+			res := v.Epoch.String()
+			assert.Equal(t, v.String, res, v.Msg)
 		}
 	}
 }

--- a/pkg/alerts/policies_test.go
+++ b/pkg/alerts/policies_test.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	testTimestampStringMs = "1575438237690"
-	testTimestamp         = serialization.EpochTime(time.Unix(0, 1575438237690*int64(time.Millisecond)))
+	testTimestamp         = serialization.EpochTime(time.Unix(0, 1575438237690*int64(time.Millisecond)).UTC())
 
 	testPoliciesResponseJSON = `{
 		"policies": [

--- a/pkg/nrdb/types_func.go
+++ b/pkg/nrdb/types_func.go
@@ -18,6 +18,11 @@ func (t *EpochSeconds) UnmarshalJSON(s []byte) error {
 	return (*serialization.EpochTime)(t).UnmarshalJSON(s)
 }
 
+// String returns the time formatted using the format string
+func (t EpochSeconds) String() string {
+	return serialization.EpochTime(t).String()
+}
+
 // MarshalJSON wrapper for EpochMilliseconds
 func (t EpochMilliseconds) MarshalJSON() ([]byte, error) {
 	return serialization.EpochTime(t).MarshalJSON()
@@ -26,4 +31,9 @@ func (t EpochMilliseconds) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON wrapper for EpochMilliseconds
 func (t *EpochMilliseconds) UnmarshalJSON(s []byte) error {
 	return (*serialization.EpochTime)(t).UnmarshalJSON(s)
+}
+
+// String returns the time formatted using the format string
+func (t EpochMilliseconds) String() string {
+	return serialization.EpochTime(t).String()
 }


### PR DESCRIPTION
The current serialization.EpochTime does not set the location to anything, making testing difficult and making assumptions on the time zone.

* On (un)marshalJSON, set timezone to UTC
* Fix unmarshal of Nanosecond resolution times (found while adding tests for String())
* Add String() to print out the time in a human readable format

* Add String() to nrdb.EpochSeconds and nrdb.EpochMilliseconds (lower level type is serialization.EpochTime)