### PR TITLE
chore(changelog): Update CHANGELOG for v0.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="v0.30.2"></a>
+## [v0.30.2] - 2020-06-15
+### Bug Fixes
+- **nrdb:** Add String() to Epoch* types
+- **serialization:** set tz UTC on MarshalJSON
+- **serialization:** Fix nanosecond handling, set tz UTC, add EpochTime.String()
+
 <a name="v0.30.1"></a>
 ## [v0.30.1] - 2020-06-12
 ### Bug Fixes
@@ -604,7 +611,8 @@
 - extract paging implementation
 - rename packages for clarity, promote Config to the public package
 
-[Unreleased]: https://github.com/newrelic/newrelic-client-go/compare/v0.30.1...HEAD
+[Unreleased]: https://github.com/newrelic/newrelic-client-go/compare/v0.30.2...HEAD
+[v0.30.2]: https://github.com/newrelic/newrelic-client-go/compare/v0.30.1...v0.30.2
 [v0.30.1]: https://github.com/newrelic/newrelic-client-go/compare/v0.30.0...v0.30.1
 [v0.30.0]: https://github.com/newrelic/newrelic-client-go/compare/v0.29.1...v0.30.0
 [v0.29.1]: https://github.com/newrelic/newrelic-client-go/compare/v0.29.0...v0.29.1

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version of this library
-const Version string = "0.30.1"
+const Version string = "0.30.2"


### PR DESCRIPTION
## [v0.30.2] - 2020-06-15
### Bug Fixes
- **nrdb:** Add String() to Epoch* types
- **serialization:** set tz UTC on MarshalJSON
- **serialization:** Fix nanosecond handling, set tz UTC, add EpochTime.String()