### PR TITLE
fix(nrql_conditions): better zero-value marshalling for threshold

### DIFF
--- a/pkg/alerts/nrql_conditions.go
+++ b/pkg/alerts/nrql_conditions.go
@@ -122,7 +122,7 @@ var (
 type NrqlConditionTerm struct {
 	Operator             AlertsNrqlConditionTermsOperator `json:"operator,omitempty"`
 	Priority             NrqlConditionPriority            `json:"priority,omitempty"`
-	Threshold            float64                          `json:"threshold"`
+	Threshold            *float64                         `json:"threshold"`
 	ThresholdDuration    int                              `json:"thresholdDuration,omitempty"`
 	ThresholdOccurrences ThresholdOccurrence              `json:"thresholdOccurrences,omitempty"`
 }

--- a/pkg/synthetics/monitor_labels_integration_test.go
+++ b/pkg/synthetics/monitor_labels_integration_test.go
@@ -4,10 +4,8 @@ package synthetics
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	mock "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
@@ -40,23 +38,8 @@ func TestIntegrationGetMonitorLabels(t *testing.T) {
 	monitor, err := synthetics.CreateMonitor(testIntegrationLabeledMonitor)
 	require.NoError(t, err)
 
-	labels, err := synthetics.GetMonitorLabels(monitor.ID)
-	require.NoError(t, err)
-	originalCount := len(labels)
-
-	// Test: Add
-	err = synthetics.AddMonitorLabel(monitor.ID, "testing", rand)
-	require.NoError(t, err)
-
 	// Test: Get
-	labels, err = synthetics.GetMonitorLabels(monitor.ID)
-	require.NoError(t, err)
-	assert.Equal(t, originalCount+1, len(labels))
-	assert.Equal(t, "Testing", (*labels[0]).Type)
-	assert.Equal(t, strings.Title(rand), (*labels[0]).Value)
-
-	// Test: Delete
-	err = synthetics.DeleteMonitorLabel(monitor.ID, "testing", rand)
+	_, err = synthetics.GetMonitorLabels(monitor.ID)
 	require.NoError(t, err)
 
 	// Deferred teardown


### PR DESCRIPTION
Resolves: #385

---
This PR also removes some extraneous test cases that are no longer relevant for monitor labels. Integration tests were failing for `TestIntegrationGetMonitorLabels` due to the following error. Tags are the future-facing resource. Labels are being removed and considered legacy.

> Error 403 Tag migration has already occurred for this account. Adding and removing labels is not allowed.