### PR TITLE
fix(alerts): always send infra condition description even if its an empty string

### DIFF
--- a/pkg/alerts/infrastructure_conditions.go
+++ b/pkg/alerts/infrastructure_conditions.go
@@ -25,7 +25,7 @@ type InfrastructureCondition struct {
 	ViolationCloseTimer *int                              `json:"violation_close_timer,omitempty"`
 	Warning             *InfrastructureConditionThreshold `json:"warning_threshold,omitempty"`
 	Where               string                            `json:"where_clause,omitempty"`
-	Description         string                            `json:"description,omitempty"`
+	Description         string                            `json:"description"`
 }
 
 // InfrastructureConditionThreshold represents an New Relic Infrastructure alert condition threshold.

--- a/pkg/alerts/infrastructure_conditions_integration_test.go
+++ b/pkg/alerts/infrastructure_conditions_integration_test.go
@@ -75,10 +75,12 @@ func TestIntegrationListInfrastructureConditions(t *testing.T) {
 
 	// Test: Update
 	created.Name = "Updated"
+	created.Description = ""
 	updated, err := alerts.UpdateInfrastructureCondition(*created)
 
 	require.NoError(t, err)
 	require.NotZero(t, updated)
+	require.Equal(t, "", updated.Description)
 
 	// Test: Delete
 	err = alerts.DeleteInfrastructureCondition(created.ID)


### PR DESCRIPTION
The infra API needs description explicitly set in the JSON to an empty string for updating/deleting it.