### PR TITLE
feat(graphql): capture validation error output from API response

### DIFF
--- a/internal/http/graphql.go
+++ b/internal/http/graphql.go
@@ -23,7 +23,11 @@ type GraphQLError struct {
 // GraphQLDownstreamResponse represents an error's downstream response.
 type GraphQLDownstreamResponse struct {
 	Extensions struct {
-		Code string `json:"code,omitempty"`
+		Code             string `json:"code,omitempty"`
+		ValidationErrors []struct {
+			Name   string `json:"name,omitempty"`
+			Reason string `json:"reason,omitempty"`
+		} `json:"validationErrors,omitempty"`
 	} `json:"extensions,omitempty"`
 	Message string `json:"message,omitempty"`
 }


### PR DESCRIPTION
Surface Nerdgraph validation errors in the graphQL error messages.  This will change error messages like this:

```
Error: A downstream error occurred., [{"extensions":{"code":"BAD_USER_INPUT"},"message":"Validation Error"}]
```

to messages like this:

```
Error: A downstream error occurred., [{"extensions":{"code":"BAD_USER_INPUT","validationErrors":[{"name":"name","reason":"length must be between 0 and 64"}]},"message":"Validation Error"}]
```
