### PR TITLE
Allow just an insert key for the newrelic package

### DIFF
--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -59,8 +59,8 @@ func New(opts ...ConfigOption) (*NewRelic, error) {
 		}
 	}
 
-	if config.PersonalAPIKey == "" && config.AdminAPIKey == "" {
-		return nil, errors.New("use of ConfigPersonalAPIKey and/or ConfigAdminAPIKey is required")
+	if config.PersonalAPIKey == "" && config.AdminAPIKey == "" && config.InsightsInsertKey == "" {
+		return nil, errors.New("must use at least one of: ConfigPersonalAPIKey, ConfigAdminAPIKey, ConfigInsightsInsertKey")
 	}
 
 	nr := &NewRelic{

--- a/newrelic/newrelic_test.go
+++ b/newrelic/newrelic_test.go
@@ -33,6 +33,27 @@ func TestNew_basic(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNew_keys(t *testing.T) {
+	t.Parallel()
+
+	// Empty
+	nr, err := New()
+	assert.Error(t, err)
+	assert.Nil(t, nr)
+
+	nrP, err := New(ConfigPersonalAPIKey(testAPIkey))
+	assert.NoError(t, err)
+	assert.NotNil(t, nrP)
+
+	nrA, err := New(ConfigAdminAPIKey(testAPIkey))
+	assert.NoError(t, err)
+	assert.NotNil(t, nrA)
+
+	nrE, err := New(ConfigInsightsInsertKey(testAPIkey))
+	assert.NoError(t, err)
+	assert.NotNil(t, nrE)
+}
+
 func TestNew_configOptionError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
We currently require either a Personal or Admin API key, each unlocking a specific set of actions.  This enables a pure Insert mode (just the Insights Insert Key required), so the `newrelic.Events.BatchMode` can be leveraged without having to build-out the sub-package itself.