### PR TITLE
Implement new endpoints for managing license keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ schema.json
 
 .vscode/
 .DS_Store
+.idea

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -2,6 +2,7 @@ package newrelic
 
 import (
 	"errors"
+	"github.com/newrelic/newrelic-client-go/pkg/apiaccesskeys"
 	"net/http"
 	"time"
 
@@ -29,8 +30,9 @@ import (
 // NewRelic is a collection of New Relic APIs.
 type NewRelic struct {
 	Accounts        accounts.Accounts
-	APM             apm.APM
 	Alerts          alerts.Alerts
+	APIAccessKeys   apiaccesskeys.APIAccessKeys
+	APM             apm.APM
 	Dashboards      dashboards.Dashboards
 	Edge            edge.Edge
 	Entities        entities.Entities
@@ -67,8 +69,9 @@ func New(opts ...ConfigOption) (*NewRelic, error) {
 		config: config,
 
 		Accounts:        accounts.New(config),
-		APM:             apm.New(config),
 		Alerts:          alerts.New(config),
+		APIAccessKeys:   apiaccesskeys.New(config),
+		APM:             apm.New(config),
 		Dashboards:      dashboards.New(config),
 		Edge:            edge.New(config),
 		Entities:        entities.New(config),

--- a/pkg/apiaccesskeys/apiaccesskey.go
+++ b/pkg/apiaccesskeys/apiaccesskey.go
@@ -1,0 +1,234 @@
+package apiaccesskeys
+
+import (
+	"errors"
+	"fmt"
+	"github.com/newrelic/newrelic-client-go/internal/http"
+)
+
+// APIAccessKey represents a New Relic API access ingest or user key.
+type APIAccessKey struct {
+	ID         string `json:"id,omitempty"`
+	Key        string `json:"key,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Notes      string `json:"notes,omitempty"`
+	Type       string `json:"type,omitempty"`
+	AccountID  int    `json:"accountId,omitempty"`
+	IngestType string `json:"ingestType,omitempty"`
+	UserID     string `json:"userId,omitempty"`
+}
+
+// apiAccessKeyCreateResponse represents the JSON response returned from creating key(s).
+type apiAccessKeyCreateResponse struct {
+	APIAccessCreateKeys struct {
+		CreatedKeys []APIAccessKey                    `json:"createdKeys,omitempty"`
+		Errors      []apiAccessKeyMutationErrResponse `json:"errors,omitempty"`
+	} `json:"apiAccessCreateKeys"`
+}
+
+// apiAccessKeyUpdateResponse represents the JSON response returned from updating key(s).
+type apiAccessKeyUpdateResponse struct {
+	APIAccessUpdateKeys struct {
+		UpdatedKeys []APIAccessKey                    `json:"updatedKeys,omitempty"`
+		Errors      []apiAccessKeyMutationErrResponse `json:"errors,omitempty"`
+	} `json:"apiAccessUpdateKeys"`
+}
+
+// apiAccessKeyGetResponse represents the JSON response returned from getting an access key.
+type apiAccessKeyGetResponse struct {
+	Actor struct {
+		APIAccess struct {
+			Key APIAccessKey `json:"key,omitempty"`
+		} `json:"apiAccess"`
+	} `json:"actor"`
+	http.GraphQLErrorResponse
+}
+
+// apiAccessKeyMutationErrResponse represents the generic error response returned from modifying API access keys.
+type apiAccessKeyMutationErrResponse struct {
+	AccountID       int    `json:"accountId,omitempty"`
+	ID              string `json:"id,omitempty"`
+	IngestErrorType string `json:"ingestErrorType,omitempty"`
+	UserErrorType   string `json:"userErrorType,omitempty"`
+	IngestType      string `json:"ingestType,omitempty"`
+	Message         string `json:"message,omitempty"`
+	Type            string `json:"type,omitempty"`
+}
+
+// apiAccessKeyDeleteResponse represents the JSON response returned from creating key(s).
+type apiAccessKeyDeleteResponse struct {
+	APIAccessDeleteKeys struct {
+		DeletedKey []struct {
+			ID string `json:"id"`
+		} `json:"deletedKeys,omitempty"`
+		Errors []apiAccessKeyMutationErrResponse `json:"errors,omitempty"`
+	} `json:"apiAccessDeleteKeys"`
+}
+
+const (
+	graphqlAPIAccessKeyBaseFields = `
+		id
+		key
+		name
+		notes
+		type
+		... on ApiAccessIngestKey {
+			id
+			name
+			accountId
+			ingestType
+			key
+			notes
+			type
+		}
+		... on ApiAccessUserKey {
+			id
+			name
+			accountId
+			key
+			notes
+			type
+			userId
+		}
+		... on ApiAccessKey {
+			id
+			name
+			key
+			notes
+			type
+		}`
+
+	graphqlAPIAccessCreateKeyFields = `createdKeys {` + graphqlAPIAccessKeyBaseFields + `}`
+
+	graphqlAPIAccessUpdatedKeyFields = `updatedKeys {` + graphqlAPIAccessKeyBaseFields + `}`
+
+	graphqlAPIAccessKeyErrorFields = `errors {
+		  message
+		  type
+		  ... on ApiAccessIngestKeyError {
+			id
+			ingestErrorType: errorType
+			accountId
+			ingestType
+			message
+			type
+		  }
+		  ... on ApiAccessKeyError {
+			message
+			type
+		  }
+		  ... on ApiAccessUserKeyError {
+			id
+			accountId
+			userErrorType: errorType
+			message
+			type
+			userId
+		  }
+		}
+	`
+
+	apiAccessKeyCreateKeys = `mutation($keys: ApiAccessCreateInput!) {
+			apiAccessCreateKeys(keys: $keys) {` + graphqlAPIAccessCreateKeyFields + graphqlAPIAccessKeyErrorFields + `
+		}}`
+
+	apiAccessKeyGetKey = `query($id: ID!, $keyType: ApiAccessKeyType!) {
+		actor {
+			apiAccess {
+				key(id: $id, keyType: $keyType) {` + graphqlAPIAccessKeyBaseFields + `}}}}`
+
+	apiAccessKeyUpdateKeys = `mutation($keys: ApiAccessUpdateInput!) {
+			apiAccessUpdateKeys(keys: $keys) {` + graphqlAPIAccessUpdatedKeyFields + graphqlAPIAccessKeyErrorFields + `
+		}}`
+
+	apiAccessKeyDeleteKeys = `mutation($keys: ApiAccessDeleteInput!) {
+			apiAccessDeleteKeys(keys: $keys) {
+				deletedKeys {
+					id
+				}` + graphqlAPIAccessKeyErrorFields + `}}`
+)
+
+// CreateAPIAccessKeysMutation create keys. You can create keys for multiple accounts at once.
+func (a *APIAccessKeys) CreateAPIAccessKeysMutation(keys APIAccessCreateKeysInput) ([]APIAccessKey, error) {
+	vars := map[string]interface{}{
+		"keys": keys,
+	}
+
+	resp := apiAccessKeyCreateResponse{}
+
+	if err := a.client.NerdGraphQuery(apiAccessKeyCreateKeys, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.APIAccessCreateKeys.Errors != nil {
+		return nil, errors.New(formatAPIAccessKeyMutationErrors(resp.APIAccessCreateKeys.Errors))
+	}
+
+	return resp.APIAccessCreateKeys.CreatedKeys, nil
+}
+
+// GetAPIAccessKeyMutation returns a single API access key.
+func (a *APIAccessKeys) GetAPIAccessKeyMutation(key APIAccessGetInput) (*APIAccessKey, error) {
+	vars := map[string]interface{}{
+		"id":      key.ID,
+		"keyType": key.KeyType,
+	}
+
+	resp := apiAccessKeyGetResponse{}
+
+	if err := a.client.NerdGraphQuery(apiAccessKeyGetKey, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Errors != nil {
+		return nil, errors.New(resp.Error())
+	}
+
+	return &resp.Actor.APIAccess.Key, nil
+}
+
+// UpdateAPIAccessKeyMutation updates keys. You can update keys for multiple accounts at once.
+func (a *APIAccessKeys) UpdateAPIAccessKeyMutation(keys APIAccessUpdateInput) ([]APIAccessKey, error) {
+	vars := map[string]interface{}{
+		"keys": keys,
+	}
+
+	resp := apiAccessKeyUpdateResponse{}
+
+	if err := a.client.NerdGraphQuery(apiAccessKeyUpdateKeys, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.APIAccessUpdateKeys.Errors != nil {
+		return nil, errors.New(formatAPIAccessKeyMutationErrors(resp.APIAccessUpdateKeys.Errors))
+	}
+
+	return resp.APIAccessUpdateKeys.UpdatedKeys, nil
+}
+
+// DeleteAPIAccessKeyMutation deletes keys.
+func (a *APIAccessKeys) DeleteAPIAccessKeyMutation(keys APIAccessDeleteInput) error {
+	vars := map[string]interface{}{
+		"keys": keys,
+	}
+
+	resp := apiAccessKeyDeleteResponse{}
+
+	if err := a.client.NerdGraphQuery(apiAccessKeyDeleteKeys, vars, &resp); err != nil {
+		return err
+	}
+
+	if resp.APIAccessDeleteKeys.Errors != nil {
+		return errors.New(formatAPIAccessKeyMutationErrors(resp.APIAccessDeleteKeys.Errors))
+	}
+
+	return nil
+}
+
+func formatAPIAccessKeyMutationErrors(errors []apiAccessKeyMutationErrResponse) string {
+	errorString := ""
+	for _, e := range errors {
+		errorString += fmt.Sprintf("%v\n", e)
+	}
+	return errorString
+}

--- a/pkg/apiaccesskeys/apiaccesskeys.go
+++ b/pkg/apiaccesskeys/apiaccesskeys.go
@@ -1,0 +1,22 @@
+// Package apikeys provides a programmatic API for interacting with New Relic API keys
+package apiaccesskeys
+
+import (
+	"github.com/newrelic/newrelic-client-go/internal/http"
+	"github.com/newrelic/newrelic-client-go/internal/logging"
+	"github.com/newrelic/newrelic-client-go/pkg/config"
+)
+
+// APIKeys is used to communicate with the New Relic APIKeys product.
+type APIAccessKeys struct {
+	client http.Client
+	logger logging.Logger
+}
+
+// New returns a new client for interacting with New Relic One entities.
+func New(config config.Config) APIAccessKeys {
+	return APIAccessKeys{
+		client: http.NewClient(config),
+		logger: config.GetLogger(),
+	}
+}

--- a/pkg/apiaccesskeys/types.go
+++ b/pkg/apiaccesskeys/types.go
@@ -1,0 +1,51 @@
+package apiaccesskeys
+
+// APIAccessCreateKeysInput represents a list of the configurations for each key you want to create.
+type APIAccessCreateKeysInput struct {
+	Ingest []APIAccessCreateIngestKeyInput `json:"ingest,omitempty"`
+	User   []APIAccessCreateUserKeyInput   `json:"user,omitempty"`
+}
+
+// APIAccessCreateIngestKeyInput represents the input for any ingest keys you want to create.
+// Each ingest key must have a type that communicates what kind of data it is for.
+// You can optionally add a name or notes to your key, which can be updated later.
+type APIAccessCreateIngestKeyInput struct {
+	AccountID  int    `json:"accountId"`
+	IngestType string `json:"ingestType"`
+	Name       string `json:"name"`
+	Notes      string `json:"notes"`
+}
+
+// APIAccessCreateUserKeyInput represents a request to create user keys. You can optionally add a name or notes to your key,
+// which can be updated later.
+type APIAccessCreateUserKeyInput struct {
+	AccountID int    `json:"accountId"`
+	UserID    int    `json:"userId"`
+	Name      string `json:"name"`
+	Notes     string `json:"notes"`
+}
+
+// APIAccessDeleteInput represents a list of each key id that you want to delete.
+type APIAccessDeleteInput struct {
+	IngestKeyIds []string `json:"ingestKeyIds,omitempty"`
+	UserKeyIds   []string `json:"userKeyIds,omitempty"`
+}
+
+// APIAccessGetInput represents a single key by ID and type that you want to retrieve from the API.
+type APIAccessGetInput struct {
+	ID      string `json:"id"`
+	KeyType string `json:"keyType"`
+}
+
+// APIAccessUpdateInput represents the input needed to update an API access key.
+type APIAccessUpdateInput struct {
+	Ingest []APIAccessUpdateKeyInput `json:"ingest,omitempty"`
+	User   []APIAccessUpdateKeyInput `json:"user,omitempty"`
+}
+
+// APIAccessUpdateKeyInput represents the individual fields required to update an API access key.
+type APIAccessUpdateKeyInput struct {
+	ID    string `json:"keyId"`
+	Name  string `json:"name"`
+	Notes string `json:"notes"`
+}


### PR DESCRIPTION
Resolves https://github.com/davidji99/newrelic-client-go/issues/2

This is a WIP to eventually address https://github.com/newrelic/terraform-provider-newrelic/issues/839.

Personally, I'm a bit confused how this client API prefers to implement the NerdGraph APIs.