### PR TITLE
Implement TagsWithMetadata to avoid non-modifiable result sets

### DIFF
--- a/pkg/entities/entity.go
+++ b/pkg/entities/entity.go
@@ -216,6 +216,19 @@ const (
 					reporting
 					type
 `
+	graphqlEntityStructTagsFields = `
+					tagsWithMetadata {
+						key
+						values {
+							mutable
+							value
+						}
+					}
+					tags {
+						key
+						values
+					}
+`
 
 	graphqlApmApplicationEntityFields = `
 					... on ApmApplicationEntity {
@@ -275,6 +288,7 @@ const (
 
 	getEntitiesQuery = `query($guids: [String!]!) { actor { entities(guids: $guids)  {` +
 		graphqlEntityStructFields +
+		graphqlEntityStructTagsFields +
 		graphqlApmApplicationEntityFields +
 		graphqlBrowserApplicationEntityFields +
 		graphqlMobileApplicationEntityFields +
@@ -282,6 +296,7 @@ const (
 
 	getEntityQuery = `query($guid: String!) { actor { entity(guid: $guid)  {` +
 		graphqlEntityStructFields +
+		graphqlEntityStructTagsFields +
 		graphqlApmApplicationEntityFields +
 		graphqlBrowserApplicationEntityFields +
 		graphqlMobileApplicationEntityFields +

--- a/pkg/entities/tags.go
+++ b/pkg/entities/tags.go
@@ -28,7 +28,36 @@ func (e *Entities) ListTags(guid string) ([]*Tag, error) {
 		return nil, err
 	}
 
-	return resp.Actor.Entity.Tags, nil
+	return filterMutable(resp)
+}
+
+// filterMutable removes tag values that are read-only from the received response.
+func filterMutable(resp listTagsResponse) ([]*Tag, error) {
+	var tags []*Tag
+
+	for _, responseTag := range resp.Actor.Entity.TagsWithMetadata {
+		if responseTag != nil {
+			tag := Tag{
+				Key: responseTag.Key,
+			}
+
+			mutable := 0
+			for _, responseTagValue := range responseTag.Values {
+				if responseTagValue.Mutable {
+					mutable++
+					tag.Values = append(tag.Values, responseTagValue.Value)
+				}
+			}
+
+			// All values were mutable
+			if len(responseTag.Values) == mutable {
+				tags = append(tags, &tag)
+			}
+
+		}
+	}
+
+	return tags, nil
 }
 
 // AddTags writes tags to the entity specified by the provided entity GUID.
@@ -121,6 +150,22 @@ func parseTagMutationErrors(errors []tagMutationError) string {
 	return strings.Join(messages, ", ")
 }
 
+// EntityTagValueWithMetadata - The value and metadata of a single entity tag.
+type EntityTagValueWithMetadata struct {
+	// Whether or not the tag can be mutated by the user.
+	Mutable bool `json:"mutable"`
+	// The tag value.
+	Value string `json:"value"`
+}
+
+// EntityTagWithMetadata - The tags with metadata of the entity.
+type EntityTagWithMetadata struct {
+	// The tag's key.
+	Key string `json:"key"`
+	// A list of tag values with metadata information.
+	Values []EntityTagValueWithMetadata `json:"values"`
+}
+
 var listTagsQuery = `
 	query($guid:EntityGuid!) { actor { entity(guid: $guid)  {` +
 	graphqlEntityStructTagsFields +
@@ -129,7 +174,8 @@ var listTagsQuery = `
 type listTagsResponse struct {
 	Actor struct {
 		Entity struct {
-			Tags []*Tag
+			Tags             []*Tag
+			TagsWithMetadata []*EntityTagWithMetadata
 		}
 	}
 }

--- a/pkg/entities/tags.go
+++ b/pkg/entities/tags.go
@@ -122,17 +122,9 @@ func parseTagMutationErrors(errors []tagMutationError) string {
 }
 
 var listTagsQuery = `
-	query($guid:EntityGuid!) {
-		actor {
-			entity(guid: $guid)  {
-				tags {
-					values
-					key
-				}
-			}
-		}
-	}
-`
+	query($guid:EntityGuid!) { actor { entity(guid: $guid)  {` +
+	graphqlEntityStructTagsFields +
+	` } } }`
 
 type listTagsResponse struct {
 	Actor struct {


### PR DESCRIPTION
related to https://github.com/newrelic/terraform-provider-newrelic/issues/756, https://github.com/newrelic/terraform-provider-newrelic/issues/791 and https://github.com/newrelic/terraform-provider-newrelic/issues/766

The nerdgraph schema has been updated to include the information about a users chances of modifying a given entity tag.  Here we hide those which are not user-editable from the user.