### PR TITLE
feat(logs): support insert key

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -50,3 +50,9 @@ type LicenseKeyAuthorizer struct{}
 func (a *LicenseKeyAuthorizer) AuthorizeRequest(r *Request, c *config.Config) {
 	r.SetHeader("X-License-Key", c.LicenseKey)
 }
+
+type LogsInsertKeyAuthorizer struct{}
+
+func (a *LogsInsertKeyAuthorizer) AuthorizeRequest(r *Request, c *config.Config) {
+	r.SetHeader("Api-Key", c.InsightsInsertKey)
+}

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -39,7 +39,11 @@ func New(cfg config.Config) Logs {
 	cfg.Compression = config.Compression.Gzip
 
 	client := http.NewClient(cfg)
-	client.SetAuthStrategy(&http.LicenseKeyAuthorizer{})
+	if cfg.InsightsInsertKey != "" {
+		client.SetAuthStrategy(&http.LogsInsertKeyAuthorizer{})
+	} else {
+		client.SetAuthStrategy(&http.LicenseKeyAuthorizer{})
+	}
 
 	pkg := Logs{
 		client:       client,


### PR DESCRIPTION
Added ability to use an insert key to send logs. Only a license key was supported previously.