### PR TITLE
fix(http): handle 'not found' downstream response

### DIFF
--- a/internal/http/graphql.go
+++ b/internal/http/graphql.go
@@ -54,6 +54,14 @@ func (r *GraphQLErrorResponse) Error() string {
 
 // IsNotFound determines if the error is due to a missing resource.
 func (r *GraphQLErrorResponse) IsNotFound() bool {
+	for _, err := range r.Errors {
+		for _, downStreamResp := range err.DownstreamResponse {
+			if strings.Contains(downStreamResp.Message, "Not Found") {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 

--- a/pkg/alerts/nrql_conditions_integration_test.go
+++ b/pkg/alerts/nrql_conditions_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/newrelic/newrelic-client-go/pkg/errors"
 	nr "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 )
 
@@ -369,6 +370,12 @@ func TestIntegrationNrqlConditions_ErrorScenarios(t *testing.T) {
 	updatedStatic, err := client.UpdateNrqlConditionStaticMutation(nr.TestAccountID, "8675309", testInvalidMutationInput)
 	require.Error(t, err)
 	require.Nil(t, updatedStatic)
+
+	// Test: 'Not Found' error for non-existent condition
+	_, err = client.GetNrqlConditionQuery(nr.TestAccountID, "999999999999999")
+	require.Error(t, err)
+	_, ok := err.(*errors.NotFound)
+	require.True(t, ok)
 
 	// Deferred teardown
 	defer func() {


### PR DESCRIPTION
Facilitates resolving: [terraform-provider-newrelic #860](https://github.com/newrelic/terraform-provider-newrelic/issues/860)

The issue above might have been caused by an upstream API change 🤔 💭 