### PR TITLE
fix: adjustments for 'Not Found' scenarios

### DIFF
--- a/pkg/alerts/policies.go
+++ b/pkg/alerts/policies.go
@@ -177,7 +177,11 @@ func (a *Alerts) QueryPolicy(accountID int, id string) (*AlertsPolicy, error) {
 		return nil, err
 	}
 
-	return &resp.Actor.Account.Alerts.Policy, nil
+	if resp.Actor.Account.Alerts.Policy == nil {
+		return nil, errors.NewNotFoundf("policy ID %v not found", id)
+	}
+
+	return resp.Actor.Account.Alerts.Policy, nil
 }
 
 // QueryPolicySearch searches NerdGraph for policies.
@@ -283,7 +287,7 @@ type alertQueryPolicyResponse struct {
 	Actor struct {
 		Account struct {
 			Alerts struct {
-				Policy AlertsPolicy `json:"policy"`
+				Policy *AlertsPolicy `json:"policy,omitempty"`
 			} `json:"alerts"`
 		} `json:"account"`
 	} `json:"actor"`


### PR DESCRIPTION
NerdGraph's API response seems to have changed for the alert policy query.

**Old API Behavior:** Querying for a non-existent alert policy would return a response containing error field values of `BAD_USER_INPUT` and `Not Found`.
**New API Behavior:** The response now returns a `null` policy if a policy is not found. This breaks things.

