### PR TITLE
refactor(alerts): remove widespread change, limit scope to only nrql condition error resp handling

### DIFF
--- a/internal/http/graphql.go
+++ b/internal/http/graphql.go
@@ -54,14 +54,6 @@ func (r *GraphQLErrorResponse) Error() string {
 
 // IsNotFound determines if the error is due to a missing resource.
 func (r *GraphQLErrorResponse) IsNotFound() bool {
-	for _, err := range r.Errors {
-		for _, downStreamResp := range err.DownstreamResponse {
-			if strings.Contains(downStreamResp.Message, "Not Found") {
-				return true
-			}
-		}
-	}
-
 	return false
 }
 


### PR DESCRIPTION
Refactors #475 

The previous change was a widespread change and currently it's safer to scope this change to the resource in question rather than for all of them.

