### PR TITLE
feat(synthetics): change resources to use personal api keys

### DIFF
--- a/pkg/alerts/example_policy_test.go
+++ b/pkg/alerts/example_policy_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func Example_policy() {
-	// Initialize the client configuration.  A Personal API key or Admin API key
-	// is required to communicate with the backend API.
+	// Initialize the client configuration. A Personal API key is required to
+	// communicate with the backend API.
+	// is deprecated.
 	cfg := config.New()
-	cfg.AdminAPIKey = os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 	cfg.PersonalAPIKey = os.Getenv("NEW_RELIC_API_KEY")
 
 	// Initialize the client.

--- a/pkg/apm/example_application_test.go
+++ b/pkg/apm/example_application_test.go
@@ -8,10 +8,9 @@ import (
 )
 
 func Example_application() {
-	// Initialize the client configuration.  A Personal API key or Admin API key
-	// is required to communicate with the backend API.
+	// Initialize the client configuration.  A Personal API key is required to
+	// communicate with the backend API.
 	cfg := config.New()
-	cfg.AdminAPIKey = os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 	cfg.PersonalAPIKey = os.Getenv("NEW_RELIC_API_KEY")
 
 	// Initialize the client.

--- a/pkg/apm/example_key_transaction_test.go
+++ b/pkg/apm/example_key_transaction_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 func Example_keyTransaction() {
-	// Initialize the client configuration.  A Personal API key or Admin API key
-	// is required to communicate with the backend API.
+	// Initialize the client configuration. A Personal API key is required to
+	// communicate with the backend API.
 	cfg := config.New()
-	cfg.AdminAPIKey = os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 	cfg.PersonalAPIKey = os.Getenv("NEW_RELIC_API_KEY")
 
 	// Initialize the client.

--- a/pkg/apm/example_labels_test.go
+++ b/pkg/apm/example_labels_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 func Example_labels() {
-	// Initialize the client configuration.  A Personal API key or Admin API key
-	// is required to communicate with the backend API.
+	// Initialize the client configuration. A Personal API key is required to
+	// communicate with the backend API.
 	cfg := config.New()
-	cfg.AdminAPIKey = os.Getenv("NEW_RELIC_ADMIN_API_KEY")
 	cfg.PersonalAPIKey = os.Getenv("NEW_RELIC_API_KEY")
 
 	// Initialize the client.

--- a/pkg/dashboards/dashboards.go
+++ b/pkg/dashboards/dashboards.go
@@ -17,8 +17,11 @@ type Dashboards struct {
 
 // New is used to create a new Dashboards client instance.
 func New(config config.Config) Dashboards {
+	client := http.NewClient(config)
+	client.SetAuthStrategy(&http.PersonalAPIKeyCapableV2Authorizer{})
+
 	pkg := Dashboards{
-		client: http.NewClient(config),
+		client: client,
 		config: config,
 		logger: config.GetLogger(),
 		pager:  &http.LinkHeaderPager{},

--- a/pkg/dashboards/example_dashboard_test.go
+++ b/pkg/dashboards/example_dashboard_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func Example_dashboard() {
-	// Initialize the client configuration.  An Admin API key is required to
+	// Initialize the client configuration. A Personal API key is required to
 	// communicate with the backend API.
 	cfg := config.New()
-	cfg.AdminAPIKey = os.Getenv("NEW_RELIC_ADMIN_API_KEY")
+	cfg.PersonalAPIKey = os.Getenv("NEW_RELIC_API_KEY")
 
 	// Initialize the client.
 	client := New(cfg)

--- a/pkg/synthetics/example_monitor_test.go
+++ b/pkg/synthetics/example_monitor_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func Example_monitor() {
-	// Initialize the client configuration.  An Admin API key is required to
+	// Initialize the client configuration. A Personal API key is required to
 	// communicate with the backend API.
 	cfg := config.New()
-	cfg.AdminAPIKey = os.Getenv("NEW_RELIC_ADMIN_API_KEY")
+	cfg.PersonalAPIKey = os.Getenv("NEW_RELIC_API_KEY")
 
 	// Initialize the client.
 	client := New(cfg)

--- a/pkg/synthetics/example_secure_credentials_test.go
+++ b/pkg/synthetics/example_secure_credentials_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Example_secureCredentials() {
-	// Initialize the client configuration.  An Admin API key is required to
+	// Initialize the client configuration. An Admin API key is required to
 	// communicate with the backend API.
 	cfg := config.New()
 	cfg.AdminAPIKey = os.Getenv("NEW_RELIC_ADMIN_API_KEY")

--- a/pkg/synthetics/secure_credentials.go
+++ b/pkg/synthetics/secure_credentials.go
@@ -13,7 +13,7 @@ type SecureCredential struct {
 func (s *Synthetics) GetSecureCredentials() ([]*SecureCredential, error) {
 	resp := getSecureCredentialsResponse{}
 
-	_, err := s.client.Get(s.config.Region().SyntheticsURL("/v1/secure-credentials"), nil, &resp)
+	_, err := s.secureCredentialsClient.Get(s.config.Region().SyntheticsURL("/v1/secure-credentials"), nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -25,7 +25,7 @@ func (s *Synthetics) GetSecureCredentials() ([]*SecureCredential, error) {
 func (s *Synthetics) GetSecureCredential(key string) (*SecureCredential, error) {
 	var sc SecureCredential
 
-	_, err := s.client.Get(s.config.Region().SyntheticsURL("/v1/secure-credentials", key), nil, &sc)
+	_, err := s.secureCredentialsClient.Get(s.config.Region().SyntheticsURL("/v1/secure-credentials", key), nil, &sc)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (s *Synthetics) AddSecureCredential(key, value, description string) (*Secur
 		Description: description,
 	}
 
-	_, err := s.client.Post(s.config.Region().SyntheticsURL("/v1/secure-credentials"), nil, sc, nil)
+	_, err := s.secureCredentialsClient.Post(s.config.Region().SyntheticsURL("/v1/secure-credentials"), nil, sc, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (s *Synthetics) UpdateSecureCredential(key, value, description string) (*Se
 		Description: description,
 	}
 
-	_, err := s.client.Put(s.config.Region().SyntheticsURL("/v1/secure-credentials", key), nil, sc, nil)
+	_, err := s.secureCredentialsClient.Put(s.config.Region().SyntheticsURL("/v1/secure-credentials", key), nil, sc, nil)
 
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func (s *Synthetics) UpdateSecureCredential(key, value, description string) (*Se
 
 // DeleteSecureCredential deletes a secure credential from your New Relic account.
 func (s *Synthetics) DeleteSecureCredential(key string) error {
-	_, err := s.client.Delete(s.config.Region().SyntheticsURL("/v1/secure-credentials", key), nil, nil)
+	_, err := s.secureCredentialsClient.Delete(s.config.Region().SyntheticsURL("/v1/secure-credentials", key), nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/synthetics/synthetics.go
+++ b/pkg/synthetics/synthetics.go
@@ -11,10 +11,11 @@ import (
 
 // Synthetics is used to communicate with the New Relic Synthetics product.
 type Synthetics struct {
-	client http.Client
-	config config.Config
-	logger logging.Logger
-	pager  http.Pager
+	client                  http.Client
+	config                  config.Config
+	logger                  logging.Logger
+	pager                   http.Pager
+	secureCredentialsClient http.Client
 }
 
 // ErrorResponse represents an error response from New Relic Synthetics.
@@ -62,13 +63,18 @@ func (e *ErrorResponse) IsNotFound() bool {
 // New is used to create a new Synthetics client instance.
 func New(config config.Config) Synthetics {
 	client := http.NewClient(config)
+	client.SetAuthStrategy(&http.PersonalAPIKeyCapableV2Authorizer{})
+	client.SetErrorValue(&ErrorResponse{})
+
+	secureCredentialsClient := http.NewClient(config)
 	client.SetErrorValue(&ErrorResponse{})
 
 	pkg := Synthetics{
-		client: client,
-		config: config,
-		logger: config.GetLogger(),
-		pager:  &http.LinkHeaderPager{},
+		client:                  client,
+		secureCredentialsClient: secureCredentialsClient,
+		config:                  config,
+		logger:                  config.GetLogger(),
+		pager:                   &http.LinkHeaderPager{},
 	}
 
 	return pkg


### PR DESCRIPTION
This PR eliminates admin API keys as an authentication method for all resources except Synthetics Secure Credentials, whiich still requires it.