### PR TITLE
fix(events): dereference the data pointer

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -66,8 +66,8 @@ func (e *Events) CreateEvent(accountID int, event interface{}) error {
 	}
 
 	resp := &createEventResponse{}
-	_, err = e.client.Post(e.config.Region().InsightsURL(accountID), nil, jsonData, resp)
 
+	_, err = e.client.Post(e.config.Region().InsightsURL(accountID), nil, *jsonData, resp)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Without the change, the received data type is a pointer and never posted to
insights.  Here we dereference the pointer so the data flows properly.