### PR TITLE
chore: fix integration tests and suppress when run from a fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Integration Tests
+      if: github.event.pull_request.head.repo.full_name == github.repository
       run: make test-integration
       env:
         NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ $ make build
 # make build-ci
 ```
 
-
 ### Testing
+Before contributing, all linting and tests must pass.
 
-Before contributing, all linting and tests must pass.  Tests can be run directly via:
+Tests can be run directly via:
 
 ```
 # Tests and Linting
@@ -101,6 +101,22 @@ $ make test-unit
 # Only integration tests
 $ make test-integration
 ```
+
+#### Integration tests
+Integration tests communicate with the New Relic API, and therefore require proper
+account credentials to run properly. The suite makes use of secrets, which will
+need to be configured in the environment or else the integraiton tests will be skipped
+during a test run. To run the integration test suite, the following secrets will
+need to be configured:
+
+```
+NEW_RELIC_API_KEY
+NEW_RELIC_ACCOUNT_ID
+NEW_RELIC_INSIGHTS_INSERT_KEY
+NEW_RELIC_LICENSE_KEY
+NEW_RELIC_REGION
+```
+
 
 #### Go Version Support
 

--- a/pkg/logs/example_log_batch_test.go
+++ b/pkg/logs/example_log_batch_test.go
@@ -58,5 +58,4 @@ func Example_basic() {
 	if err := client.Flush(); err != nil {
 		log.Fatal("error flushing log queue: ", err)
 	}
-
 }

--- a/pkg/logs/example_log_test.go
+++ b/pkg/logs/example_log_test.go
@@ -3,6 +3,7 @@
 package logs
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -10,8 +11,7 @@ import (
 	"github.com/newrelic/newrelic-client-go/pkg/config"
 )
 
-func TestExample_log(t *testing.T) {
-	//func Example_basic() {
+func Example_log(t *testing.T) {
 	// Initialize the client configuration.  A New Relic License Key is required
 	// to communicate with the backend API.
 	cfg := config.New()
@@ -32,4 +32,6 @@ func TestExample_log(t *testing.T) {
 	if err := client.CreateLogEntry(logEntry); err != nil {
 		log.Fatal("error posting Log entry: ", err)
 	}
+
+	fmt.Printf("success")
 }

--- a/pkg/logs/logs_integration_test.go
+++ b/pkg/logs/logs_integration_test.go
@@ -28,8 +28,7 @@ var testData = []testDatum{
 	},
 }
 
-// Test: CreateEvent
-func TestIntegrationEvents(t *testing.T) {
+func TestIntegrationLogs(t *testing.T) {
 	t.Parallel()
 
 	client := newIntegrationTestClient(t)

--- a/pkg/plugins/plugins_integration_test.go
+++ b/pkg/plugins/plugins_integration_test.go
@@ -5,13 +5,15 @@ package plugins
 import (
 	"testing"
 
+	mock "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationPlugins(t *testing.T) {
 	t.Parallel()
 
-	client := newIntegrationTestClient(t)
+	tc := mock.NewIntegrationTestConfig(t)
+	client := New(tc)
 
 	// Test: List
 	listResult, err := client.ListPlugins(nil)

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package plugins
 
 import (


### PR DESCRIPTION
- suppress integration tests for fork-based runs
- fix log example test so that it is not run
- add unit tag to plugins unit tests
- refactor logs code for clarity
- update documentation for running integration tests
