### PR TITLE
fix(alerts): don't omitempty for muting rule's enabled field

### DIFF
--- a/pkg/alerts/muting_rules.go
+++ b/pkg/alerts/muting_rules.go
@@ -8,7 +8,7 @@ type MutingRule struct {
 	CreatedAt     string                   `json:"createdAt,omitempty"`
 	CreatedByUser ByUser                   `json:"createdByUser,omitempty"`
 	Description   string                   `json:"description,omitempty"`
-	Enabled       bool                     `json:"enabled,omitempty"`
+	Enabled       bool                     `json:"enabled"`
 	Name          string                   `json:"name,omitempty"`
 	UpdatedAt     string                   `json:"updatedAt,omitempty"`
 	UpdatedByUser ByUser                   `json:"updatedByUser,omitempty"`


### PR DESCRIPTION
Related to newrelic/terraform-provider-newrelic#954.

`omitempty` causes `fill_option` values of `false` to be omitted from the payload when making requests.