### PR TITLE
Add code to link and unlink Cloud accounts to a NewRelic account

### DIFF
--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -2,6 +2,7 @@ package newrelic
 
 import (
 	"errors"
+	"github.com/newrelic/newrelic-client-go/pkg/infrastructure"
 	"net/http"
 	"time"
 
@@ -39,6 +40,7 @@ type NewRelic struct {
 	Entities        entities.Entities
 	Events          events.Events
 	EventsToMetrics eventstometrics.EventsToMetrics
+	Infrastructure  infrastructure.Infrastructure
 	Logs            logs.Logs
 	NerdGraph       nerdgraph.NerdGraph
 	NerdStorage     nerdstorage.NerdStorage
@@ -79,6 +81,7 @@ func New(opts ...ConfigOption) (*NewRelic, error) {
 		Entities:        entities.New(config),
 		Events:          events.New(config),
 		EventsToMetrics: eventstometrics.New(config),
+		Infrastructure:  infrastructure.New(config),
 		Logs:            logs.New(config),
 		NerdGraph:       nerdgraph.New(config),
 		NerdStorage:     nerdstorage.New(config),

--- a/pkg/infrastructure/cloud.go
+++ b/pkg/infrastructure/cloud.go
@@ -1,0 +1,112 @@
+package infrastructure
+
+type LinkCloudAccountInput struct {
+	AccountID int                     `json:"accountId"`
+	AWS       []LinkAWSAccountInput   `json:"aws"`
+	Azure     []LinkAzureAccountInput `json:"azure"`
+	GCP       []LinkGCPAccountInput   `json:"gcp"`
+}
+
+type LinkAWSAccountInput struct {
+	Name string `json:"name"`
+	ARN  string `json:"arn"`
+}
+
+type LinkAzureAccountInput struct {
+	Name           string `json:"name"`
+	ApplicationID  string `json:"applicationId"`
+	ClientSecret   string `json:"clientSecret"`
+	TenantID       string `json:"tenantId"`
+	SubscriptionId string `json:"subscriptionId"`
+}
+
+type LinkGCPAccountInput struct {
+	Name      string `json:"name"`
+	ProjectId string `json:"projectId"`
+}
+
+type linkCloudAccountOutput struct {
+	LinkedAccounts []LinkedCloudAccount `json:"linkedAccounts"`
+}
+
+type LinkedCloudAccount struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	AuthLabel string `json:"authLabel"`
+}
+
+// LinkCloudAccount is the mutation to link a New Relic account to a Cloud account (AWS / Azure / GCP).
+func (i *Infrastructure) LinkCloudAccount(account LinkCloudAccountInput) ([]LinkedCloudAccount, error) {
+	vars := map[string]interface{}{
+		"account": account,
+	}
+
+	var resp linkCloudAccountOutput
+	if err := i.client.NerdGraphQuery(linkCloudAccountMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.LinkedAccounts, nil
+}
+
+type UnlinkCloudAccountInput struct {
+	Accounts []LinkedCloudAccountRef `json:"accounts"`
+}
+
+type LinkedCloudAccountRef struct {
+	LinkedAccountId int `json:"linkedAccountId"`
+}
+
+type UnlinkedCloudAccount struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type unlinkCloudAccountOutput struct {
+	UnlinkedAccounts []UnlinkedCloudAccount `json:"unlinkedAccounts"`
+}
+
+// UnlinkCloudAccount is the mutation to unlink a New Relic account from a Cloud account (AWS / Azure / GCP).
+func (i *Infrastructure) UnlinkCloudAccount(accountID int, accounts UnlinkCloudAccountInput) ([]UnlinkedCloudAccount, error) {
+	vars := map[string]interface{}{
+		"accountID": accountID,
+		"accounts":  accounts,
+	}
+
+	resp := unlinkCloudAccountOutput{}
+	if err := i.client.NerdGraphQuery(unlinkCloudAccountMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.UnlinkedAccounts, nil
+}
+
+const (
+	graphqlErrors = `
+    errors {
+      type
+      message
+    }
+    `
+
+	linkCloudAccountMutation = `
+		mutation($accounts: LinkCloudAccountInput!) {
+			cloudLinkAccount(accounts: $accounts) {
+				linkedAccounts {
+					id
+					name
+					authLabel
+				}` +
+		graphqlErrors +
+		`} }`
+
+	unlinkCloudAccountMutation = `
+		mutation($accountID: Int!, $accounts: UnlinkCloudAccountInput!) {
+			cloudUnlinkAccount(accountId: $accountID, accounts: $accounts) {
+				unlinkedAccounts {
+					id
+					name
+				}` +
+		graphqlErrors +
+		`} }`
+)

--- a/pkg/infrastructure/cloud_test.go
+++ b/pkg/infrastructure/cloud_test.go
@@ -1,0 +1,117 @@
+// +build unit
+
+package infrastructure
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testLinkCloudAccountResponseJSON = `{
+		"data": {
+			"linkedAccounts": [
+				{
+					"id": 17327,
+					"name": "unit-test-linked-account1",
+					"authLabel": "unit-test-auth-label1"
+				},
+				{
+					"id": 28934,
+					"name": "unit-test-linked-account2",
+					"authLabel": "unit-test-auth-label2"
+				}
+			]
+		}
+	}`
+	testUnlinkCloudAccountResponseJSON = `{
+		"data": {
+			"unlinkedAccounts": [
+				{
+					"id": 17327,
+					"name": "unit-test-linked-account1",
+				},
+				{
+					"id": 28934,
+					"name": "unit-test-linked-account2",
+				}
+			]
+		}
+	}`
+	testErrorResponseJSON = `{
+		"errors": [
+			{
+				"message": "Could not link cloud account"
+			}
+		]
+	}`
+)
+
+func TestInfrastructure_LinkCloudAccount_Success(t *testing.T) {
+	t.Parallel()
+	infrastructure := newMockResponse(t, testLinkCloudAccountResponseJSON, http.StatusOK)
+
+	expected := []LinkedCloudAccount{
+		{
+			ID:        17327,
+			Name:      "unit-test-linked-account1",
+			AuthLabel: "unit-test-auth-label1",
+		},
+		{
+			ID:        28934,
+			Name:      "unit-test-linked-account2",
+			AuthLabel: "unit-test-auth-label2",
+		},
+	}
+
+	actual, err := infrastructure.LinkCloudAccount(LinkCloudAccountInput{AccountID: 3242})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestInfrastructure_LinkCloudAccount_Error(t *testing.T) {
+	t.Parallel()
+	infrastructure := newMockResponse(t, testErrorResponseJSON, http.StatusOK)
+	_, err := infrastructure.LinkCloudAccount(LinkCloudAccountInput{AccountID: 3242})
+
+	assert.Error(t, err)
+}
+
+func TestInfrastructure_UnlinkCloudAccount_Success(t *testing.T) {
+	t.Parallel()
+	infrastructure := newMockResponse(t, testLinkCloudAccountResponseJSON, http.StatusOK)
+
+	expected := []UnlinkedCloudAccount{
+		{
+			ID:   17327,
+			Name: "unit-test-linked-account1",
+		},
+		{
+			ID:   28934,
+			Name: "unit-test-linked-account2",
+		},
+	}
+
+	actual, err := infrastructure.UnlinkCloudAccount(3242, UnlinkCloudAccountInput{
+		Accounts: []LinkedCloudAccountRef{
+			{LinkedAccountId: 17327},
+			{LinkedAccountId: 28934},
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestInfrastructure_UnlinkCloudAccount_Error(t *testing.T) {
+	t.Parallel()
+	infrastructure := newMockResponse(t, testErrorResponseJSON, http.StatusOK)
+	_, err := infrastructure.UnlinkCloudAccount(3242, UnlinkCloudAccountInput{})
+
+	assert.Error(t, err)
+}

--- a/pkg/infrastructure/error_response.go
+++ b/pkg/infrastructure/error_response.go
@@ -1,0 +1,44 @@
+// Package infrastructure provides metadata about the underlying Infrastructure API.
+package infrastructure
+
+import (
+	"github.com/newrelic/newrelic-client-go/internal/http"
+)
+
+// ErrorResponse represents an error response from New Relic Infrastructure.
+type ErrorResponse struct {
+	Errors  []*ErrorDetail `json:"errors,omitempty"`
+	Message string         `json:"description,omitempty"`
+}
+
+// ErrorDetail represents the details of an error response from New Relic Infrastructure.
+type ErrorDetail struct {
+	Status string `json:"status,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// Error surfaces an error message from the Infrastructure error response.
+func (e *ErrorResponse) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+
+	if len(e.Errors) > 0 && e.Errors[0].Detail != "" {
+		return e.Errors[0].Detail
+	}
+
+	return ""
+}
+
+// New creates a new instance of ErrorResponse.
+func (e *ErrorResponse) New() http.ErrorResponse {
+	return &ErrorResponse{}
+}
+
+func (e *ErrorResponse) IsNotFound() bool {
+	return false
+}
+
+func (e *ErrorResponse) IsTimeout() bool {
+	return false
+}

--- a/pkg/infrastructure/error_response_test.go
+++ b/pkg/infrastructure/error_response_test.go
@@ -1,0 +1,3 @@
+// +build unit
+
+package infrastructure

--- a/pkg/infrastructure/infrastructure.go
+++ b/pkg/infrastructure/infrastructure.go
@@ -3,42 +3,20 @@ package infrastructure
 
 import (
 	"github.com/newrelic/newrelic-client-go/internal/http"
+	"github.com/newrelic/newrelic-client-go/pkg/config"
 )
 
-// ErrorResponse represents an error response from New Relic Infrastructure.
-type ErrorResponse struct {
-	Errors  []*ErrorDetail `json:"errors,omitempty"`
-	Message string         `json:"description,omitempty"`
+// Infrastructure is used to communicate with the New Relic Infrastructure product.
+type Infrastructure struct {
+	client http.Client
 }
 
-// ErrorDetail represents the details of an error response from New Relic Infrastructure.
-type ErrorDetail struct {
-	Status string `json:"status,omitempty"`
-	Detail string `json:"detail,omitempty"`
-}
+// New is used to create a new APM client instance.
+func New(config config.Config) Infrastructure {
+	client := http.NewClient(config)
+	client.SetAuthStrategy(&http.PersonalAPIKeyCapableV2Authorizer{})
 
-// Error surfaces an error message from the Infrastructure error response.
-func (e *ErrorResponse) Error() string {
-	if e.Message != "" {
-		return e.Message
+	return Infrastructure{
+		client: client,
 	}
-
-	if len(e.Errors) > 0 && e.Errors[0].Detail != "" {
-		return e.Errors[0].Detail
-	}
-
-	return ""
-}
-
-// New creates a new instance of ErrorResponse.
-func (e *ErrorResponse) New() http.ErrorResponse {
-	return &ErrorResponse{}
-}
-
-func (e *ErrorResponse) IsNotFound() bool {
-	return false
-}
-
-func (e *ErrorResponse) IsTimeout() bool {
-	return false
 }

--- a/pkg/infrastructure/infrastructure_test.go
+++ b/pkg/infrastructure/infrastructure_test.go
@@ -1,3 +1,16 @@
 // +build unit
 
 package infrastructure
+
+import (
+	"testing"
+
+	mock "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
+)
+
+func newMockResponse(t *testing.T, mockJSONResponse string, statusCode int) Infrastructure {
+	ts := mock.NewMockServer(t, mockJSONResponse, statusCode)
+	tc := mock.NewTestConfig(t, ts)
+
+	return New(tc)
+}


### PR DESCRIPTION
This pull requests adds functionality to link a Cloud account to a NewRelic infrastructure account