### PR TITLE
fix(dashboards): DashboardWidgetConfigurationInput needs to be nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ NEW_RELIC_LICENSE_KEY
 NEW_RELIC_REGION
 ```
 
+Optional for debugging (defaults to `debug`):
+
+```
+NEW_RELIC_LOG_LEVEL=trace
+```
 
 #### Go Version Support
 

--- a/pkg/dashboards/dashboards_api_integration_test.go
+++ b/pkg/dashboards/dashboards_api_integration_test.go
@@ -3,6 +3,7 @@
 package dashboards
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,7 +38,7 @@ func TestIntegrationDashboard_Basic(t *testing.T) {
 					{
 						Title: "Test Text Widget",
 						Configuration: DashboardWidgetConfigurationInput{
-							Markdown: DashboardMarkdownWidgetConfigurationInput{
+							Markdown: &DashboardMarkdownWidgetConfigurationInput{
 								Text: "Test Text widget **markdown**",
 							},
 						},
@@ -83,8 +84,10 @@ func TestIntegrationDashboard_Basic(t *testing.T) {
 				Name: dash.Pages[0].Name,
 				Widgets: []DashboardWidgetInput{
 					{
-						ID:    dash.Pages[0].Widgets[0].ID,
-						Title: "Updated Title",
+						// Even though the config isn't changing, we have to pass it. 2021-01-11 JT
+						Configuration: dashboardInput.Pages[0].Widgets[0].Configuration,
+						ID:            dash.Pages[0].Widgets[0].ID,
+						Title:         "Updated Title",
 					},
 				},
 			},
@@ -94,6 +97,7 @@ func TestIntegrationDashboard_Basic(t *testing.T) {
 	upDash, err := client.DashboardUpdate(updatedDashboard, dashGUID)
 	require.NoError(t, err)
 	require.NotNil(t, upDash)
+	fmt.Printf("Pages: '%+v'", upDash)
 	require.Equal(t, 1, len(upDash.EntityResult.Pages))
 	require.Equal(t, 1, len(upDash.EntityResult.Pages[0].Widgets))
 	assert.Equal(t, updatedDashboard.Pages[0].Widgets[0].Title, upDash.EntityResult.Pages[0].Widgets[0].Title)

--- a/pkg/dashboards/types.go
+++ b/pkg/dashboards/types.go
@@ -166,7 +166,7 @@ type DashboardLineWidgetConfigurationInput struct {
 // DashboardMarkdownWidgetConfigurationInput - Configuration for visualization type 'viz.markdown'
 type DashboardMarkdownWidgetConfigurationInput struct {
 	// Markdown content of the widget
-	Text string `json:"text"`
+	Text string `json:"text,omitempty"`
 }
 
 // DashboardPageInput - Page input
@@ -212,19 +212,19 @@ type DashboardUpdateResult struct {
 // DashboardWidgetConfigurationInput - Typed configuration for known visualizations. At most one may be populated.
 type DashboardWidgetConfigurationInput struct {
 	// Configuration for visualization type 'viz.area'
-	Area DashboardAreaWidgetConfigurationInput `json:"area,omitempty"`
+	Area *DashboardAreaWidgetConfigurationInput `json:"area,omitempty"`
 	// Configuration for visualization type 'viz.bar'
-	Bar DashboardBarWidgetConfigurationInput `json:"bar,omitempty"`
+	Bar *DashboardBarWidgetConfigurationInput `json:"bar,omitempty"`
 	// Configuration for visualization type 'viz.billboard'
-	Billboard DashboardBillboardWidgetConfigurationInput `json:"billboard,omitempty"`
+	Billboard *DashboardBillboardWidgetConfigurationInput `json:"billboard,omitempty"`
 	// Configuration for visualization type 'viz.line'
-	Line DashboardLineWidgetConfigurationInput `json:"line,omitempty"`
+	Line *DashboardLineWidgetConfigurationInput `json:"line,omitempty"`
 	// Configuration for visualization type 'viz.markdown'
-	Markdown DashboardMarkdownWidgetConfigurationInput `json:"markdown,omitempty"`
+	Markdown *DashboardMarkdownWidgetConfigurationInput `json:"markdown,omitempty"`
 	// Configuration for visualization type 'viz.pie'
-	Pie DashboardPieWidgetConfigurationInput `json:"pie,omitempty"`
+	Pie *DashboardPieWidgetConfigurationInput `json:"pie,omitempty"`
 	// Configuration for visualization type 'viz.table'
-	Table DashboardTableWidgetConfigurationInput `json:"table,omitempty"`
+	Table *DashboardTableWidgetConfigurationInput `json:"table,omitempty"`
 }
 
 // DashboardWidgetInput - Widget Input

--- a/pkg/testhelpers/config.go
+++ b/pkg/testhelpers/config.go
@@ -47,6 +47,7 @@ func NewIntegrationTestConfig(t *testing.T) config.Config {
 	envInsightsInsertKey := os.Getenv("NEW_RELIC_INSIGHTS_INSERT_KEY")
 	envLicenseKey := os.Getenv("NEW_RELIC_LICENSE_KEY")
 	envRegion := os.Getenv("NEW_RELIC_REGION")
+	envLogLevel := os.Getenv("NEW_RELIC_LOG_LEVEL")
 
 	if envPersonalAPIKey == "" {
 		t.Skipf("acceptance testing requires NEW_RELIC_API_KEY")
@@ -55,7 +56,11 @@ func NewIntegrationTestConfig(t *testing.T) config.Config {
 	cfg := config.New()
 
 	// Set some defaults
-	cfg.LogLevel = LogLevel
+	if envLogLevel != "" {
+		cfg.LogLevel = envLogLevel
+	} else {
+		cfg.LogLevel = LogLevel
+	}
 	cfg.UserAgent = UserAgent
 
 	cfg.PersonalAPIKey = envPersonalAPIKey


### PR DESCRIPTION
NON GENERATED CHANGES

Need to make all fields in `DashboardWidgetConfigurationInput` nullable, otherwise we can only create `markdown` widgets.

This needs to be worked into the code gen, but need this for TF stat.