### PR TITLE
fix(http): update error message for 401 status code to account for missing API key AND invalid API key

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -339,6 +339,10 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 	}
 
 	if !isResponseSuccess(resp) {
+		if errorValue.IsUnauthorized(resp) {
+			return nil, nrErrors.NewUnauthorizedError()
+		}
+
 		return nil, nrErrors.NewUnexpectedStatusCode(resp.StatusCode, errorValue.Error())
 	}
 

--- a/internal/http/errors.go
+++ b/internal/http/errors.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -10,6 +11,7 @@ import (
 type ErrorResponse interface {
 	IsNotFound() bool
 	IsRetryableError() bool
+	IsUnauthorized(resp *http.Response) bool
 	Error() string
 	New() ErrorResponse
 }
@@ -40,6 +42,11 @@ func (e *DefaultErrorResponse) IsNotFound() bool {
 
 func (e *DefaultErrorResponse) IsRetryableError() bool {
 	return false
+}
+
+// IsUnauthorized checks a response for a 401 Unauthorize HTTP status code.
+func (e *DefaultErrorResponse) IsUnauthorized(resp *http.Response) bool {
+	return resp.StatusCode == http.StatusUnauthorized
 }
 
 // New creates a new instance of the DefaultErrorResponse struct.

--- a/internal/http/graphql.go
+++ b/internal/http/graphql.go
@@ -100,7 +100,7 @@ func (r *GraphQLErrorResponse) IsUnauthorized(resp *http.Response) bool {
 		return false
 	}
 
-	if resp.StatusCode == 401 {
+	if resp.StatusCode == http.StatusUnauthorized {
 		return true
 	}
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -3,6 +3,7 @@ package errors
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // NewNotFound returns a new instance of NotFound with an optional custom error message.
@@ -84,6 +85,32 @@ type UnexpectedStatusCode struct {
 }
 
 func (e *UnexpectedStatusCode) Error() string {
+	msg := fmt.Sprintf("%d response returned", e.statusCode)
+
+	if e.err != "" {
+		msg += fmt.Sprintf(": %s", e.err)
+	}
+
+	return msg
+}
+
+// NewUnauthorizedError returns a new instance of UnauthorizedError
+// with an optional custom message.
+func NewUnauthorizedError() *UnauthorizedError {
+	return &UnauthorizedError{
+		err:        "Invalid credentials provided. Missing API key or an invalid API key was provided.",
+		statusCode: http.StatusUnauthorized,
+	}
+}
+
+// UnauthorizedError is returned when a 401 HTTP status code is returned
+// from New Relic's APIs.
+type UnauthorizedError struct {
+	err        string
+	statusCode int
+}
+
+func (e *UnauthorizedError) Error() string {
 	msg := fmt.Sprintf("%d response returned", e.statusCode)
 
 	if e.err != "" {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -3,6 +3,7 @@
 package errors
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,4 +23,13 @@ func TestErrorUnexpectedStatusCode(t *testing.T) {
 	e := NewUnexpectedStatusCode(99, "wat")
 
 	assert.Equal(t, "99 response returned: wat", e.Error())
+}
+
+func TestErrorUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	e := NewUnauthorizedError()
+
+	assert.Equal(t, 401, e.statusCode)
+	assert.True(t, strings.Contains(e.Error(), "Invalid credentials provided"))
 }

--- a/pkg/infrastructure/infrastructure.go
+++ b/pkg/infrastructure/infrastructure.go
@@ -2,7 +2,9 @@
 package infrastructure
 
 import (
-	"github.com/newrelic/newrelic-client-go/internal/http"
+	"net/http"
+
+	nrhttp "github.com/newrelic/newrelic-client-go/internal/http"
 )
 
 // ErrorResponse represents an error response from New Relic Infrastructure.
@@ -31,7 +33,7 @@ func (e *ErrorResponse) Error() string {
 }
 
 // New creates a new instance of ErrorResponse.
-func (e *ErrorResponse) New() http.ErrorResponse {
+func (e *ErrorResponse) New() nrhttp.ErrorResponse {
 	return &ErrorResponse{}
 }
 
@@ -41,4 +43,9 @@ func (e *ErrorResponse) IsNotFound() bool {
 
 func (e *ErrorResponse) IsRetryableError() bool {
 	return false
+}
+
+// IsUnauthorized checks a response for a 401 Unauthorize HTTP status code.
+func (e *ErrorResponse) IsUnauthorized(resp *http.Response) bool {
+	return resp.StatusCode == http.StatusUnauthorized
 }

--- a/pkg/nerdgraph/nerdgraph_integration_test.go
+++ b/pkg/nerdgraph/nerdgraph_integration_test.go
@@ -1,4 +1,4 @@
-// +build sometimes
+// +build integration
 
 package nerdgraph
 

--- a/pkg/synthetics/synthetics_test.go
+++ b/pkg/synthetics/synthetics_test.go
@@ -36,7 +36,6 @@ func TestError(t *testing.T) {
 	// 1st Server Error Message
 	e.ServerErrorMessage = "server message"
 	assert.Equal(t, "server message", e.Error())
-
 }
 
 func newTestClient(t *testing.T, handler http.Handler) Synthetics {


### PR DESCRIPTION
Resolves: #605

Note: We'll need to release the Terraform provider with this update to satisfy the parent ticket referenced in #605 