### PR TITLE
fix(dashboards): remove manual changes so code generation works again

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -175,6 +175,23 @@ packages:
         field_type_override: string
         skip_type_create: true
 
+      # These need to be pointers within DashboardWidgetConfigurationInput, so
+      # they can be nullable
+      - name: DashboardAreaWidgetConfigurationInput
+        field_type_override: "*DashboardAreaWidgetConfigurationInput"
+      - name: DashboardBarWidgetConfigurationInput
+        field_type_override: "*DashboardBarWidgetConfigurationInput"
+      - name: DashboardBillboardWidgetConfigurationInput
+        field_type_override: "*DashboardBillboardWidgetConfigurationInput"
+      - name: DashboardLineWidgetConfigurationInput
+        field_type_override: "*DashboardLineWidgetConfigurationInput"
+      - name: DashboardMarkdownWidgetConfigurationInput
+        field_type_override: "*DashboardMarkdownWidgetConfigurationInput"
+      - name: DashboardPieWidgetConfigurationInput
+        field_type_override: "*DashboardPieWidgetConfigurationInput"
+      - name: DashboardTableWidgetConfigurationInput
+        field_type_override: "*DashboardTableWidgetConfigurationInput"
+
       - name: DashboardAlertSeverity
         field_type_override: entities.DashboardAlertSeverity
         skip_type_create: true

--- a/pkg/dashboards/types.go
+++ b/pkg/dashboards/types.go
@@ -166,7 +166,7 @@ type DashboardLineWidgetConfigurationInput struct {
 // DashboardMarkdownWidgetConfigurationInput - Configuration for visualization type 'viz.markdown'
 type DashboardMarkdownWidgetConfigurationInput struct {
 	// Markdown content of the widget
-	Text string `json:"text,omitempty"`
+	Text string `json:"text"`
 }
 
 // DashboardPageInput - Page input


### PR DESCRIPTION
Mad rush to get a fix out, and there was an easy tutone option...  Revert an unnecessary change, and use tutone config to make the required changes.