### PR TITLE
refactor(testhelpers): Remove hard-coded TestAccountID

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,12 @@ during a test run. To run the integration test suite, the following secrets will
 need to be configured:
 
 ``` bash
-NEW_RELIC_API_KEY
 NEW_RELIC_ACCOUNT_ID
+NEW_RELIC_API_KEY
 NEW_RELIC_INSIGHTS_INSERT_KEY
 NEW_RELIC_LICENSE_KEY
 NEW_RELIC_REGION
+NEW_RELIC_TEST_USER_ID
 ```
 
 Optional for debugging (defaults to `debug`):

--- a/pkg/apiaccess/keys_integration_test.go
+++ b/pkg/apiaccess/keys_integration_test.go
@@ -7,11 +7,16 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/newrelic/newrelic-client-go/pkg/testhelpers"
+	mock "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 )
 
 func TestIntegrationAPIAccess_IngestKeys(t *testing.T) {
 	t.Parallel()
+
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
 
 	client := newIntegrationTestClient(t)
 
@@ -19,7 +24,7 @@ func TestIntegrationAPIAccess_IngestKeys(t *testing.T) {
 	createInput := APIAccessCreateInput{
 		Ingest: []APIAccessCreateIngestKeyInput{
 			{
-				AccountID:  testhelpers.TestAccountID,
+				AccountID:  testAccountID,
 				IngestType: "BROWSER",
 				Name:       "test-integration-api-access",
 				Notes:      "This ingest key was created by an integration test.",
@@ -61,10 +66,15 @@ func TestIntegrationAPIAccess_IngestKeys(t *testing.T) {
 func TestIntegrationAPIAccess_UserKeys(t *testing.T) {
 	t.Parallel()
 
-	userID, err := testhelpers.GetTestUserID()
+	userID, err := mock.GetTestUserID()
 	if err != nil {
 		t.Skipf("Skipping `TestIntegrationAPIAccess_UserKeys` integration test due error: %v", err)
 		return
+	}
+
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
 	}
 
 	client := newIntegrationTestClient(t)
@@ -73,7 +83,7 @@ func TestIntegrationAPIAccess_UserKeys(t *testing.T) {
 	createInput := APIAccessCreateInput{
 		User: []APIAccessCreateUserKeyInput{
 			{
-				AccountID: testhelpers.TestAccountID,
+				AccountID: testAccountID,
 				Name:      "test-integration-api-access",
 				Notes:     "This user key was created by an integration test.",
 				UserID:    userID,
@@ -94,7 +104,7 @@ func TestIntegrationAPIAccess_UserKeys(t *testing.T) {
 	// Test: Search
 	searchResult, err := client.SearchAPIAccessKeys(APIAccessKeySearchQuery{
 		Scope: APIAccessKeySearchScope{
-			AccountIDs: []int{testhelpers.TestAccountID},
+			AccountIDs: []int{testAccountID},
 		},
 		Types: []APIAccessKeyType{APIAccessKeyTypeTypes.USER},
 	})
@@ -124,7 +134,7 @@ func TestIntegrationAPIAccess_UserKeys(t *testing.T) {
 }
 
 func newIntegrationTestClient(t *testing.T) APIAccess {
-	tc := testhelpers.NewIntegrationTestConfig(t)
+	tc := mock.NewIntegrationTestConfig(t)
 
 	return New(tc)
 }

--- a/pkg/cloud/cloud_api_integration_test.go
+++ b/pkg/cloud/cloud_api_integration_test.go
@@ -14,6 +14,11 @@ import (
 func TestCloudAccount_Basic(t *testing.T) {
 	t.Parallel()
 
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
 	testARN := os.Getenv("INTEGRATION_TESTING_AWS_ARN")
 	if testARN == "" {
 		t.Skip("an AWS ARN is required to run cloud account tests")
@@ -26,8 +31,8 @@ func TestCloudAccount_Basic(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, linkedAccount := range *getResponse {
-		if linkedAccount.NrAccountId == mock.TestAccountID {
-			a.CloudUnlinkAccount(mock.TestAccountID, []CloudUnlinkAccountsInput{
+		if linkedAccount.NrAccountId == testAccountID {
+			a.CloudUnlinkAccount(testAccountID, []CloudUnlinkAccountsInput{
 				{
 					LinkedAccountId: linkedAccount.ID,
 				},
@@ -36,7 +41,7 @@ func TestCloudAccount_Basic(t *testing.T) {
 	}
 
 	// Link the account
-	linkResponse, err := a.CloudLinkAccount(mock.TestAccountID, CloudLinkCloudAccountsInput{
+	linkResponse, err := a.CloudLinkAccount(testAccountID, CloudLinkCloudAccountsInput{
 		Aws: []CloudAwsLinkAccountInput{
 			{
 				Arn:  testARN,
@@ -53,7 +58,7 @@ func TestCloudAccount_Basic(t *testing.T) {
 
 	var linkedAccountID int
 	for _, linkedAccount := range *getResponse {
-		if linkedAccount.NrAccountId == mock.TestAccountID {
+		if linkedAccount.NrAccountId == testAccountID {
 			linkedAccountID = linkedAccount.ID
 			break
 		}
@@ -62,7 +67,7 @@ func TestCloudAccount_Basic(t *testing.T) {
 
 	// Rename the account
 	newName := "NEW-DTK-NAME"
-	renameResponse, err := a.CloudRenameAccount(mock.TestAccountID, []CloudRenameAccountsInput{
+	renameResponse, err := a.CloudRenameAccount(testAccountID, []CloudRenameAccountsInput{
 		{
 			LinkedAccountId: linkedAccountID,
 			Name:            newName,
@@ -72,7 +77,7 @@ func TestCloudAccount_Basic(t *testing.T) {
 	require.NotNil(t, renameResponse)
 
 	// Unlink the account
-	// unlinkResponse, err := a.CloudUnlinkAccount(mock.TestAccountID, CloudUnlinkAccountsInput{linkedAccountID})
+	// unlinkResponse, err := a.CloudUnlinkAccount(testAccountID, CloudUnlinkAccountsInput{linkedAccountID})
 	// require.NoError(t, err)
 	// require.NotNil(t, unlinkResponse)
 }

--- a/pkg/cloud/example_cloud_account_test.go
+++ b/pkg/cloud/example_cloud_account_test.go
@@ -3,9 +3,9 @@ package cloud
 import (
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/newrelic/newrelic-client-go/pkg/config"
-	mock "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 )
 
 func Example_cloudAccounts() {
@@ -17,6 +17,12 @@ func Example_cloudAccounts() {
 	// Initialize the client.
 	client := New(cfg)
 
+	envAccountID := os.Getenv("NEW_RELIC_ACCOUNT_ID")
+	accountID, err := strconv.Atoi(envAccountID)
+	if err != nil {
+		log.Fatal("must set NEW_RELIC_ACCOUNT_ID")
+	}
+
 	// Get the linked cloud accounts
 	linkedAccounts, err := client.GetLinkedAccounts("aws")
 	if err != nil {
@@ -26,7 +32,7 @@ func Example_cloudAccounts() {
 	log.Printf("linked accounts count: %d", len(*linkedAccounts))
 
 	// Link a cloud account
-	linkResponse, err := client.CloudLinkAccount(mock.TestAccountID, CloudLinkCloudAccountsInput{
+	linkResponse, err := client.CloudLinkAccount(accountID, CloudLinkCloudAccountsInput{
 		Aws: []CloudAwsLinkAccountInput{
 			{
 				Arn:  "arn:aws:iam::12345678:role/MyAWSARN",
@@ -41,7 +47,7 @@ func Example_cloudAccounts() {
 	linkedAccountID := linkResponse.LinkedAccounts[0].ID
 
 	// Rename a linked account
-	_, err = client.CloudRenameAccount(mock.TestAccountID, []CloudRenameAccountsInput{
+	_, err = client.CloudRenameAccount(accountID, []CloudRenameAccountsInput{
 		{
 			LinkedAccountId: linkedAccountID,
 			Name:            "My Renamed Linked AWS Account",
@@ -52,7 +58,7 @@ func Example_cloudAccounts() {
 	}
 
 	// Unlink a linked account
-	_, err = client.CloudUnlinkAccount(mock.TestAccountID, []CloudUnlinkAccountsInput{{linkedAccountID}})
+	_, err = client.CloudUnlinkAccount(accountID, []CloudUnlinkAccountsInput{{linkedAccountID}})
 	if err != nil {
 		log.Fatal("error unlinking linked cloud account:", err)
 	}

--- a/pkg/dashboards/dashboards_api_integration_test.go
+++ b/pkg/dashboards/dashboards_api_integration_test.go
@@ -21,6 +21,11 @@ func newIntegrationTestClient(t *testing.T) Dashboards {
 func TestIntegrationDashboard_Basic(t *testing.T) {
 	t.Parallel()
 
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
 	client := newIntegrationTestClient(t)
 
 	// Test vars
@@ -48,7 +53,7 @@ func TestIntegrationDashboard_Basic(t *testing.T) {
 	}
 
 	// Test: DashboardCreate
-	result, err := client.DashboardCreate(mock.TestAccountID, dashboardInput)
+	result, err := client.DashboardCreate(testAccountID, dashboardInput)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -112,6 +117,11 @@ func TestIntegrationDashboard_Basic(t *testing.T) {
 func TestIntegrationDashboard_LinkedEntities(t *testing.T) {
 	t.Parallel()
 
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
 	client := newIntegrationTestClient(t)
 
 	// Test vars
@@ -139,7 +149,7 @@ func TestIntegrationDashboard_LinkedEntities(t *testing.T) {
 	}
 
 	// Create a dashboard to reference in linked entity GUIDs
-	resultDashA, err := client.DashboardCreate(mock.TestAccountID, dashboardAInput)
+	resultDashA, err := client.DashboardCreate(testAccountID, dashboardAInput)
 	require.NoError(t, err)
 	require.NotNil(t, resultDashA)
 
@@ -159,7 +169,7 @@ func TestIntegrationDashboard_LinkedEntities(t *testing.T) {
 							Bar: &DashboardBarWidgetConfigurationInput{
 								NRQLQueries: []DashboardWidgetNRQLQueryInput{
 									{
-										AccountID: mock.TestAccountID,
+										AccountID: testAccountID,
 										Query:     "FROM Transaction SELECT average(duration) FACET appName",
 									},
 								},
@@ -175,7 +185,7 @@ func TestIntegrationDashboard_LinkedEntities(t *testing.T) {
 	}
 
 	// Test: Create dashboard with a widget that includes `linkedEntityGuids`
-	resultDashB, err := client.DashboardCreate(mock.TestAccountID, dashboardBInput)
+	resultDashB, err := client.DashboardCreate(testAccountID, dashboardBInput)
 
 	require.NoError(t, err)
 	require.NotNil(t, resultDashB)

--- a/pkg/events/events_integration_test.go
+++ b/pkg/events/events_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	nr "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
+	mock "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 )
 
 const (
@@ -54,10 +54,15 @@ var testEvents = []testEventData{
 func TestIntegrationEvents(t *testing.T) {
 	t.Parallel()
 
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
 	client := newIntegrationTestClient(t)
 
 	for _, event := range testEvents {
-		err := client.CreateEvent(nr.TestAccountID, event.Event)
+		err := client.CreateEvent(testAccountID, event.Event)
 		if event.err == nil {
 			assert.NoError(t, err)
 		} else {
@@ -69,9 +74,14 @@ func TestIntegrationEvents(t *testing.T) {
 func TestIntegrationEvents_BatchMode_Timeout(t *testing.T) {
 	t.Parallel()
 
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
 	client := newIntegrationTestClient(t)
 
-	err := client.BatchMode(context.Background(), nr.TestAccountID, BatchConfigTimeout(testBatchTimeout))
+	err = client.BatchMode(context.Background(), testAccountID, BatchConfigTimeout(testBatchTimeout))
 	require.NoError(t, err)
 
 	for _, event := range testEvents {
@@ -87,9 +97,14 @@ func TestIntegrationEvents_BatchMode_Timeout(t *testing.T) {
 func TestIntegrationEvents_BatchMode_Size(t *testing.T) {
 	t.Parallel()
 
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
 	client := newIntegrationTestClient(t)
 
-	err := client.BatchMode(context.Background(), nr.TestAccountID, BatchConfigQueueSize(testBatchSize))
+	err = client.BatchMode(context.Background(), testAccountID, BatchConfigQueueSize(testBatchSize))
 	require.NoError(t, err)
 
 	for _, event := range testEvents {
@@ -120,7 +135,7 @@ func TestIntegrationEvents_marshalEvent(t *testing.T) {
 }
 
 func newIntegrationTestClient(t *testing.T) Events {
-	tc := nr.NewIntegrationTestConfig(t)
+	tc := mock.NewIntegrationTestConfig(t)
 
 	return New(tc)
 }

--- a/pkg/events/example_basic_test.go
+++ b/pkg/events/example_basic_test.go
@@ -5,9 +5,9 @@ package events
 import (
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/newrelic/newrelic-client-go/pkg/config"
-	nr "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 )
 
 func Example_basic() {
@@ -15,6 +15,11 @@ func Example_basic() {
 	// to communicate with the backend API.
 	cfg := config.New()
 	cfg.InsightsInsertKey = os.Getenv("NEW_RELIC_INSIGHTS_INSERT_KEY")
+
+	accountID, err := strconv.Atoi(os.Getenv("NEW_RELIC_ACCOUNT_ID"))
+	if err != nil {
+		log.Fatal("environment variable NEW_RELIC_ACCOUNT_ID required")
+	}
 
 	// Initialize the client.
 	client := New(cfg)
@@ -28,7 +33,7 @@ func Example_basic() {
 	}
 
 	// Post a custom event.
-	if err := client.CreateEvent(nr.TestAccountID, event); err != nil {
+	if err := client.CreateEvent(accountID, event); err != nil {
 		log.Fatal("error posting custom event:", err)
 	}
 }

--- a/pkg/events/example_batch_test.go
+++ b/pkg/events/example_batch_test.go
@@ -6,9 +6,9 @@ import (
 	"context"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/newrelic/newrelic-client-go/pkg/config"
-	nr "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 )
 
 func Example_batch() {
@@ -17,11 +17,17 @@ func Example_batch() {
 	cfg := config.New()
 	cfg.InsightsInsertKey = os.Getenv("NEW_RELIC_INSIGHTS_INSERT_KEY")
 
+	envAccountID := os.Getenv("NEW_RELIC_ACCOUNT_ID")
+	accountID, err := strconv.Atoi(envAccountID)
+	if err != nil {
+		log.Fatal("environment variable NEW_RELIC_ACCOUNT_ID required")
+	}
+
 	// Initialize the client.
 	client := New(cfg)
 
 	// Start batch mode
-	if err := client.BatchMode(context.Background(), nr.TestAccountID); err != nil {
+	if err := client.BatchMode(context.Background(), accountID); err != nil {
 		log.Fatal("error starting batch mode:", err)
 	}
 

--- a/pkg/eventstometrics/eventstometrics_integration_test.go
+++ b/pkg/eventstometrics/eventstometrics_integration_test.go
@@ -7,19 +7,23 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	nr "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
+	mock "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 )
 
 func TestIntegrationEventsToMetrics(t *testing.T) {
 	t.Parallel()
 
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
 	var (
-		rand                = nr.RandSeq(5)
+		rand                = mock.RandSeq(5)
 		testRuleName        = "testRule_" + rand
 		testOtherRuleName   = "testRuleOther_" + rand
 		testRuleDescription = "testRuleDescription"
 		testRuleNrql        = "SELECT uniqueCount(account_id) AS `Transaction.account_id` FROM Transaction FACET appName, name"
-		testAccountID       = nr.TestAccountID
 		testCreateInput     = []EventsToMetricsCreateRuleInput{
 			{
 				AccountID:   testAccountID,
@@ -102,7 +106,7 @@ func TestIntegrationEventsToMetrics(t *testing.T) {
 }
 
 func newIntegrationTestClient(t *testing.T) EventsToMetrics {
-	tc := nr.NewIntegrationTestConfig(t)
+	tc := mock.NewIntegrationTestConfig(t)
 
 	return New(tc)
 }

--- a/pkg/nerdstorage/nerdstorage_integration_test.go
+++ b/pkg/nerdstorage/nerdstorage_integration_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	nr "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
+	mock "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 )
 
 var (
@@ -50,32 +50,37 @@ var (
 func TestIntegrationNerdStorageWithAccountScope(t *testing.T) {
 	t.Parallel()
 
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
 	client := newIntegrationTestClient(t)
 
-	document, err := client.WriteDocumentWithAccountScope(nr.TestAccountID, testWriteInput)
+	document, err := client.WriteDocumentWithAccountScope(testAccountID, testWriteInput)
 	require.NoError(t, err)
 	require.NotNil(t, document)
 
 	testAlternateWriteInput := testWriteInput
 	testAlternateWriteInput.DocumentID = testAlternateDocumentID
 
-	document, err = client.WriteDocumentWithAccountScope(nr.TestAccountID, testAlternateWriteInput)
+	document, err = client.WriteDocumentWithAccountScope(testAccountID, testAlternateWriteInput)
 	require.NoError(t, err)
 	require.NotNil(t, document)
 
-	collection, err := client.GetCollectionWithAccountScope(nr.TestAccountID, testGetCollectionInput)
+	collection, err := client.GetCollectionWithAccountScope(testAccountID, testGetCollectionInput)
 	require.NoError(t, err)
 	require.NotNil(t, collection)
 
-	document, err = client.GetDocumentWithAccountScope(nr.TestAccountID, testGetDocumentInput)
+	document, err = client.GetDocumentWithAccountScope(testAccountID, testGetDocumentInput)
 	require.NoError(t, err)
 	require.NotNil(t, document)
 
-	ok, err := client.DeleteDocumentWithAccountScope(nr.TestAccountID, testDeleteDocumentInput)
+	ok, err := client.DeleteDocumentWithAccountScope(testAccountID, testDeleteDocumentInput)
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	ok, err = client.DeleteCollectionWithAccountScope(nr.TestAccountID, testDeleteCollectionInput)
+	ok, err = client.DeleteCollectionWithAccountScope(testAccountID, testDeleteCollectionInput)
 	require.NoError(t, err)
 	require.True(t, ok)
 }
@@ -147,7 +152,7 @@ func TestIntegrationNerdStorageWithEntityScope(t *testing.T) {
 }
 
 func newIntegrationTestClient(t *testing.T) NerdStorage {
-	tc := nr.NewIntegrationTestConfig(t)
+	tc := mock.NewIntegrationTestConfig(t)
 
 	return New(tc)
 }

--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -8,14 +8,8 @@ import (
 	"time"
 )
 
-const (
-	// DTK Terraform Test Account
-	TestAccountID = 2520528
-)
-
 var (
-	letters    = []rune("abcdefghijklmnopqrstuvwxyz")
-	TestUserID = os.Getenv("NEW_RELIC_TEST_USER_ID")
+	letters = []rune("abcdefghijklmnopqrstuvwxyz")
 )
 
 // RandSeq is used to get a string made up of n random lowercase letters.
@@ -28,14 +22,29 @@ func RandSeq(n int) string {
 	return string(b)
 }
 
+// GetTestUserID returns the integer value for a New Relic user ID from the environment
 func GetTestUserID() (int, error) {
-	userID := os.Getenv("NEW_RELIC_TEST_USER_ID")
+	return getEnvInt("NEW_RELIC_TEST_USER_ID")
+}
 
-	if userID == "" {
-		return 0, fmt.Errorf("failed to get test user ID due to undefined environment variable %s", "NEW_RELIC_TEST_USER_ID")
+// GetTestAccountID returns the integer value for a New Relic Account ID from the environment
+func GetTestAccountID() (int, error) {
+	return getEnvInt("NEW_RELIC_ACCOUNT_ID")
+}
+
+// getEnvInt helper to DRY up the other env get calls for integers
+func getEnvInt(name string) (int, error) {
+	if name == "" {
+		return 0, fmt.Errorf("failed to get environment value, no name specified")
 	}
 
-	n, err := strconv.Atoi(userID)
+	id := os.Getenv(name)
+
+	if id == "" {
+		return 0, fmt.Errorf("failed to get environment value due to undefined environment variable %s", name)
+	}
+
+	n, err := strconv.Atoi(id)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
TestAccountID (among other values) are hard-coded into tests making it difficult for folks to contribute.  This removes `testhelpers.TestAccountID`, and updates all tests to read `NEW_RELIC_ACCOUNT_ID` (via helper functions)