### PR TITLE
(chore) remove omitEmpty from MutingRuleScheduleUpdateInput and MutingRuleUpdateInput.Schedule

### DIFF
--- a/pkg/alerts/muting_rules.go
+++ b/pkg/alerts/muting_rules.go
@@ -121,13 +121,13 @@ type MutingRuleScheduleCreateInput struct {
 
 // MutingRuleScheduleUpdateInput is the time window when the MutingRule should actively mute violations for Update
 type MutingRuleScheduleUpdateInput struct {
-	StartTime        *NaiveDateTime            `json:"startTime,omitempty"`
-	EndTime          *NaiveDateTime            `json:"endTime,omitempty"`
-	TimeZone         *string                   `json:"timeZone,omitempty"`
-	Repeat           *MutingRuleScheduleRepeat `json:"repeat,omitempty"`
-	EndRepeat        *NaiveDateTime            `json:"endRepeat,omitempty"`
-	RepeatCount      *int                      `json:"repeatCount,omitempty"`
-	WeeklyRepeatDays *[]DayOfWeek              `json:"weeklyRepeatDays,omitempty"`
+	StartTime        *NaiveDateTime            `json:"startTime"`
+	EndTime          *NaiveDateTime            `json:"endTime"`
+	TimeZone         *string                   `json:"timeZone"`
+	Repeat           *MutingRuleScheduleRepeat `json:"repeat"`
+	EndRepeat        *NaiveDateTime            `json:"endRepeat"`
+	RepeatCount      *int                      `json:"repeatCount"`
+	WeeklyRepeatDays *[]DayOfWeek              `json:"weeklyRepeatDays"`
 }
 
 // MutingRuleCreateInput is the input for creating muting rules.
@@ -148,7 +148,7 @@ type MutingRuleUpdateInput struct {
 	Description string                         `json:"description,omitempty"`
 	Enabled     bool                           `json:"enabled"`
 	Name        string                         `json:"name,omitempty"`
-	Schedule    *MutingRuleScheduleUpdateInput `json:"schedule,omitempty"`
+	Schedule    *MutingRuleScheduleUpdateInput `json:"schedule"`
 }
 
 // ListMutingRules queries for all muting rules in a given account.


### PR DESCRIPTION
This removes omitEmpty from all of the fields in the mutingRuleScheduleUpdateInput struct.
These fields will be managed as empty by Terraform even omitted from a terraform config.

Removing the omitEmpty tag allows these fields to be nulled if they were set and then removed from a user's terraform config.

Removing this tag from MutingRuleUpdate input allows the entire schedule object to be nulled out if that block is removed from a terraform config.