### PR TITLE
Fix interface unmarshal on empty / null values

### DIFF
--- a/pkg/apiaccess/types.go
+++ b/pkg/apiaccess/types.go
@@ -585,7 +585,8 @@ type APIAccessKeyInterface interface {
 	ImplementsAPIAccessKey()
 }
 
-//yes
+// UnmarshalAPIAccessKeyInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalAPIAccessKeyInterface(b []byte) (*APIAccessKeyInterface, error) {
 	var err error
 
@@ -593,6 +594,11 @@ func UnmarshalAPIAccessKeyInterface(b []byte) (*APIAccessKeyInterface, error) {
 	err = json.Unmarshal(b, &rawMessageAPIAccessKey)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageAPIAccessKey) < 1 {
+		return nil, nil
 	}
 
 	var typeName string
@@ -642,7 +648,8 @@ type APIAccessKeyErrorInterface interface {
 	GetError() error
 }
 
-//yes
+// UnmarshalAPIAccessKeyErrorInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalAPIAccessKeyErrorInterface(b []byte) (*APIAccessKeyErrorInterface, error) {
 	var err error
 
@@ -650,6 +657,11 @@ func UnmarshalAPIAccessKeyErrorInterface(b []byte) (*APIAccessKeyErrorInterface,
 	err = json.Unmarshal(b, &rawMessageAPIAccessKeyError)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageAPIAccessKeyError) < 1 {
+		return nil, nil
 	}
 
 	var typeName string

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -5293,7 +5293,8 @@ type CloudIntegrationInterface interface {
 	ImplementsCloudIntegration()
 }
 
-//yes
+// UnmarshalCloudIntegrationInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, error) {
 	var err error
 
@@ -5301,6 +5302,11 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 	err = json.Unmarshal(b, &rawMessageCloudIntegration)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageCloudIntegration) < 1 {
+		return nil, nil
 	}
 
 	var typeName string
@@ -6369,7 +6375,8 @@ type CloudProviderInterface interface {
 	ImplementsCloudProvider()
 }
 
-//yes
+// UnmarshalCloudProviderInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalCloudProviderInterface(b []byte) (*CloudProviderInterface, error) {
 	var err error
 
@@ -6377,6 +6384,11 @@ func UnmarshalCloudProviderInterface(b []byte) (*CloudProviderInterface, error) 
 	err = json.Unmarshal(b, &rawMessageCloudProvider)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageCloudProvider) < 1 {
+		return nil, nil
 	}
 
 	var typeName string

--- a/pkg/edge/types.go
+++ b/pkg/edge/types.go
@@ -332,7 +332,8 @@ type EdgeEndpointDetailInterface interface {
 	ImplementsEdgeEndpointDetail()
 }
 
-//yes
+// UnmarshalEdgeEndpointDetailInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalEdgeEndpointDetailInterface(b []byte) (*EdgeEndpointDetailInterface, error) {
 	var err error
 
@@ -340,6 +341,11 @@ func UnmarshalEdgeEndpointDetailInterface(b []byte) (*EdgeEndpointDetailInterfac
 	err = json.Unmarshal(b, &rawMessageEdgeEndpointDetail)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageEdgeEndpointDetail) < 1 {
+		return nil, nil
 	}
 
 	var typeName string

--- a/pkg/entities/types.go
+++ b/pkg/entities/types.go
@@ -6191,7 +6191,8 @@ type AlertableEntityInterface interface {
 	ImplementsAlertableEntity()
 }
 
-//yes
+// UnmarshalAlertableEntityInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalAlertableEntityInterface(b []byte) (*AlertableEntityInterface, error) {
 	var err error
 
@@ -6199,6 +6200,11 @@ func UnmarshalAlertableEntityInterface(b []byte) (*AlertableEntityInterface, err
 	err = json.Unmarshal(b, &rawMessageAlertableEntity)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageAlertableEntity) < 1 {
+		return nil, nil
 	}
 
 	var typeName string
@@ -6317,7 +6323,8 @@ type AlertableEntityOutlineInterface interface {
 	ImplementsAlertableEntityOutline()
 }
 
-//yes
+// UnmarshalAlertableEntityOutlineInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalAlertableEntityOutlineInterface(b []byte) (*AlertableEntityOutlineInterface, error) {
 	var err error
 
@@ -6325,6 +6332,11 @@ func UnmarshalAlertableEntityOutlineInterface(b []byte) (*AlertableEntityOutline
 	err = json.Unmarshal(b, &rawMessageAlertableEntityOutline)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageAlertableEntityOutline) < 1 {
+		return nil, nil
 	}
 
 	var typeName string
@@ -6443,7 +6455,8 @@ type ApmBrowserApplicationEntityInterface interface {
 	ImplementsApmBrowserApplicationEntity()
 }
 
-//yes
+// UnmarshalApmBrowserApplicationEntityInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalApmBrowserApplicationEntityInterface(b []byte) (*ApmBrowserApplicationEntityInterface, error) {
 	var err error
 
@@ -6451,6 +6464,11 @@ func UnmarshalApmBrowserApplicationEntityInterface(b []byte) (*ApmBrowserApplica
 	err = json.Unmarshal(b, &rawMessageApmBrowserApplicationEntity)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageApmBrowserApplicationEntity) < 1 {
+		return nil, nil
 	}
 
 	var typeName string
@@ -6489,7 +6507,8 @@ type ApmBrowserApplicationEntityOutlineInterface interface {
 	ImplementsApmBrowserApplicationEntityOutline()
 }
 
-//yes
+// UnmarshalApmBrowserApplicationEntityOutlineInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalApmBrowserApplicationEntityOutlineInterface(b []byte) (*ApmBrowserApplicationEntityOutlineInterface, error) {
 	var err error
 
@@ -6497,6 +6516,11 @@ func UnmarshalApmBrowserApplicationEntityOutlineInterface(b []byte) (*ApmBrowser
 	err = json.Unmarshal(b, &rawMessageApmBrowserApplicationEntityOutline)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageApmBrowserApplicationEntityOutline) < 1 {
+		return nil, nil
 	}
 
 	var typeName string
@@ -6535,7 +6559,8 @@ type CollectionEntityInterface interface {
 	ImplementsCollectionEntity()
 }
 
-//yes
+// UnmarshalCollectionEntityInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalCollectionEntityInterface(b []byte) (*CollectionEntityInterface, error) {
 	var err error
 
@@ -6543,6 +6568,11 @@ func UnmarshalCollectionEntityInterface(b []byte) (*CollectionEntityInterface, e
 	err = json.Unmarshal(b, &rawMessageCollectionEntity)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageCollectionEntity) < 1 {
+		return nil, nil
 	}
 
 	var typeName string
@@ -6588,7 +6618,8 @@ type EntityInterface interface {
 	GetType() string
 }
 
-//yes
+// UnmarshalEntityInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalEntityInterface(b []byte) (*EntityInterface, error) {
 	var err error
 
@@ -6596,6 +6627,11 @@ func UnmarshalEntityInterface(b []byte) (*EntityInterface, error) {
 	err = json.Unmarshal(b, &rawMessageEntity)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageEntity) < 1 {
+		return nil, nil
 	}
 
 	var typeName string
@@ -6781,7 +6817,8 @@ type EntityOutlineInterface interface {
 	GetType() string
 }
 
-//yes
+// UnmarshalEntityOutlineInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalEntityOutlineInterface(b []byte) (*EntityOutlineInterface, error) {
 	var err error
 
@@ -6789,6 +6826,11 @@ func UnmarshalEntityOutlineInterface(b []byte) (*EntityOutlineInterface, error) 
 	err = json.Unmarshal(b, &rawMessageEntityOutline)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageEntityOutline) < 1 {
+		return nil, nil
 	}
 
 	var typeName string
@@ -6967,7 +7009,8 @@ type InfrastructureIntegrationEntityInterface interface {
 	ImplementsInfrastructureIntegrationEntity()
 }
 
-//yes
+// UnmarshalInfrastructureIntegrationEntityInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalInfrastructureIntegrationEntityInterface(b []byte) (*InfrastructureIntegrationEntityInterface, error) {
 	var err error
 
@@ -6975,6 +7018,11 @@ func UnmarshalInfrastructureIntegrationEntityInterface(b []byte) (*Infrastructur
 	err = json.Unmarshal(b, &rawMessageInfrastructureIntegrationEntity)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageInfrastructureIntegrationEntity) < 1 {
+		return nil, nil
 	}
 
 	var typeName string
@@ -7023,7 +7071,8 @@ type InfrastructureIntegrationEntityOutlineInterface interface {
 	ImplementsInfrastructureIntegrationEntityOutline()
 }
 
-//yes
+// UnmarshalInfrastructureIntegrationEntityOutlineInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalInfrastructureIntegrationEntityOutlineInterface(b []byte) (*InfrastructureIntegrationEntityOutlineInterface, error) {
 	var err error
 
@@ -7031,6 +7080,11 @@ func UnmarshalInfrastructureIntegrationEntityOutlineInterface(b []byte) (*Infras
 	err = json.Unmarshal(b, &rawMessageInfrastructureIntegrationEntityOutline)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageInfrastructureIntegrationEntityOutline) < 1 {
+		return nil, nil
 	}
 
 	var typeName string

--- a/pkg/nrdb/types.go
+++ b/pkg/nrdb/types.go
@@ -341,7 +341,8 @@ type SuggestedNRQLQueryInterface interface {
 	ImplementsSuggestedNRQLQuery()
 }
 
-//yes
+// UnmarshalSuggestedNRQLQueryInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func UnmarshalSuggestedNRQLQueryInterface(b []byte) (*SuggestedNRQLQueryInterface, error) {
 	var err error
 
@@ -349,6 +350,11 @@ func UnmarshalSuggestedNRQLQueryInterface(b []byte) (*SuggestedNRQLQueryInterfac
 	err = json.Unmarshal(b, &rawMessageSuggestedNRQLQuery)
 	if err != nil {
 		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageSuggestedNRQLQuery) < 1 {
+		return nil, nil
 	}
 
 	var typeName string

--- a/templates/typegen/types.go.tmpl
+++ b/templates/typegen/types.go.tmpl
@@ -149,7 +149,8 @@ type {{ $interfaceType.Name }}Interface interface{
   {{- end }}
 }
 
-//yes
+// Unmarshal{{ $interfaceType.Name }}Interface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
 func Unmarshal{{ $interfaceType.Name }}Interface(b []byte) (*{{ $interfaceType.Name }}Interface, error) {
   var err error
 
@@ -157,6 +158,11 @@ func Unmarshal{{ $interfaceType.Name }}Interface(b []byte) (*{{ $interfaceType.N
   err = json.Unmarshal(b, &rawMessage{{ $interfaceType.Name }})
   if err != nil {
     return nil, err
+  }
+
+  // Nothing to unmarshal
+  if len(rawMessage{{ $interfaceType.Name }}) < 1 {
+    return nil, nil
   }
 
   var typeName string


### PR DESCRIPTION
Tests are currently broken as the API returns a null value, or `[]` set for part of the CloudIntegrations config on the test account.  Completely valid test case, though we do not check for it thus the tests fail.

* Update template for typegen
* `make generate`