### PR TITLE
feat(alerts): adding id to alertsMutingRulesQuery

### DIFF
--- a/pkg/alerts/muting_rules.go
+++ b/pkg/alerts/muting_rules.go
@@ -271,6 +271,7 @@ const (
 			account(id: $accountID) {
 				alerts {
 					mutingRules {
+						id
 						name
 						description
 						enabled


### PR DESCRIPTION
currently the `alertsMutingRulesQuery` does not include the rule ids, which is needed for the following methods:
- GetMutingRule
- UpdateMutingRule
- DeleteMutingRule