### PR TITLE
feat(alerts): adding id to alertsMutingRulesQuery

### DIFF
--- a/pkg/alerts/muting_rules.go
+++ b/pkg/alerts/muting_rules.go
@@ -271,6 +271,7 @@ const (
 			account(id: $accountID) {
 				alerts {
 					mutingRules {
+						id
 						name
 						description
 						enabled


### PR DESCRIPTION
updating alertsMutingRulesQuery to include ids, which are required to use the other CRUD methods related to muting rules