### PR TITLE
fix(dashboards): Return rawConfiguration on get

### DIFF
--- a/pkg/dashboards/dashboard.go
+++ b/pkg/dashboards/dashboard.go
@@ -85,6 +85,7 @@ const getDashboardEntityQuery = `query ($guid: EntityGuid!) {
           owner { email userId }
           updatedAt
           widgets {
+            rawConfiguration
             configuration {
               area { nrqlQueries { accountId query } }
               bar { nrqlQueries { accountId query } }

--- a/pkg/dashboards/dashboards_api_integration_test.go
+++ b/pkg/dashboards/dashboards_api_integration_test.go
@@ -78,6 +78,8 @@ func TestIntegrationDashboard_Basic(t *testing.T) {
 	require.Equal(t, 1, len(dash.Pages[0].Widgets))
 
 	assert.Equal(t, dashboardInput.Pages[0].Widgets[0].Title, dash.Pages[0].Widgets[0].Title)
+	assert.Equal(t, dashboardInput.Pages[0].Widgets[0].Configuration.Markdown.Text, dash.Pages[0].Widgets[0].Configuration.Markdown.Text)
+	assert.Greater(t, len(dash.Pages[0].Widgets[0].RawConfiguration), 1)
 
 	// Test: DashboardUpdate
 	updatedDashboard := DashboardInput{


### PR DESCRIPTION
There are multiple visualizations, plus config options for the `Configuration` versions that are only available in the `rawConfiguration` field, which we do not currently fetch.

This adds the field to the fetch, and a test to ensure that it's returned.