### PR TITLE
fix(dashboards): return an error.NotFound instead of nil

### DIFF
--- a/pkg/dashboards/dashboard.go
+++ b/pkg/dashboards/dashboard.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
+	"github.com/newrelic/newrelic-client-go/pkg/errors"
 )
 
 // ListDashboardsParams represents a set of filters to be
@@ -56,11 +57,11 @@ func (d *Dashboards) GetDashboardEntity(gUID entities.EntityGUID) (*entities.Das
 		return nil, err
 	}
 
-	if resp.Actor.Entity != nil {
-		return resp.Actor.Entity.(*entities.DashboardEntity), nil
+	if resp.Actor.Entity == nil {
+		return nil, errors.NewNotFound("entity not found. GUID: '" + string(gUID) + "'")
 	}
 
-	return nil, nil
+	return resp.Actor.Entity.(*entities.DashboardEntity), nil
 }
 
 // getDashboardEntityQuery is not auto-generated as tutone does not currently support

--- a/pkg/dashboards/dashboards_api_integration_test.go
+++ b/pkg/dashboards/dashboards_api_integration_test.go
@@ -25,8 +25,9 @@ func TestIntegrationDashboard_Nil(t *testing.T) {
 
 	// Test: GetDashboardEntity
 	dash, err := client.GetDashboardEntity(`bad-guid`)
-	require.NoError(t, err)
-	require.Nil(t, dash)
+	require.NotNil(t, err)
+	assert.EqualError(t, err, `entity not found. GUID: 'bad-guid'`)
+	assert.Nil(t, dash)
 }
 
 func TestIntegrationDashboard_Basic(t *testing.T) {


### PR DESCRIPTION
Should of done this the first time, didn't, now have to back track.

Return that we didn't find it as an error.