### PR TITLE
Allow passing context to apm methods

### DIFF
--- a/pkg/apm/application_instances.go
+++ b/pkg/apm/application_instances.go
@@ -1,6 +1,9 @@
 package apm
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // ApplicationInstanceLinks represents all the links for a New Relic application instance.
 type ApplicationInstanceLinks struct {
@@ -30,13 +33,18 @@ type ListApplicationInstancesParams struct {
 
 // ListApplicationInstances is used to retrieve New Relic application instances.
 func (a *APM) ListApplicationInstances(applicationID int, params *ListApplicationInstancesParams) ([]*ApplicationInstance, error) {
+	return a.ListApplicationInstancesWithContext(context.Background(), applicationID, params)
+}
+
+// ListApplicationInstancesWithContext is used to retrieve New Relic application instances.
+func (a *APM) ListApplicationInstancesWithContext(ctx context.Context, applicationID int, params *ListApplicationInstancesParams) ([]*ApplicationInstance, error) {
 	instances := []*ApplicationInstance{}
 	url := fmt.Sprintf("/applications/%d/instances.json", applicationID)
 	nextURL := a.config.Region().RestURL(url)
 
 	for nextURL != "" {
 		response := applicationInstancesResponse{}
-		resp, err := a.client.Get(nextURL, &params, &response)
+		resp, err := a.client.GetWithContext(ctx, nextURL, &params, &response)
 
 		if err != nil {
 			return nil, err
@@ -53,10 +61,15 @@ func (a *APM) ListApplicationInstances(applicationID int, params *ListApplicatio
 
 // GetApplicationInstance is used to retrieve a specific New Relic application instance.
 func (a *APM) GetApplicationInstance(applicationID int, instanceID int) (*ApplicationInstance, error) {
+	return a.GetApplicationInstanceWithContext(context.Background(), applicationID, instanceID)
+}
+
+// GetApplicationInstanceWithContext is used to retrieve a specific New Relic application instance.
+func (a *APM) GetApplicationInstanceWithContext(ctx context.Context, applicationID int, instanceID int) (*ApplicationInstance, error) {
 	response := applicationInstanceResponse{}
 	url := fmt.Sprintf("/applications/%d/instances/%d.json", applicationID, instanceID)
 
-	_, err := a.client.Get(a.config.Region().RestURL(url), nil, &response)
+	_, err := a.client.GetWithContext(ctx, a.config.Region().RestURL(url), nil, &response)
 
 	if err != nil {
 		return nil, err

--- a/pkg/apm/applications.go
+++ b/pkg/apm/applications.go
@@ -1,5 +1,7 @@
 package apm
 
+import "context"
+
 // ApplicationsInterface interface should be refactored to be a global interface for fetching NR type things
 type ApplicationsInterface interface {
 	find(accountID int, name string) (*Application, error)
@@ -85,7 +87,7 @@ func (a *APM) ListApplications(params *ListApplicationsParams) ([]*Application, 
 		parent: a,
 	}
 
-	return method.list(accountID, params)
+	return method.list(context.Background(), accountID, params)
 }
 
 // GetApplication is used to retrieve a single New Relic application.
@@ -95,7 +97,7 @@ func (a *APM) GetApplication(applicationID int) (*Application, error) {
 		parent: a,
 	}
 
-	return method.get(accountID, applicationID)
+	return method.get(context.Background(), accountID, applicationID)
 }
 
 // UpdateApplication is used to update a New Relic application's name and/or settings.
@@ -105,7 +107,7 @@ func (a *APM) UpdateApplication(applicationID int, params UpdateApplicationParam
 		parent: a,
 	}
 
-	return method.update(accountID, applicationID, params)
+	return method.update(context.Background(), accountID, applicationID, params)
 }
 
 // DeleteApplication is used to delete a New Relic application.
@@ -116,5 +118,5 @@ func (a *APM) DeleteApplication(applicationID int) (*Application, error) {
 		parent: a,
 	}
 
-	return method.remove(accountID, applicationID)
+	return method.remove(context.Background(), accountID, applicationID)
 }

--- a/pkg/apm/applications.go
+++ b/pkg/apm/applications.go
@@ -81,42 +81,63 @@ type UpdateApplicationParams struct {
 
 // ListApplications is used to retrieve New Relic applications.
 func (a *APM) ListApplications(params *ListApplicationsParams) ([]*Application, error) {
+	return a.ListApplicationsWithContext(context.Background(), params)
+}
+
+// ListApplicationsWithContext is used to retrieve New Relic applications.
+func (a *APM) ListApplicationsWithContext(ctx context.Context, params *ListApplicationsParams) ([]*Application, error) {
 	accountID := 0
 
 	method := applicationsREST{
 		parent: a,
 	}
 
-	return method.list(context.Background(), accountID, params)
+	return method.list(ctx, accountID, params)
 }
 
 // GetApplication is used to retrieve a single New Relic application.
 func (a *APM) GetApplication(applicationID int) (*Application, error) {
+	return a.GetApplicationWithContext(context.Background(), applicationID)
+}
+
+// GetApplicationWithContext is used to retrieve a single New Relic application.
+func (a *APM) GetApplicationWithContext(ctx context.Context, applicationID int) (*Application, error) {
 	accountID := 0
 	method := applicationsREST{
 		parent: a,
 	}
 
-	return method.get(context.Background(), accountID, applicationID)
+	return method.get(ctx, accountID, applicationID)
 }
 
 // UpdateApplication is used to update a New Relic application's name and/or settings.
 func (a *APM) UpdateApplication(applicationID int, params UpdateApplicationParams) (*Application, error) {
+	return a.UpdateApplicationWithContext(context.Background(), applicationID, params)
+}
+
+// UpdateApplicationWithContext is used to update a New Relic application's name and/or settings.
+func (a *APM) UpdateApplicationWithContext(ctx context.Context, applicationID int, params UpdateApplicationParams) (*Application, error) {
 	accountID := 0
 	method := applicationsREST{
 		parent: a,
 	}
 
-	return method.update(context.Background(), accountID, applicationID, params)
+	return method.update(ctx, accountID, applicationID, params)
 }
 
 // DeleteApplication is used to delete a New Relic application.
 // This process will only succeed if the application is no longer reporting data.
 func (a *APM) DeleteApplication(applicationID int) (*Application, error) {
+	return a.DeleteApplicationWithContext(context.Background(), applicationID)
+}
+
+// DeleteApplicationWithContext is used to delete a New Relic application.
+// This process will only succeed if the application is no longer reporting data.
+func (a *APM) DeleteApplicationWithContext(ctx context.Context, applicationID int) (*Application, error) {
 	accountID := 0
 	method := applicationsREST{
 		parent: a,
 	}
 
-	return method.remove(context.Background(), accountID, applicationID)
+	return method.remove(ctx, accountID, applicationID)
 }

--- a/pkg/apm/applications_metrics.go
+++ b/pkg/apm/applications_metrics.go
@@ -1,6 +1,7 @@
 package apm
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"time"
@@ -82,12 +83,19 @@ func (m *MetricTimesliceValues) UnmarshalJSON(b []byte) error {
 //
 // https://rpm.newrelic.com/api/explore/applications/metric_names
 func (a *APM) GetMetricNames(applicationID int, params MetricNamesParams) ([]*MetricName, error) {
+	return a.GetMetricNamesWithContext(context.Background(), applicationID, params)
+}
+
+// GetMetricNamesWithContext is used to retrieve a list of known metrics and their value names for the given resource.
+//
+// https://rpm.newrelic.com/api/explore/applications/metric_names
+func (a *APM) GetMetricNamesWithContext(ctx context.Context, applicationID int, params MetricNamesParams) ([]*MetricName, error) {
 	nextURL := a.config.Region().RestURL("applications", strconv.Itoa(applicationID), "metrics.json")
 	response := metricNamesResponse{}
 	metrics := []*MetricName{}
 
 	for nextURL != "" {
-		resp, err := a.client.Get(nextURL, &params, &response)
+		resp, err := a.client.GetWithContext(ctx, nextURL, &params, &response)
 
 		if err != nil {
 			return nil, err
@@ -106,13 +114,20 @@ func (a *APM) GetMetricNames(applicationID int, params MetricNamesParams) ([]*Me
 //
 // https://rpm.newrelic.com/api/explore/applications/metric_data
 func (a *APM) GetMetricData(applicationID int, params MetricDataParams) ([]*MetricData, error) {
+	return a.GetMetricDataWithContext(context.Background(), applicationID, params)
+}
+
+// GetMetricDataWithContext is used to retrieve a list of values for each of the requested metrics.
+//
+// https://rpm.newrelic.com/api/explore/applications/metric_data
+func (a *APM) GetMetricDataWithContext(ctx context.Context, applicationID int, params MetricDataParams) ([]*MetricData, error) {
 	nextURL := a.config.Region().RestURL("applications", strconv.Itoa(applicationID), "/metrics/data.json")
 
 	response := metricDataResponse{}
 	data := []*MetricData{}
 
 	for nextURL != "" {
-		resp, err := a.client.Get(nextURL, &params, &response)
+		resp, err := a.client.GetWithContext(ctx, nextURL, &params, &response)
 
 		if err != nil {
 			return nil, err

--- a/pkg/apm/applications_rest.go
+++ b/pkg/apm/applications_rest.go
@@ -32,16 +32,6 @@ func (a *applicationsREST) list(ctx context.Context, accountID int, params *List
 	return apps, nil
 }
 
-// find looks for an account / application name combination and returns the result
-func (a *applicationsREST) find(ctx context.Context, accountID int, name string) (*Application, error) {
-	return nil, fmt.Errorf("find application is not implemented")
-}
-
-// create application is not implemented in the API
-func (a *applicationsREST) create(ctx context.Context, accountID int, name string) (*Application, error) {
-	return nil, fmt.Errorf("create application is not implemented")
-}
-
 // get is used to retrieve a single New Relic application.
 func (a *applicationsREST) get(ctx context.Context, accountID int, applicationID int) (*Application, error) {
 	response := applicationResponse{}

--- a/pkg/apm/applications_rest.go
+++ b/pkg/apm/applications_rest.go
@@ -1,6 +1,7 @@
 package apm
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -10,13 +11,13 @@ type applicationsREST struct {
 }
 
 // list is used to retrieve New Relic applications.
-func (a *applicationsREST) list(accountID int, params *ListApplicationsParams) ([]*Application, error) {
+func (a *applicationsREST) list(ctx context.Context, accountID int, params *ListApplicationsParams) ([]*Application, error) {
 	apps := []*Application{}
 	nextURL := a.parent.config.Region().RestURL("applications.json")
 
 	for nextURL != "" {
 		response := applicationsResponse{}
-		resp, err := a.parent.client.Get(nextURL, &params, &response)
+		resp, err := a.parent.client.GetWithContext(ctx, nextURL, &params, &response)
 
 		if err != nil {
 			return nil, err
@@ -32,21 +33,21 @@ func (a *applicationsREST) list(accountID int, params *ListApplicationsParams) (
 }
 
 // find looks for an account / application name combination and returns the result
-func (a *applicationsREST) find(accountID int, name string) (*Application, error) {
+func (a *applicationsREST) find(ctx context.Context, accountID int, name string) (*Application, error) {
 	return nil, fmt.Errorf("find application is not implemented")
 }
 
 // create application is not implemented in the API
-func (a *applicationsREST) create(accountID int, name string) (*Application, error) {
+func (a *applicationsREST) create(ctx context.Context, accountID int, name string) (*Application, error) {
 	return nil, fmt.Errorf("create application is not implemented")
 }
 
 // get is used to retrieve a single New Relic application.
-func (a *applicationsREST) get(accountID int, applicationID int) (*Application, error) {
+func (a *applicationsREST) get(ctx context.Context, accountID int, applicationID int) (*Application, error) {
 	response := applicationResponse{}
 	url := fmt.Sprintf("/applications/%d.json", applicationID)
 
-	_, err := a.parent.client.Get(a.parent.config.Region().RestURL(url), nil, &response)
+	_, err := a.parent.client.GetWithContext(ctx, a.parent.config.Region().RestURL(url), nil, &response)
 
 	if err != nil {
 		return nil, err
@@ -56,14 +57,14 @@ func (a *applicationsREST) get(accountID int, applicationID int) (*Application, 
 }
 
 // update is used to update a New Relic application's name and/or settings.
-func (a *applicationsREST) update(accountID int, applicationID int, params UpdateApplicationParams) (*Application, error) {
+func (a *applicationsREST) update(ctx context.Context, accountID int, applicationID int, params UpdateApplicationParams) (*Application, error) {
 	response := applicationResponse{}
 	reqBody := updateApplicationRequest{
 		Fields: updateApplicationFields(params),
 	}
 	url := fmt.Sprintf("/applications/%d.json", applicationID)
 
-	_, err := a.parent.client.Put(a.parent.config.Region().RestURL(url), nil, &reqBody, &response)
+	_, err := a.parent.client.PutWithContext(ctx, a.parent.config.Region().RestURL(url), nil, &reqBody, &response)
 
 	if err != nil {
 		return nil, err
@@ -74,11 +75,11 @@ func (a *applicationsREST) update(accountID int, applicationID int, params Updat
 
 // remove is used to delete a New Relic application.
 // This process will only succeed if the application is no longer reporting data.
-func (a *applicationsREST) remove(accountID int, applicationID int) (*Application, error) {
+func (a *applicationsREST) remove(ctx context.Context, accountID int, applicationID int) (*Application, error) {
 	response := applicationResponse{}
 	url := fmt.Sprintf("/applications/%d.json", applicationID)
 
-	_, err := a.parent.client.Delete(a.parent.config.Region().RestURL(url), nil, &response)
+	_, err := a.parent.client.DeleteWithContext(ctx, a.parent.config.Region().RestURL(url), nil, &response)
 
 	if err != nil {
 		return nil, err

--- a/pkg/apm/deployments.go
+++ b/pkg/apm/deployments.go
@@ -1,6 +1,7 @@
 package apm
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -25,6 +26,11 @@ type DeploymentLinks struct {
 
 // ListDeployments returns deployments for an application.
 func (a *APM) ListDeployments(applicationID int) ([]*Deployment, error) {
+	return a.ListDeploymentsWithContext(context.Background(), applicationID)
+}
+
+// ListDeploymentsWithContext returns deployments for an application.
+func (a *APM) ListDeploymentsWithContext(ctx context.Context, applicationID int) ([]*Deployment, error) {
 	deployments := []*Deployment{}
 	nextURL := a.config.Region().RestURL("applications", strconv.Itoa(applicationID), "deployments.json")
 
@@ -35,6 +41,7 @@ func (a *APM) ListDeployments(applicationID int) ([]*Deployment, error) {
 			return nil, err
 		}
 
+		req.WithContext(ctx)
 		req.SetAuthStrategy(&http.PersonalAPIKeyCapableV2Authorizer{})
 
 		resp, err := a.client.Do(req)
@@ -54,6 +61,11 @@ func (a *APM) ListDeployments(applicationID int) ([]*Deployment, error) {
 
 // CreateDeployment creates a deployment marker for an application.
 func (a *APM) CreateDeployment(applicationID int, deployment Deployment) (*Deployment, error) {
+	return a.CreateDeploymentWithContext(context.Background(), applicationID, deployment)
+}
+
+// CreateDeploymentWithContext creates a deployment marker for an application.
+func (a *APM) CreateDeploymentWithContext(ctx context.Context, applicationID int, deployment Deployment) (*Deployment, error) {
 	reqBody := deploymentRequestBody{
 		Deployment: deployment,
 	}
@@ -65,6 +77,7 @@ func (a *APM) CreateDeployment(applicationID int, deployment Deployment) (*Deplo
 		return nil, err
 	}
 
+	req.WithContext(ctx)
 	req.SetAuthStrategy(&http.PersonalAPIKeyCapableV2Authorizer{})
 
 	_, err = a.client.Do(req)
@@ -78,6 +91,11 @@ func (a *APM) CreateDeployment(applicationID int, deployment Deployment) (*Deplo
 
 // DeleteDeployment deletes a deployment marker for an application.
 func (a *APM) DeleteDeployment(applicationID int, deploymentID int) (*Deployment, error) {
+	return a.DeleteDeploymentWithContext(context.Background(), applicationID, deploymentID)
+}
+
+// DeleteDeploymentWithContext deletes a deployment marker for an application.
+func (a *APM) DeleteDeploymentWithContext(ctx context.Context, applicationID int, deploymentID int) (*Deployment, error) {
 	resp := deploymentResponse{}
 	url := a.config.Region().RestURL("applications", strconv.Itoa(applicationID), "deployments", fmt.Sprintf("%d.json", deploymentID))
 
@@ -86,6 +104,7 @@ func (a *APM) DeleteDeployment(applicationID int, deploymentID int) (*Deployment
 		return nil, err
 	}
 
+	req.WithContext(ctx)
 	req.SetAuthStrategy(&http.PersonalAPIKeyCapableV2Authorizer{})
 
 	_, err = a.client.Do(req)

--- a/pkg/apm/key_transactions.go
+++ b/pkg/apm/key_transactions.go
@@ -1,6 +1,7 @@
 package apm
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -31,12 +32,17 @@ type ListKeyTransactionsParams struct {
 
 // ListKeyTransactions returns all key transactions for an account.
 func (a *APM) ListKeyTransactions(params *ListKeyTransactionsParams) ([]*KeyTransaction, error) {
+	return a.ListKeyTransactionsWithContext(context.Background(), params)
+}
+
+// ListKeyTransactionsWithContext returns all key transactions for an account.
+func (a *APM) ListKeyTransactionsWithContext(ctx context.Context, params *ListKeyTransactionsParams) ([]*KeyTransaction, error) {
 	results := []*KeyTransaction{}
 	nextURL := a.config.Region().RestURL("key_transactions.json")
 
 	for nextURL != "" {
 		response := keyTransactionsResponse{}
-		resp, err := a.client.Get(nextURL, &params, &response)
+		resp, err := a.client.GetWithContext(ctx, nextURL, &params, &response)
 
 		if err != nil {
 			return nil, err
@@ -53,10 +59,15 @@ func (a *APM) ListKeyTransactions(params *ListKeyTransactionsParams) ([]*KeyTran
 
 // GetKeyTransaction returns a specific key transaction by ID.
 func (a *APM) GetKeyTransaction(id int) (*KeyTransaction, error) {
+	return a.GetKeyTransactionWithContext(context.Background(), id)
+}
+
+// GetKeyTransactionWithContext returns a specific key transaction by ID.
+func (a *APM) GetKeyTransactionWithContext(ctx context.Context, id int) (*KeyTransaction, error) {
 	response := keyTransactionResponse{}
 	url := fmt.Sprintf("/key_transactions/%d.json", id)
 
-	_, err := a.client.Get(a.config.Region().RestURL(url), nil, &response)
+	_, err := a.client.GetWithContext(ctx, a.config.Region().RestURL(url), nil, &response)
 
 	if err != nil {
 		return nil, err

--- a/pkg/apm/labels.go
+++ b/pkg/apm/labels.go
@@ -1,6 +1,8 @@
 package apm
 
 import (
+	"context"
+
 	"github.com/newrelic/newrelic-client-go/pkg/errors"
 )
 
@@ -20,12 +22,17 @@ type LabelLinks struct {
 
 // ListLabels returns the labels within an account.
 func (a *APM) ListLabels() ([]*Label, error) {
+	return a.ListLabelsWithContext(context.Background())
+}
+
+// ListLabelsWithContext returns the labels within an account.
+func (a *APM) ListLabelsWithContext(ctx context.Context) ([]*Label, error) {
 	labels := []*Label{}
 	nextURL := a.config.Region().RestURL("labels.json")
 
 	for nextURL != "" {
 		response := labelsResponse{}
-		resp, err := a.client.Get(nextURL, nil, &response)
+		resp, err := a.client.GetWithContext(ctx, nextURL, nil, &response)
 
 		if err != nil {
 			return nil, err
@@ -43,7 +50,13 @@ func (a *APM) ListLabels() ([]*Label, error) {
 // GetLabel gets a label by key. A label's key
 // is a string hash formatted as <Category>:<Name>.
 func (a *APM) GetLabel(key string) (*Label, error) {
-	labels, err := a.ListLabels()
+	return a.GetLabelWithContext(context.Background(), key)
+}
+
+// GetLabelWithContext gets a label by key. A label's key
+// is a string hash formatted as <Category>:<Name>.
+func (a *APM) GetLabelWithContext(ctx context.Context, key string) (*Label, error) {
+	labels, err := a.ListLabelsWithContext(ctx)
 
 	if err != nil {
 		return nil, err
@@ -60,13 +73,18 @@ func (a *APM) GetLabel(key string) (*Label, error) {
 
 // CreateLabel creates a new label within an account.
 func (a *APM) CreateLabel(label Label) (*Label, error) {
+	return a.CreateLabelWithContext(context.Background(), label)
+}
+
+// CreateLabelWithContext creates a new label within an account.
+func (a *APM) CreateLabelWithContext(ctx context.Context, label Label) (*Label, error) {
 	reqBody := labelRequestBody{
 		Label: label,
 	}
 	resp := labelResponse{}
 
 	// The API currently uses a PUT request for label creation
-	_, err := a.client.Put(a.config.Region().RestURL("labels.json"), nil, &reqBody, &resp)
+	_, err := a.client.PutWithContext(ctx, a.config.Region().RestURL("labels.json"), nil, &reqBody, &resp)
 
 	if err != nil {
 		return nil, err
@@ -78,9 +96,15 @@ func (a *APM) CreateLabel(label Label) (*Label, error) {
 // DeleteLabel deletes a label by key. A label's key
 // is a string hash formatted as <Category>:<Name>.
 func (a *APM) DeleteLabel(key string) (*Label, error) {
+	return a.DeleteLabelWithContext(context.Background(), key)
+}
+
+// DeleteLabelWithContext deletes a label by key. A label's key
+// is a string hash formatted as <Category>:<Name>.
+func (a *APM) DeleteLabelWithContext(ctx context.Context, key string) (*Label, error) {
 	resp := labelResponse{}
 
-	_, err := a.client.Delete(a.config.Region().RestURL("labels", key+".json"), nil, &resp)
+	_, err := a.client.DeleteWithContext(ctx, a.config.Region().RestURL("labels", key+".json"), nil, &resp)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hello

As discussed [here](https://github.com/newrelic/newrelic-client-go/issues/721), this PR adds a version of all APM methods that accepts a context parameter.

I did not add a version for applicationsREST internal functions because, well, they are internal.

Thanks!