### PR TITLE
Fix tutone generation

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -205,7 +205,6 @@ packages:
         field_type_override: "*DashboardBarWidgetConfigurationInput"
       - name: DashboardBillboardWidgetConfigurationInput
         field_type_override: "*DashboardBillboardWidgetConfigurationInput"
-        skip_type_create: true
       - name: DashboardLineWidgetConfigurationInput
         field_type_override: "*DashboardLineWidgetConfigurationInput"
       - name: DashboardMarkdownWidgetConfigurationInput
@@ -214,6 +213,10 @@ packages:
         field_type_override: "*DashboardPieWidgetConfigurationInput"
       - name: DashboardTableWidgetConfigurationInput
         field_type_override: "*DashboardTableWidgetConfigurationInput"
+
+      # Override this in type_overrides.go
+      - name: DashboardBillboardWidgetThresholdInput
+        skip_type_create: true
 
       #
       # Types that we should auto-detect are in another package someday

--- a/pkg/dashboards/dashboards_api.go
+++ b/pkg/dashboards/dashboards_api.go
@@ -5,7 +5,6 @@ import (
 	"context"
 
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
-	"github.com/newrelic/newrelic-client-go/pkg/errors"
 )
 
 // Create a `DashboardEntity`
@@ -34,14 +33,6 @@ func (a *Dashboards) DashboardCreateWithContext(
 
 	if err := a.client.NerdGraphQueryWithContext(ctx, DashboardCreateMutation, vars, &resp); err != nil {
 		return nil, err
-	}
-
-	if len(resp.DashboardCreateResult.Errors) > 0 {
-		for _, err := range resp.DashboardCreateResult.Errors {
-			if err.Type == DashboardCreateErrorTypeTypes.INVALID_INPUT {
-				return nil, errors.NewInvalidInput(err.Description)
-			}
-		}
 	}
 
 	return &resp.DashboardCreateResult, nil

--- a/pkg/dashboards/dashboards_api.go
+++ b/pkg/dashboards/dashboards_api.go
@@ -3,6 +3,7 @@ package dashboards
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
 )
@@ -33,6 +34,15 @@ func (a *Dashboards) DashboardCreateWithContext(
 
 	if err := a.client.NerdGraphQueryWithContext(ctx, DashboardCreateMutation, vars, &resp); err != nil {
 		return nil, err
+	}
+
+	// If we got errors back, wrap them all up
+	if len(resp.DashboardCreateResult.Errors) > 0 {
+		errs := fmt.Errorf("query error")
+		for _, err := range resp.DashboardCreateResult.Errors {
+			errs = fmt.Errorf("%w; %s", errs, err.Description)
+		}
+		return nil, errs
 	}
 
 	return &resp.DashboardCreateResult, nil
@@ -496,6 +506,15 @@ func (a *Dashboards) DashboardDeleteWithContext(
 		return nil, err
 	}
 
+	// If we got errors back, wrap them all up
+	if len(resp.DashboardDeleteResult.Errors) > 0 {
+		errs := fmt.Errorf("query error")
+		for _, err := range resp.DashboardDeleteResult.Errors {
+			errs = fmt.Errorf("%w; %s", errs, err.Description)
+		}
+		return nil, errs
+	}
+
 	return &resp.DashboardDeleteResult, nil
 }
 
@@ -541,6 +560,15 @@ func (a *Dashboards) DashboardUpdateWithContext(
 
 	if err := a.client.NerdGraphQueryWithContext(ctx, DashboardUpdateMutation, vars, &resp); err != nil {
 		return nil, err
+	}
+
+	// If we got errors back, wrap them all up
+	if len(resp.DashboardUpdateResult.Errors) > 0 {
+		errs := fmt.Errorf("query error")
+		for _, err := range resp.DashboardUpdateResult.Errors {
+			errs = fmt.Errorf("%w; %s", errs, err.Description)
+		}
+		return nil, errs
 	}
 
 	return &resp.DashboardUpdateResult, nil

--- a/pkg/dashboards/dashboards_api_integration_test.go
+++ b/pkg/dashboards/dashboards_api_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
-	"github.com/newrelic/newrelic-client-go/pkg/errors"
 	mock "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 )
 
@@ -260,6 +259,4 @@ func TestIntegrationDashboard_InvalidInput(t *testing.T) {
 
 	require.Nil(t, dash)
 	require.Error(t, err)
-	_, ok := err.(*errors.InvalidInput)
-	assert.True(t, ok)
 }

--- a/pkg/dashboards/types.go
+++ b/pkg/dashboards/types.go
@@ -376,8 +376,3 @@ type DashboardWidgetVisualizationInput struct {
 	// Nerdpack artifact ID
 	ID string `json:"id,omitempty"`
 }
-
-// Float - The `Float` scalar type represents signed double-precision fractional
-// values as specified by
-// [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
-type Float string

--- a/templates/nerdgraphclient/client.go.tmpl
+++ b/templates/nerdgraphclient/client.go.tmpl
@@ -2,13 +2,12 @@
 package {{.PackageName | lower}}
 {{$packageName := .PackageName}}
 
-{{- if gt (len .Imports) 0 }}
 import(
+  "fmt"
   {{- range .Imports}}
   "{{.}}"
   {{- end}}
 )
-{{- end}}
 
 {{range .Mutations}}
 {{/*
@@ -49,6 +48,15 @@ func (a *{{$packageName|title}}) {{.Name | title}}WithContext(
 	if err := a.client.NerdGraphQueryWithContext(ctx, {{.Name}}Mutation, vars, &resp); err != nil {
 		return nil, err
 	}
+
+  // If we got errors back, wrap them all up
+  if len(resp.{{.Name}}Result.Errors) > 0 {
+    errs := fmt.Errorf("query error")
+    for _, err := range resp.{{.Name}}Result.Errors {
+      errs = fmt.Errorf("%w; %s", errs, err.Description)
+    }
+    return nil, errs
+  }
 
 	return &resp.{{first .Signature.Return}}, nil
 }

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/client9/misspell v0.3.4
-	github.com/git-chglog/git-chglog v0.14.2
+	github.com/git-chglog/git-chglog v0.15.0
 	github.com/golangci/golangci-lint v1.41.1
 	github.com/goreleaser/goreleaser v0.173.2
 	github.com/llorllale/go-gitlint v0.0.0-20210608233938-d6303cc52cc5

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -57,8 +57,8 @@ contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EU
 contrib.go.opencensus.io/exporter/stackdriver v0.13.5/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
 contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/AlecAivazis/survey/v2 v2.2.9 h1:LWvJtUswz/W9/zVVXELrmlvdwWcKE60ZAw0FWV9vssk=
-github.com/AlecAivazis/survey/v2 v2.2.9/go.mod h1:9DYvHgXtiXm6nCn+jXnOXLKbH+Yo9u8fAS/SduGdoPk=
+github.com/AlecAivazis/survey/v2 v2.2.14 h1:aTYTaCh1KLd+YWilkeJ65Ph78g48NVQ3ay9xmaNIyhk=
+github.com/AlecAivazis/survey/v2 v2.2.14/go.mod h1:TH2kPCDU3Kqq7pLbnCWwZXDBjnhZtmsCle5EiYDJ2fg=
 github.com/AlekSi/pointer v1.1.0 h1:SSDMPcXD9jSl8FPy9cRzoRaMJtm9g9ggGTxecRUbQoI=
 github.com/AlekSi/pointer v1.1.0/go.mod h1:y7BvfRI3wXPWKXEBhU71nbnIEEZX0QTSB2Bj48UJIZE=
 github.com/Azure/azure-amqp-common-go/v3 v3.1.0/go.mod h1:PBIGdzcO1teYoufTKMcGibdKaYZv4avS+O6LNIp8bq0=
@@ -311,8 +311,8 @@ github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASx
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
-github.com/git-chglog/git-chglog v0.14.2 h1:nx84X23vc0eLCYfNX+EmuaqvVUb3mvjKdW9fcC3eJWs=
-github.com/git-chglog/git-chglog v0.14.2/go.mod h1:QYJ8Ctd/bMkNX3R+AyZf2x0iF6InIZ6xEOqCOldbAOQ=
+github.com/git-chglog/git-chglog v0.15.0 h1:Pdj7QRIzwmyfAYd88mBphZHLDBZOsYiJn4Ptu3r+jYU=
+github.com/git-chglog/git-chglog v0.15.0/go.mod h1:wyyMv2ae72ybG7tmN96sehVL9eLea75m0IuxTj744gk=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
@@ -1238,7 +1238,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190530182044-ad28b68e88f1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1299,8 +1298,9 @@ golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56 h1:b8jxX3zqjpqb2LklXPzKSGJhzyxCOZSz8ncv8Nv+y7w=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
When resolving an issue with billboard input, a type was skipped that is needed.  Update the tutone config to generate the old type, and skip the overridden type.  [Reference](https://github.com/newrelic/newrelic-client-go/commit/c84c84690fd363ecf0b7fa6074359ebc9af4c803#diff-c8fb5f06f26ca2ea1554da789ba1914c18e334991add8cbd66482c4568907a17R208)