### PR TITLE
fix: type for validation duration

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -586,7 +586,7 @@ packages:
         field_type_override: nrtime.EpochMilliseconds
         skip_type_create: true
       - name: EpochMilliseconds
-        field_type_override: nrtime.EpochMilliseconds
+        field_type_override: int64
         skip_type_create: true
       - name: EpochSeconds
         field_type_override: nrtime.EpochSeconds

--- a/pkg/installevents/types.go
+++ b/pkg/installevents/types.go
@@ -84,7 +84,7 @@ type InstallationRecipeEvent struct {
 	// The timestamp for when the recipe event occurred.
 	Timestamp nrtime.EpochSeconds `json:"timestamp"`
 	// The number of milliseconds it took to validate the recipe.
-	ValidationDurationMilliseconds nrtime.EpochMilliseconds `json:"validationDurationMilliseconds"`
+	ValidationDurationMilliseconds int64 `json:"validationDurationMilliseconds"`
 }
 
 // InstallationRecipeStatus - An object that represents a recipe status.
@@ -124,7 +124,7 @@ type InstallationRecipeStatus struct {
 	// Whether or not the recipe being installed is a targeted install.
 	TargetedInstall bool `json:"targetedInstall"`
 	// The number of milliseconds it took to validate the recipe.
-	ValidationDurationMilliseconds nrtime.EpochMilliseconds `json:"validationDurationMilliseconds"`
+	ValidationDurationMilliseconds int64 `json:"validationDurationMilliseconds"`
 }
 
 // InstallationStatusError - An object that represents a status error whenever an recipe has failed to install.


### PR DESCRIPTION
## Context

For the new install-events-service, we want to override `EpochMilliseconds` to `int64` as the serialization in the client is giving us some headache. This should take care of the unsupported type problems we've been seeing when running the `newrelic-cli` with this branch of the client.