### PR TITLE
fix(release): use --tag-mode all-branches for version bump

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,8 +13,8 @@ REL_CMD=${GOBIN}/goreleaser
 RELEASE_NOTES_FILE=${SRCDIR}/tmp/relnotes.md
 
 # Compare versions
-VER_CURR=$(${VER_CMD} current --strip-prefix)
-VER_NEXT=$(${VER_CMD} next --strip-prefix)
+VER_CURR=$(${VER_CMD} current --strip-prefix --tag-mode all-branches)
+VER_NEXT=$(${VER_CMD} next --strip-prefix --tag-mode all-branches)
 
 if [ $CURRENT_GIT_BRANCH != ${DEFAULT_BRANCH} ]; then
   echo "Not on ${DEFAULT_BRANCH}, skipping"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,18 +38,27 @@ if [ -z "${GIT_EMAIL}" ]; then
   exit 1
 fi
 
-echo "Generating release for v${VER_NEXT}"
+echo "Generating release for v${VER_NEXT} with git user ${GIT_USER}"
 
-# Bump package version
+# Update version in version.go file manually
+echo -e "package version\n\n// Version of this library\nconst Version string = \"${VER_NEXT}\"" > internal/version/version.go
+
+echo "version.go updated using echo"
+cat internal/version/version.go
+
+# Update package version in version.go file using svu
 ${VER_BUMP} set ${VER_NEXT} -r -w ${VER_PACKAGE}
+
+echo "version.go updated by svu"
+cat internal/version/version.go
 
 # Auto-generate CHANGELOG updates
 ${CHANGELOG_CMD} --next-tag v${VER_NEXT} -o CHANGELOG.md
 
 # Commit CHANGELOG updates
-git add CHANGELOG.md ${VER_PACKAGE}/
+git add CHANGELOG.md internal/version/version.go
 
-git commit --no-verify -m "chore(release): Releasing v${VER_NEXT}"
+git commit --no-verify -m "chore(release): release v${VER_NEXT}"
 git tag v${VER_NEXT}
 git push --no-verify origin HEAD:${DEFAULT_BRANCH} --tags
 


### PR DESCRIPTION
For some reason a branch might not have the correct list of tags, so we need to reference the rest of the branches to see what the actual latest and next tags should be.