### PR TITLE
feat(install): add DETECTED status to installevents via code gen

### DIFF
--- a/pkg/installevents/types.go
+++ b/pkg/installevents/types.go
@@ -29,6 +29,8 @@ var InstallationRecipeStatusTypeTypes = struct {
 	AVAILABLE InstallationRecipeStatusType
 	// Defines a canceled recipe when attempting to install.
 	CANCELED InstallationRecipeStatusType
+	// Defines when New Relic instrumentation compatibility is detected.
+	DETECTED InstallationRecipeStatusType
 	// Defines a recipe that has failed during installation.
 	FAILED InstallationRecipeStatusType
 	// Defines a recipe that has been installed.
@@ -46,6 +48,8 @@ var InstallationRecipeStatusTypeTypes = struct {
 	AVAILABLE: "AVAILABLE",
 	// Defines a canceled recipe when attempting to install.
 	CANCELED: "CANCELED",
+	// Defines when New Relic instrumentation compatibility is detected.
+	DETECTED: "DETECTED",
 	// Defines a recipe that has failed during installation.
 	FAILED: "FAILED",
 	// Defines a recipe that has been installed.


### PR DESCRIPTION
This PR adds the `DETECTED` status type. The `DETECTED` status is applied to an installation recipe when New Relic instrumentation compatibility is detected.