### PR TITLE
feat: use improved error handling for muting rules

### DIFF
--- a/pkg/alerts/muting_rules.go
+++ b/pkg/alerts/muting_rules.go
@@ -207,7 +207,7 @@ func (a *Alerts) CreateMutingRuleWithContext(ctx context.Context, accountID int,
 
 	resp := alertMutingRuleCreateResponse{}
 
-	if err := a.client.NerdGraphQueryWithContext(ctx, alertsMutingRulesCreate, vars, &resp); err != nil {
+	if err := a.NerdGraphQueryWithContext(ctx, alertsMutingRulesCreate, vars, &resp); err != nil {
 		return nil, err
 	}
 
@@ -229,7 +229,7 @@ func (a *Alerts) UpdateMutingRuleWithContext(ctx context.Context, accountID int,
 
 	resp := alertMutingRuleUpdateResponse{}
 
-	if err := a.client.NerdGraphQueryWithContext(ctx, alertsMutingRulesUpdate, vars, &resp); err != nil {
+	if err := a.NerdGraphQueryWithContext(ctx, alertsMutingRulesUpdate, vars, &resp); err != nil {
 		return nil, err
 	}
 
@@ -250,7 +250,7 @@ func (a *Alerts) DeleteMutingRuleWithContext(ctx context.Context, accountID int,
 
 	resp := alertMutingRuleDeleteResponse{}
 
-	return a.client.NerdGraphQueryWithContext(ctx, alertsMutingRuleDelete, vars, &resp)
+	return a.NerdGraphQueryWithContext(ctx, alertsMutingRuleDelete, vars, &resp)
 }
 
 type alertMutingRuleCreateResponse struct {


### PR DESCRIPTION
This PR uses the custom `NerdGraphQueryWithContext` on Alerts to provided richer error messaging in the TF Provider. For more context: #803  