### PR TITLE
fix(http): Better handling of Deprecation Errors for NerdGraph requests

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -364,8 +364,11 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 		return nil, nrErrors.NewNotFound("resource not found")
 	}
 
-	if errorValue.Error() != "" {
-		return nil, errorValue
+	// Ignore deprecation errors
+	if !errorValue.IsDeprecated() {
+		if errorValue.Error() != "" {
+			return nil, errorValue
+		}
 	}
 
 	if req.value == nil {

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -118,6 +118,10 @@ func (c *CustomErrorResponse) IsRetryableError() bool {
 	return false
 }
 
+func (c *CustomErrorResponse) IsDeprecated() bool {
+	return false
+}
+
 func (c *CustomErrorResponse) IsUnauthorized(resp *http.Response) bool {
 	return resp.StatusCode == http.StatusUnauthorized
 }

--- a/internal/http/errors.go
+++ b/internal/http/errors.go
@@ -12,6 +12,7 @@ type ErrorResponse interface {
 	IsNotFound() bool
 	IsRetryableError() bool
 	IsUnauthorized(resp *http.Response) bool
+	IsDeprecated() bool
 	Error() string
 	New() ErrorResponse
 }
@@ -41,6 +42,10 @@ func (e *DefaultErrorResponse) IsNotFound() bool {
 }
 
 func (e *DefaultErrorResponse) IsRetryableError() bool {
+	return false
+}
+
+func (e *DefaultErrorResponse) IsDeprecated() bool {
 	return false
 }
 

--- a/internal/http/graphql.go
+++ b/internal/http/graphql.go
@@ -87,6 +87,21 @@ func (r *GraphQLErrorResponse) IsUnauthorized(resp *http.Response) bool {
 	return false
 }
 
+// IsDeprecated parses error messages for warnings that a field being used
+// is deprecated.  We want to bubble that up, but not stop returning data
+//
+// Example deprecation message:
+//   This field is deprecated! Please use `relatedEntities` instead.
+func (r *GraphQLErrorResponse) IsDeprecated() bool {
+	for _, err := range r.Errors {
+		if strings.HasPrefix(err.Message, "This field is deprecated!") {
+			return true
+		}
+	}
+
+	return false
+}
+
 // New creates a new instance of GraphQLErrorRepsonse.
 func (r *GraphQLErrorResponse) New() ErrorResponse {
 	return &GraphQLErrorResponse{}

--- a/pkg/entities/entity_integration_test.go
+++ b/pkg/entities/entity_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/newrelic/newrelic-client-go/internal/http"
 	"github.com/newrelic/newrelic-client-go/pkg/common"
 	mock "github.com/newrelic/newrelic-client-go/pkg/testhelpers"
 )
@@ -110,7 +111,11 @@ func TestIntegrationGetEntities(t *testing.T) {
 	guids := []common.EntityGUID{"MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"}
 	actual, err := client.GetEntities(guids)
 
-	require.NoError(t, err)
+	if e, ok := err.(*http.GraphQLErrorResponse); ok {
+		if !e.IsDeprecated() {
+			require.NoError(t, e)
+		}
+	}
 	require.Greater(t, len((*actual)), 0)
 }
 
@@ -122,7 +127,11 @@ func TestIntegrationGetEntity(t *testing.T) {
 
 	result, err := client.GetEntity(entityGUID)
 
-	require.NoError(t, err)
+	if e, ok := err.(*http.GraphQLErrorResponse); ok {
+		if !e.IsDeprecated() {
+			require.NoError(t, e)
+		}
+	}
 	require.NotNil(t, result)
 
 	actual := (*result).(*ApmApplicationEntity)
@@ -145,7 +154,11 @@ func TestIntegrationGetEntity_ApmEntity(t *testing.T) {
 
 	result, err := client.GetEntity("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
 
-	require.NoError(t, err)
+	if e, ok := err.(*http.GraphQLErrorResponse); ok {
+		if !e.IsDeprecated() {
+			require.NoError(t, e)
+		}
+	}
 	require.NotNil(t, result)
 
 	actual := (*result).(*ApmApplicationEntity)
@@ -172,7 +185,11 @@ func TestIntegrationGetEntity_BrowserEntity(t *testing.T) {
 
 	result, err := client.GetEntity("MjUwODI1OXxCUk9XU0VSfEFQUExJQ0FUSU9OfDIwNDI2MTYyOA")
 
-	require.NoError(t, err)
+	if e, ok := err.(*http.GraphQLErrorResponse); ok {
+		if !e.IsDeprecated() {
+			require.NoError(t, e)
+		}
+	}
 	require.NotNil(t, result)
 
 	actual := (*result).(*BrowserApplicationEntity)
@@ -193,8 +210,12 @@ func TestIntegrationGetEntity_MobileEntity(t *testing.T) {
 
 	result, err := client.GetEntity("NDQ0NTN8TU9CSUxFfEFQUExJQ0FUSU9OfDE3ODg1NDI")
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+	if e, ok := err.(*http.GraphQLErrorResponse); ok {
+		if !e.IsDeprecated() {
+			require.NoError(t, e)
+		}
+	}
+	require.NotNil(t, (*result))
 
 	actual := (*result).(*MobileApplicationEntity)
 

--- a/pkg/infrastructure/infrastructure.go
+++ b/pkg/infrastructure/infrastructure.go
@@ -45,6 +45,10 @@ func (e *ErrorResponse) IsRetryableError() bool {
 	return false
 }
 
+func (e *ErrorResponse) IsDeprecated() bool {
+	return false
+}
+
 // IsUnauthorized checks a response for a 401 Unauthorize HTTP status code.
 func (e *ErrorResponse) IsUnauthorized(resp *http.Response) bool {
 	return resp.StatusCode == http.StatusUnauthorized

--- a/pkg/synthetics/synthetics.go
+++ b/pkg/synthetics/synthetics.go
@@ -2,24 +2,25 @@
 package synthetics
 
 import (
-	"net/http"
 	"strings"
 
-	nrhttp "github.com/newrelic/newrelic-client-go/internal/http"
+	"github.com/newrelic/newrelic-client-go/internal/http"
 	"github.com/newrelic/newrelic-client-go/pkg/config"
 	"github.com/newrelic/newrelic-client-go/pkg/logging"
 )
 
 // Synthetics is used to communicate with the New Relic Synthetics product.
 type Synthetics struct {
-	client nrhttp.Client
+	client http.Client
 	config config.Config
 	logger logging.Logger
-	pager  nrhttp.Pager
+	pager  http.Pager
 }
 
 // ErrorResponse represents an error response from New Relic Synthetics.
 type ErrorResponse struct {
+	http.DefaultErrorResponse
+
 	Message            string        `json:"error,omitempty"`
 	Messages           []ErrorDetail `json:"errors,omitempty"`
 	ServerErrorMessage string        `json:"message,omitempty"`
@@ -52,34 +53,21 @@ func (e *ErrorResponse) Error() string {
 }
 
 // New creates a new instance of ErrorResponse.
-func (e *ErrorResponse) New() nrhttp.ErrorResponse {
+func (e *ErrorResponse) New() http.ErrorResponse {
 	return &ErrorResponse{}
-}
-
-func (e *ErrorResponse) IsNotFound() bool {
-	return false
-}
-
-func (e *ErrorResponse) IsRetryableError() bool {
-	return false
-}
-
-// IsUnauthorized checks the response for a 401 Unauthorize HTTP status code.
-func (e *ErrorResponse) IsUnauthorized(resp *http.Response) bool {
-	return resp.StatusCode == http.StatusUnauthorized
 }
 
 // New is used to create a new Synthetics client instance.
 func New(config config.Config) Synthetics {
-	client := nrhttp.NewClient(config)
-	client.SetAuthStrategy(&nrhttp.PersonalAPIKeyCapableV2Authorizer{})
+	client := http.NewClient(config)
+	client.SetAuthStrategy(&http.PersonalAPIKeyCapableV2Authorizer{})
 	client.SetErrorValue(&ErrorResponse{})
 
 	pkg := Synthetics{
 		client: client,
 		config: config,
 		logger: config.GetLogger(),
-		pager:  &nrhttp.LinkHeaderPager{},
+		pager:  &http.LinkHeaderPager{},
 	}
 
 	return pkg


### PR DESCRIPTION
Previously, any error condition coming from NerdGraph caused the request to fail.  This isn't great as field `deprecations` are now being returned as errors, with the result set.  Example Entities query:

```
entities {
  relationships {...}
}
```
Result:
```
This field is deprecated! Please use `relatedEntities` instead.
```

This change implements a custom error method for GraphQL Queries (NerdGraph really) that checks to see if it's a deprecation error and continues anyway.  So now there is a case where you get back a valid response body and an error.

*THIS IS LIKELY TO CAUSE SOME DOWNSTREAM ISSUES* but not sure yet... The updated method to check if an error is valid or not is a bit clumsy, and consists of:

```go
  resp, err := client.GetEntities(guids)

  if e, ok := err.(*http.GraphQLErrorResponse); ok {
    if !e.IsDeprecated() {
      return e
    }
  }
```