### PR TITLE
Feat(nrql_conditions): add optional SlideBy field to signal

### DIFF
--- a/pkg/alerts/nrql_conditions.go
+++ b/pkg/alerts/nrql_conditions.go
@@ -26,6 +26,7 @@ type AlertsNrqlConditionSignal struct {
 	AggregationMethod *NrqlConditionAggregationMethod `json:"aggregationMethod,omitempty"`
 	AggregationDelay  *int                            `json:"aggregationDelay,omitempty"`
 	AggregationTimer  *int                            `json:"aggregationTimer,omitempty"`
+	SlideBy           *int                            `json:"slideBy,omitempty"`
 }
 
 // AlertsNrqlConditionCreateSignal - Configuration that defines the signal that the NRQL condition will use to evaluate for Create.
@@ -38,6 +39,7 @@ type AlertsNrqlConditionCreateSignal struct {
 	AggregationMethod *NrqlConditionAggregationMethod `json:"aggregationMethod,omitempty"`
 	AggregationDelay  *int                            `json:"aggregationDelay,omitempty"`
 	AggregationTimer  *int                            `json:"aggregationTimer,omitempty"`
+	SlideBy           *int                            `json:"slideBy,omitempty"`
 }
 
 // AlertsNrqlConditionUpdateSignal - Configuration that defines the signal that the NRQL condition will use to evaluate for Update.
@@ -50,6 +52,7 @@ type AlertsNrqlConditionUpdateSignal struct {
 	AggregationMethod *NrqlConditionAggregationMethod `json:"aggregationMethod"`
 	AggregationDelay  *int                            `json:"aggregationDelay"`
 	AggregationTimer  *int                            `json:"aggregationTimer"`
+	SlideBy           *int                            `json:"slideBy"`
 }
 
 // NrqlConditionAggregationMethod - The available aggregation methods.
@@ -844,6 +847,7 @@ const (
       aggregationMethod
       aggregationDelay
       aggregationTimer
+      slideBy
     }
   `
 

--- a/pkg/alerts/nrql_conditions_integration_test.go
+++ b/pkg/alerts/nrql_conditions_integration_test.go
@@ -24,6 +24,7 @@ var (
 	nrqlConditionBaseAggMethod          = NrqlConditionAggregationMethodTypes.Cadence // needed for setting pointer
 	nrqlConditionBaseAggDelay           = 2                                           // needed for setting pointer
 	nrqlConditionBaseAggTimer           = 5                                           // needed for setting pointer
+	nrqlConditionBaseSlideBy            = 30                                          // needed for setting pointer
 
 	nrqlConditionCreateBase = NrqlConditionCreateBase{
 		Description: "test description",
@@ -152,6 +153,72 @@ var (
 			AggregationDelay:  &nrqlConditionBaseAggDelay,
 		},
 	}
+
+	nrqlConditionCreateWithSlideBy = NrqlConditionCreateBase{
+		Description: "test description",
+		Enabled:     true,
+		Name:        fmt.Sprintf("test-nrql-condition-%s", testNrqlConditionRandomString),
+		Nrql: NrqlConditionCreateQuery{
+			Query: "SELECT rate(sum(apm.service.cpu.usertime.utilization), 1 second) * 100 as cpuUsage FROM Metric WHERE appName like 'Dummy App' FACET OtherStuff",
+		},
+		RunbookURL: "test.com",
+		Terms: []NrqlConditionTerm{
+			{
+				Threshold:            &nrqlConditionBaseThreshold,
+				ThresholdOccurrences: ThresholdOccurrences.AtLeastOnce,
+				ThresholdDuration:    600,
+				Operator:             AlertsNRQLConditionTermsOperatorTypes.ABOVE,
+				Priority:             NrqlConditionPriorities.Critical,
+			},
+		},
+		ViolationTimeLimitSeconds: 3600,
+		Expiration: &AlertsNrqlConditionExpiration{
+			CloseViolationsOnExpiration: true,
+			ExpirationDuration:          &nrqlConditionBaseExpirationDuration,
+			OpenViolationOnExpiration:   false,
+		},
+		Signal: &AlertsNrqlConditionCreateSignal{
+			AggregationWindow: &nrqlConditionBaseAggWindow,
+			FillOption:        &AlertsFillOptionTypes.STATIC,
+			FillValue:         &nrqlConditionBaseSignalFillValue,
+			AggregationMethod: &nrqlConditionBaseAggMethod,
+			AggregationDelay:  &nrqlConditionBaseAggDelay,
+			SlideBy:           &nrqlConditionBaseSlideBy,
+		},
+	}
+
+	nrqlConditionUpdateWithSlideBy = NrqlConditionUpdateBase{
+		Description: "test description",
+		Enabled:     true,
+		Name:        fmt.Sprintf("test-nrql-condition-%s", testNrqlConditionRandomString),
+		Nrql: NrqlConditionUpdateQuery{
+			Query: "SELECT rate(sum(apm.service.cpu.usertime.utilization), 1 second) * 100 as cpuUsage FROM Metric WHERE appName like 'Dummy App'",
+		},
+		RunbookURL: "test.com",
+		Terms: []NrqlConditionTerm{
+			{
+				Threshold:            &nrqlConditionBaseThreshold,
+				ThresholdOccurrences: ThresholdOccurrences.AtLeastOnce,
+				ThresholdDuration:    600,
+				Operator:             AlertsNRQLConditionTermsOperatorTypes.ABOVE,
+				Priority:             NrqlConditionPriorities.Critical,
+			},
+		},
+		ViolationTimeLimitSeconds: 3600,
+		Expiration: &AlertsNrqlConditionExpiration{
+			CloseViolationsOnExpiration: true,
+			ExpirationDuration:          &nrqlConditionBaseExpirationDuration,
+			OpenViolationOnExpiration:   false,
+		},
+		Signal: &AlertsNrqlConditionUpdateSignal{
+			AggregationWindow: &nrqlConditionBaseAggWindow,
+			FillOption:        &AlertsFillOptionTypes.STATIC,
+			FillValue:         &nrqlConditionBaseSignalFillValue,
+			AggregationMethod: &nrqlConditionBaseAggMethod,
+			AggregationDelay:  &nrqlConditionBaseAggDelay,
+			SlideBy:           &nrqlConditionBaseSlideBy,
+		},
+	}
 )
 
 //REST API integration test (deprecated)
@@ -249,11 +316,11 @@ func TestIntegrationNrqlConditions_Baseline(t *testing.T) {
 	var (
 		randStr             = mock.RandSeq(5)
 		createBaselineInput = NrqlConditionCreateInput{
-			NrqlConditionCreateBase: nrqlConditionCreateBase,
+			NrqlConditionCreateBase: nrqlConditionCreateWithSlideBy,
 			BaselineDirection:       &NrqlBaselineDirections.LowerOnly,
 		}
 		updateBaselineInput = NrqlConditionUpdateInput{
-			NrqlConditionUpdateBase: nrqlConditionUpdateBase,
+			NrqlConditionUpdateBase: nrqlConditionUpdateWithSlideBy,
 			BaselineDirection:       &NrqlBaselineDirections.LowerOnly,
 		}
 	)


### PR DESCRIPTION
This adds support to the Go Client for sliding window aggregation in NRQL conditions. This feature will be released Feb 1

SlideBy and value functions are mutually exclusive, so i've added slideBy to the baseline NRQL condition integration tests, which also can't have value function set.

This is a prerequisite for https://github.com/newrelic/terraform-provider-newrelic/pull/1552