### PR TITLE
Add license key authorization for the Event API.

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -42,7 +42,11 @@ func New(cfg config.Config) Events {
 	cfg.Compression = config.Compression.Gzip
 
 	client := http.NewClient(cfg)
-	client.SetAuthStrategy(&http.InsightsInsertKeyAuthorizer{})
+	if cfg.InsightsInsertKey != "" {
+		client.SetAuthStrategy(&http.InsightsInsertKeyAuthorizer{})
+	} else {
+		client.SetAuthStrategy(&http.LicenseKeyAuthorizer{})
+	}
 
 	pkg := Events{
 		client:       client,

--- a/pkg/events/events_integration_test.go
+++ b/pkg/events/events_integration_test.go
@@ -72,6 +72,28 @@ func TestIntegrationEvents(t *testing.T) {
 	}
 }
 
+func TestIntegrationEventsLicenseKey(t *testing.T) {
+	t.Parallel()
+
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	tc := mock.NewIntegrationTestConfig(t)
+	tc.InsightsInsertKey = ""
+	client := New(tc)
+
+	for _, event := range testEvents {
+		err := client.CreateEvent(testAccountID, event.Event)
+		if event.err == nil {
+			assert.NoError(t, err)
+		} else {
+			assert.Equal(t, event.err, err)
+		}
+	}
+}
+
 func TestIntegrationEvents_BatchMode_Timeout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adding License Key Authorizer for the Event API. To keep backwards compatibility the Insight Insert Key is prioritised over the License Key.

The reason for adding this authorizer is to make it easy in the New Relic CLI to create an event without requiring an Insights Insert key.