### PR TITLE
feat(installevents): implement metadata field as arbitrary key-value store on recipe event 

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -631,6 +631,9 @@ packages:
       - name: ID
         field_type_override: string
         skip_type_create: true
+      - name: InstallationRawMetadata
+        field_type_override: map[string]interface{}
+        skip_type_create: true
     mutations:
       - name: installationCreateRecipeEvent
         max_query_field_depth: 1
@@ -877,7 +880,7 @@ packages:
       - name: ServiceLevelObjective
         skip_fields:
           - ResultQueries
-      
+
       # Overrides needed
       - name: ServiceLevelEventsQuery
         field_type_override: "*ServiceLevelEventsQuery"

--- a/pkg/installevents/installevents_api.go
+++ b/pkg/installevents/installevents_api.go
@@ -141,6 +141,7 @@ const InstallationCreateRecipeEventMutation = `mutation(
 	kernelArch
 	kernelVersion
 	logFilePath
+	metadata
 	name
 	os
 	platform

--- a/pkg/installevents/installevents_api_integration_test.go
+++ b/pkg/installevents/installevents_api_integration_test.go
@@ -31,6 +31,35 @@ func TestInstallationCreateRecipeEvent(t *testing.T) {
 	require.NotNil(t, response)
 }
 
+func TestInstallationCreateRecipeEvent_ShouldSendMetadata(t *testing.T) {
+	t.Parallel()
+
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	client := newIntegrationTestClient(t)
+
+	status := InstallationRecipeStatus{
+		CliVersion: "0.0.1",
+		Name:       "test",
+		Status:     InstallationRecipeStatusTypeTypes.AVAILABLE,
+		Metadata: map[string]interface{}{
+			"someKey": "some value",
+		},
+	}
+
+	response, err := client.InstallationCreateRecipeEvent(testAccountID, status)
+
+	require.NoError(t, err)
+	require.NotNil(t, response.Metadata)
+
+	if metaValue, ok := response.Metadata["someKey"].(string); ok {
+		require.Equal(t, "some value", metaValue)
+	}
+}
+
 func newIntegrationTestClient(t *testing.T) Installevents {
 	tc := mock.NewIntegrationTestConfig(t)
 

--- a/pkg/installevents/types.go
+++ b/pkg/installevents/types.go
@@ -164,6 +164,8 @@ type InstallationRecipeEvent struct {
 	KernelVersion string `json:"kernelVersion"`
 	// The path to the log file on the customer's host.
 	LogFilePath string `json:"logFilePath"`
+	// Additional key:value data related to the environment where the installation occurred.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 	// The unique name for a given recipe.
 	Name string `json:"name"`
 	// The OS of the customer's machine.
@@ -212,6 +214,8 @@ type InstallationRecipeStatus struct {
 	KernelVersion string `json:"kernelVersion"`
 	// The path to the log file on the customer's host.
 	LogFilePath string `json:"logFilePath"`
+	// Additional key:value data related to an error or related to the environment where the installation ocurred.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 	// The unique name for a given recipe.
 	Name string `json:"name"`
 	// The OS of the customer's machine.


### PR DESCRIPTION
**Note:** The `metadata` field in NerdGraph is an arbitrary key:value object represented as a GraphQL custom scalar type named `InstallationRawMetadata`. Since Tutone translates scalars as strings, we perform an override in our Tutone config to ensure the proper Go type is generated for this field, which is `map[string]interface{}` 😎 