### PR TITLE
add x-account-id header

### DIFF
--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -83,6 +83,10 @@ func (c *Client) NewRequest(method string, url string, params interface{}, reqBo
 		req.SetHeader("User-Agent", defaultUserAgent)
 	}
 
+	if cfg.AccountID != "" {
+		req.SetHeader("X-Account-ID", cfg.AccountID)
+	}
+
 	return req, nil
 }
 

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -163,6 +163,14 @@ func ConfigAdminAPIKey(adminAPIKey string) ConfigOption {
 	}
 }
 
+// ConfigAccoundId sets the AccoundId to be used when making authenticated network calls.
+func ConfigAccountId(accountId string) ConfigOption {
+	return func(cfg *config.Config) error {
+		cfg.AccountID = accountId
+		return nil
+	}
+}
+
 // ConfigRegion sets the New Relic Region this client will use.
 func ConfigRegion(r string) ConfigOption {
 	return func(cfg *config.Config) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,9 @@ type Config struct {
 	// see: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#admin
 	AdminAPIKey string
 
+	// AccountID to authenticate API requests with child accounts
+	AccountID string
+
 	// InsightsInsertKey to send custom events to Insights
 	InsightsInsertKey string
 


### PR DESCRIPTION
Experimenting adding x-account-id header addressed in the newrelic-client-go issue. https://github.com/newrelic/newrelic-client-go/issues/697

Hopefully pave a way to address this [terraform-provider-newrelic](https://github.com/newrelic/terraform-provider-newrelic/issues/1645) issue

