### PR TITLE
feat(auth): Add X-Account-ID header if value exists in request context

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"github.com/newrelic/newrelic-client-go/pkg/config"
+	"github.com/newrelic/newrelic-client-go/pkg/contextkeys"
 )
 
 // RequestAuthorizer is an interface that allows customizatino of how a request is authorized.
@@ -26,6 +27,10 @@ func (a *PersonalAPIKeyCapableV2Authorizer) AuthorizeRequest(r *Request, c *conf
 		r.SetHeader("Api-Key", c.PersonalAPIKey)
 	} else {
 		r.SetHeader("X-Api-Key", c.AdminAPIKey)
+	}
+
+	if xAccountID, ok := contextkeys.GetXAccountID(r.request.Context()); ok == true {
+		r.SetHeader("X-Account-ID", xAccountID)
 	}
 }
 

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -29,7 +29,7 @@ func (a *PersonalAPIKeyCapableV2Authorizer) AuthorizeRequest(r *Request, c *conf
 		r.SetHeader("X-Api-Key", c.AdminAPIKey)
 	}
 
-	if accountID, ok := contextkeys.GetAccountID(r.request.Context()); ok == true {
+	if accountID, ok := contextkeys.GetAccountID(r.request.Context()); ok {
 		r.SetHeader("X-Account-ID", accountID)
 	}
 }

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -29,8 +29,8 @@ func (a *PersonalAPIKeyCapableV2Authorizer) AuthorizeRequest(r *Request, c *conf
 		r.SetHeader("X-Api-Key", c.AdminAPIKey)
 	}
 
-	if xAccountID, ok := contextkeys.GetXAccountID(r.request.Context()); ok == true {
-		r.SetHeader("X-Account-ID", xAccountID)
+	if accountID, ok := contextkeys.GetAccountID(r.request.Context()); ok == true {
+		r.SetHeader("X-Account-ID", accountID)
 	}
 }
 

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -6,11 +6,12 @@ package http
 import (
 	"context"
 	"encoding/json"
-	"github.com/newrelic/newrelic-client-go/pkg/contextkeys"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/newrelic/newrelic-client-go/pkg/contextkeys"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -313,7 +313,7 @@ func TestCustomRequestHeaders(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestXAccountIDHeaderWithPersonalAPIKeyCapableV2Authorizer(t *testing.T) {
+func TestAccountIDHeaderWithPersonalAPIKeyCapableV2Authorizer(t *testing.T) {
 	// Given mock server
 	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -328,7 +328,7 @@ func TestXAccountIDHeaderWithPersonalAPIKeyCapableV2Authorizer(t *testing.T) {
 
 	// When a request is made with context
 	req, err := c.NewRequest("GET", c.config.Region().RestURL("path"), nil, nil, nil)
-	ctx := contextkeys.SetXAccountID(context.Background(), "custom-account-id")
+	ctx := contextkeys.SetAccountID(context.Background(), "custom-account-id")
 	req.WithContext(ctx)
 
 	// Then there are no errors with the request

--- a/pkg/contextkeys/contextkeys.go
+++ b/pkg/contextkeys/contextkeys.go
@@ -1,0 +1,41 @@
+package contextkeys
+
+import "context"
+
+// ContextKeys gets and sets context values from a context.
+type contextKeys struct {
+	xAccountID struct{}
+}
+
+var (
+	keys = contextKeys{
+		xAccountID: struct{}{},
+	}
+)
+
+// SetXAccountID inserts the account ID value into context.
+func SetXAccountID(ctx context.Context, value string) context.Context {
+	return keys.setXAccountID(ctx, value)
+}
+
+// GetXAccountID returns the account ID from the context.
+func GetXAccountID(ctx context.Context) (string, bool) {
+	return keys.getXAccountIDFromContext(ctx)
+}
+
+func (c contextKeys) getXAccountIDFromContext(ctx context.Context) (string, bool) {
+	if nil != ctx {
+		xAccountID, ok := ctx.Value(keys.xAccountID).(string)
+		return xAccountID, ok
+	}
+
+	return "", false
+}
+
+func (c contextKeys) setXAccountID(ctx context.Context, value string) context.Context {
+	if nil == ctx {
+		ctx = context.Background()
+	}
+
+	return context.WithValue(ctx, c.xAccountID, value)
+}

--- a/pkg/contextkeys/contextkeys.go
+++ b/pkg/contextkeys/contextkeys.go
@@ -4,38 +4,38 @@ import "context"
 
 // ContextKeys gets and sets context values from a context.
 type contextKeys struct {
-	xAccountID struct{}
+	accountID struct{}
 }
 
 var (
 	keys = contextKeys{
-		xAccountID: struct{}{},
+		accountID: struct{}{},
 	}
 )
 
-// SetXAccountID inserts the account ID value into context.
-func SetXAccountID(ctx context.Context, value string) context.Context {
-	return keys.setXAccountID(ctx, value)
+// SetAccountID inserts the account ID value into context.
+func SetAccountID(ctx context.Context, value string) context.Context {
+	return keys.setAccountID(ctx, value)
 }
 
-// GetXAccountID returns the account ID from the context.
-func GetXAccountID(ctx context.Context) (string, bool) {
-	return keys.getXAccountIDFromContext(ctx)
+// GetAccountID returns the account ID from the context.
+func GetAccountID(ctx context.Context) (string, bool) {
+	return keys.getAccountIDFromContext(ctx)
 }
 
-func (c contextKeys) getXAccountIDFromContext(ctx context.Context) (string, bool) {
+func (c contextKeys) getAccountIDFromContext(ctx context.Context) (string, bool) {
 	if nil != ctx {
-		xAccountID, ok := ctx.Value(keys.xAccountID).(string)
-		return xAccountID, ok
+		accountID, ok := ctx.Value(keys.accountID).(string)
+		return accountID, ok
 	}
 
 	return "", false
 }
 
-func (c contextKeys) setXAccountID(ctx context.Context, value string) context.Context {
+func (c contextKeys) setAccountID(ctx context.Context, value string) context.Context {
 	if nil == ctx {
 		ctx = context.Background()
 	}
 
-	return context.WithValue(ctx, c.xAccountID, value)
+	return context.WithValue(ctx, c.accountID, value)
 }

--- a/pkg/contextkeys/contextkeys.go
+++ b/pkg/contextkeys/contextkeys.go
@@ -2,7 +2,7 @@ package contextkeys
 
 import "context"
 
-// ContextKeys gets and sets context values from a context.
+// contextKeys gets and sets context values from a context.
 type contextKeys struct {
 	accountID struct{}
 }
@@ -15,27 +15,29 @@ var (
 
 // SetAccountID inserts the account ID value into context.
 func SetAccountID(ctx context.Context, value string) context.Context {
-	return keys.setAccountID(ctx, value)
+	return keys.SetAccountID(ctx, value)
 }
 
 // GetAccountID returns the account ID from the context.
 func GetAccountID(ctx context.Context) (string, bool) {
-	return keys.getAccountIDFromContext(ctx)
+	return keys.GetAccountID(ctx)
 }
 
-func (c contextKeys) getAccountIDFromContext(ctx context.Context) (string, bool) {
+// SetAccountID inserts the account ID value into context.
+func (c contextKeys) SetAccountID(ctx context.Context, value string) context.Context {
+	if nil == ctx {
+		ctx = context.Background()
+	}
+
+	return context.WithValue(ctx, c.accountID, value)
+}
+
+// GetAccountID returns the account ID from the context.
+func (c contextKeys) GetAccountID(ctx context.Context) (string, bool) {
 	if nil != ctx {
 		accountID, ok := ctx.Value(keys.accountID).(string)
 		return accountID, ok
 	}
 
 	return "", false
-}
-
-func (c contextKeys) setAccountID(ctx context.Context, value string) context.Context {
-	if nil == ctx {
-		ctx = context.Background()
-	}
-
-	return context.WithValue(ctx, c.accountID, value)
 }

--- a/pkg/contextkeys/contextkeys_test.go
+++ b/pkg/contextkeys/contextkeys_test.go
@@ -25,7 +25,7 @@ func TestGetAccountID_DefaultReturnValueWhenNoAccountIDFound(t *testing.T) {
 	assert.Equal(t, "", defaultValue)
 }
 
-func TestSetAccountID(t *testing.T) {
+func TestSetAccountID_SetsTheAccountID(t *testing.T) {
 	ctx := SetAccountID(context.Background(), "some-account-id")
 	result, ok := GetAccountID(ctx)
 
@@ -40,4 +40,40 @@ func TestSetAccountID_CreatesContextIfNil(t *testing.T) {
 	result, ok := GetAccountID(ctx)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, "some-account-id", result)
+}
+
+func TestContextKeys_SetAccountID_SetsValues(t *testing.T) {
+	x := contextKeys{}
+	ctx := x.SetAccountID(context.Background(), "some-account-id")
+	result, ok := x.GetAccountID(ctx)
+
+	assert.Equal(t, true, ok)
+	assert.Equal(t, "some-account-id", result)
+}
+
+func TestContextKeys_SetAccountID_CreatesContextIfNil(t *testing.T) {
+	x := contextKeys{}
+	ctx := x.SetAccountID(nil, "some-account-id")
+	assert.NotNil(t, ctx)
+
+	result, ok := x.GetAccountID(ctx)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, "some-account-id", result)
+}
+
+func TestContextKeys_GetAccountID_ReturnsAccountIDIfFound(t *testing.T) {
+	x := contextKeys{}
+	testCtx := context.WithValue(context.Background(), keys.accountID, "some-account-id")
+	accountID, ok := x.GetAccountID(testCtx)
+
+	assert.Equal(t, true, ok)
+	assert.Equal(t, "some-account-id", accountID)
+}
+
+func TestContextKeys_GetAccountID_DefaultReturnValueWhenNoAccountIDFound(t *testing.T) {
+	x := contextKeys{}
+	defaultValue, ok := x.GetAccountID(context.Background())
+
+	assert.Equal(t, false, ok)
+	assert.Equal(t, "", defaultValue)
 }

--- a/pkg/contextkeys/contextkeys_test.go
+++ b/pkg/contextkeys/contextkeys_test.go
@@ -5,8 +5,9 @@ package contextkeys
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetAccountID_ReturnsAccountIDIfFound(t *testing.T) {

--- a/pkg/contextkeys/contextkeys_test.go
+++ b/pkg/contextkeys/contextkeys_test.go
@@ -9,34 +9,34 @@ import (
 	"testing"
 )
 
-func TestGetXAccountID_ReturnsAccountIDIfFound(t *testing.T) {
-	testCtx := context.WithValue(context.Background(), keys.xAccountID, "some-account-id")
-	xAccountID, ok := GetXAccountID(testCtx)
+func TestGetAccountID_ReturnsAccountIDIfFound(t *testing.T) {
+	testCtx := context.WithValue(context.Background(), keys.accountID, "some-account-id")
+	accountID, ok := GetAccountID(testCtx)
 
 	assert.Equal(t, true, ok)
-	assert.Equal(t, "some-account-id", xAccountID)
+	assert.Equal(t, "some-account-id", accountID)
 }
 
-func TestGetXAccountID_DefaultReturnValueWhenNoAccountIDFound(t *testing.T) {
-	defaultValue, ok := GetXAccountID(context.Background())
+func TestGetAccountID_DefaultReturnValueWhenNoAccountIDFound(t *testing.T) {
+	defaultValue, ok := GetAccountID(context.Background())
 
 	assert.Equal(t, false, ok)
 	assert.Equal(t, "", defaultValue)
 }
 
-func TestSetXAccountID(t *testing.T) {
-	ctx := SetXAccountID(context.Background(), "some-account-id")
-	result, ok := GetXAccountID(ctx)
+func TestSetAccountID(t *testing.T) {
+	ctx := SetAccountID(context.Background(), "some-account-id")
+	result, ok := GetAccountID(ctx)
 
 	assert.Equal(t, true, ok)
 	assert.Equal(t, "some-account-id", result)
 }
 
-func TestSetXAccountID_CreatesContextIfNil(t *testing.T) {
-	ctx := SetXAccountID(nil, "some-account-id")
+func TestSetAccountID_CreatesContextIfNil(t *testing.T) {
+	ctx := SetAccountID(nil, "some-account-id")
 	assert.NotNil(t, ctx)
 
-	result, ok := GetXAccountID(ctx)
+	result, ok := GetAccountID(ctx)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, "some-account-id", result)
 }

--- a/pkg/contextkeys/contextkeys_test.go
+++ b/pkg/contextkeys/contextkeys_test.go
@@ -1,0 +1,42 @@
+//go:build unit
+// +build unit
+
+package contextkeys
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetXAccountID_ReturnsAccountIDIfFound(t *testing.T) {
+	testCtx := context.WithValue(context.Background(), keys.xAccountID, "some-account-id")
+	xAccountID, ok := GetXAccountID(testCtx)
+
+	assert.Equal(t, true, ok)
+	assert.Equal(t, "some-account-id", xAccountID)
+}
+
+func TestGetXAccountID_DefaultReturnValueWhenNoAccountIDFound(t *testing.T) {
+	defaultValue, ok := GetXAccountID(context.Background())
+
+	assert.Equal(t, false, ok)
+	assert.Equal(t, "", defaultValue)
+}
+
+func TestSetXAccountID(t *testing.T) {
+	ctx := SetXAccountID(context.Background(), "some-account-id")
+	result, ok := GetXAccountID(ctx)
+
+	assert.Equal(t, true, ok)
+	assert.Equal(t, "some-account-id", result)
+}
+
+func TestSetXAccountID_CreatesContextIfNil(t *testing.T) {
+	ctx := SetXAccountID(nil, "some-account-id")
+	assert.NotNil(t, ctx)
+
+	result, ok := GetXAccountID(ctx)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, "some-account-id", result)
+}

--- a/pkg/entities/types.go
+++ b/pkg/entities/types.go
@@ -40,7 +40,7 @@ var AccountStatusTypes = struct {
 	UPGRADED:               "UPGRADED",
 }
 
-// AgentApplicationSettingsBrowserLoader - Determines which Browser Loader will be configured. Some allowed return values are specified for backwards-compatability and do not represent currently allowed values for new applications.
+// AgentApplicationSettingsBrowserLoader - Determines which Browser Loader will be configured. Some allowed return values are specified for backwards-compatibility and do not represent currently allowed values for new applications.
 // See [documentation](https://docs.newrelic.com/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#agent-types) for further information.
 type AgentApplicationSettingsBrowserLoader string
 
@@ -913,7 +913,7 @@ var DashboardEntityAlertStatusTypes = struct {
 	YELLOW: "YELLOW",
 }
 
-// DashboardEntityPermissions - Permisions that represent visibility & editability
+// DashboardEntityPermissions - Permissions that represent visibility & editability
 type DashboardEntityPermissions string
 
 var DashboardEntityPermissionsTypes = struct {
@@ -1062,7 +1062,7 @@ var DashboardMetricLineChartWidgetVisualizationTypeTypes = struct {
 	METRIC_LINE_CHART: "METRIC_LINE_CHART",
 }
 
-// DashboardPermissions - Permisions that represent visibility & editability
+// DashboardPermissions - Permissions that represent visibility & editability
 type DashboardPermissions string
 
 var DashboardPermissionsTypes = struct {
@@ -3071,7 +3071,7 @@ type AgentTracesErrorTrace struct {
 	Path string `json:"path"`
 	// Error stack trace.
 	StackTrace []AgentTracesStackTraceFrame `json:"stackTrace,omitempty"`
-	// When the error occured.
+	// When the error occurred.
 	StartTime *nrtime.EpochMilliseconds `json:"startTime"`
 	// URI.
 	Uri string `json:"uri,omitempty"`
@@ -3147,7 +3147,7 @@ type AgentTracesSqlTrace struct {
 	Sql string `json:"sql,omitempty"`
 	// An agent generated `sql_id`.
 	SqlId string `json:"sqlId"`
-	// When the SQL query occured.
+	// When the SQL query occurred.
 	StartTime *nrtime.EpochMilliseconds `json:"startTime"`
 	// Call time, as added across all `call_count` traces.
 	TotalCallTime Milliseconds `json:"totalCallTime,omitempty"`
@@ -4706,7 +4706,7 @@ type ApmApplicationDeployment struct {
 	Permalink string `json:"permalink,omitempty"`
 	// The revision of the app that was deployed
 	Revision string `json:"revision,omitempty"`
-	// The moment the deployment occured
+	// The moment the deployment occurred
 	Timestamp *nrtime.EpochMilliseconds `json:"timestamp,omitempty"`
 	// The user who triggered the deployment
 	User string `json:"user,omitempty"`

--- a/pkg/installevents/types.go
+++ b/pkg/installevents/types.go
@@ -214,7 +214,7 @@ type InstallationRecipeStatus struct {
 	KernelVersion string `json:"kernelVersion"`
 	// The path to the log file on the customer's host.
 	LogFilePath string `json:"logFilePath"`
-	// Additional key:value data related to an error or related to the environment where the installation ocurred.
+	// Additional key:value data related to an error or related to the environment where the installation occurred.
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 	// The unique name for a given recipe.
 	Name string `json:"name"`


### PR DESCRIPTION
Closes https://github.com/newrelic/newrelic-client-go/issues/697

This PR adds an X-Account-ID header on REST requests so the same API key can be used across all account it has access to (not just it's primary account id).

To add the header, users should leverage the request's `context` and add an `X-Account-ID` key in the request's context.  This is done with a `contextkeys` package.

This work is meant to address an issue creating channels for child accounts with New Relic's [terraform-provider-newrelic](https://github.com/newrelic/terraform-provider-newrelic/issues/1645).
