### PR TITLE
chore(ci): do not run tutone generate on every push to main

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,7 +1,5 @@
 name: Tutone Generate
 on:
-  push:
-    branches: [main]
   schedule:
     - cron: '5 5 * * 1'
 


### PR DESCRIPTION
This job has a tendency to fail at the moment given the amount and frequency of changes happening in NerdGraph. We can keep the cron job running, but we don't need to have a red **x** on the `main` branch due to this 😉 