### PR TITLE
docs: update the readme's "Developer Toolkit" and Roadmap links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![CLA assistant](https://cla-assistant.io/readme/badge/newrelic/newrelic-client-go)](https://cla-assistant.io/newrelic/newrelic-client-go)
 [![Release](https://img.shields.io/github/release/newrelic/newrelic-client-go/all.svg)](https://github.com/newrelic/newrelic-client-go/releases/latest)
 
-The New Relic Client provides the building blocks for tools in the [Developer Toolkit](https://newrelic.github.io/developer-toolkit/), enabling quick access to the suite of New Relic APIs. As a library, it can also be leveraged within your own custom applications.
+The New Relic Client provides the building blocks for tools in the [Developer Toolkit](https://discuss.newrelic.com/t/about-the-developer-toolkit-category/90159), enabling quick access to the suite of New Relic APIs. As a library, it can also be leveraged within your own custom applications.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ func main() {
 
 New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices.
 
-- [Roadmap](https://newrelic.github.io/developer-toolkit/roadmap/) - As part of the Developer Toolkit, the roadmap for this project follows the same RFC process
+- [Roadmap](https://discuss.newrelic.com/t/rfc-developer-toolkit-roadmap-2020/90528) - As part of the Developer Toolkit, the roadmap for this project follows the same RFC process
 - [Issues or Enhancement Requests](https://github.com/newrelic/newrelic-client-go/issues) - Issues and enhancement requests can be submitted in the Issues tab of this repository. Please search for and review the existing open issues before submitting a new issue.
 - [Contributors Guide](CONTRIBUTING.md) - Contributions are welcome (and if you submit a Enhancement Request, expect to be invited to contribute it yourself :grin:).
 - [Community discussion board](https://discuss.newrelic.com/c/build-on-new-relic/developer-toolkit) - Like all official New Relic open source projects, there's a related Community topic in the New Relic Explorers Hub.


### PR DESCRIPTION
This PR updates the links to `https://newrelic.github.io/developer-toolkit/` which is no longer working.

This includes:

- The link at the top of the readme leading to the "Developer Toolkit"
- The link to the roadmap

The former was replaced by the same link to [Developer ToolKit](https://discuss.newrelic.com/t/about-the-developer-toolkit-category/90159) found in the readme. under the section **Community Support**.

The latter was hard to find and the closest that I could come up was with [RFC: Developer Toolkit Roadmap - 2020](https://discuss.newrelic.com/t/rfc-developer-toolkit-roadmap-2020/90528).
