### PR TITLE
feat: Expose EntityGUID on NRQL Conditions.

### DIFF
--- a/pkg/alerts/nrql_conditions.go
+++ b/pkg/alerts/nrql_conditions.go
@@ -3,6 +3,7 @@ package alerts
 import (
 	"context"
 	"fmt"
+	"github.com/newrelic/newrelic-client-go/pkg/common"
 
 	"github.com/newrelic/newrelic-client-go/pkg/errors"
 )
@@ -350,17 +351,18 @@ type NrqlAlertCondition struct {
 
 // NrqlCondition represents a New Relic NRQL Alert condition.
 type NrqlCondition struct {
-	Enabled             bool              `json:"enabled"`
-	IgnoreOverlap       bool              `json:"ignore_overlap,omitempty"`
-	ExpectedGroups      int               `json:"expected_groups,omitempty"`
-	ID                  int               `json:"id,omitempty"`
-	ViolationCloseTimer int               `json:"violation_time_limit_seconds,omitempty"`
-	Name                string            `json:"name,omitempty"`
-	Nrql                NrqlQuery         `json:"nrql,omitempty"`
-	RunbookURL          string            `json:"runbook_url,omitempty"`
-	Terms               []ConditionTerm   `json:"terms,omitempty"`
-	Type                string            `json:"type,omitempty"`
-	ValueFunction       ValueFunctionType `json:"value_function,omitempty"`
+	Enabled             bool               `json:"enabled"`
+	IgnoreOverlap       bool               `json:"ignore_overlap,omitempty"`
+	ExpectedGroups      int                `json:"expected_groups,omitempty"`
+	ID                  int                `json:"id,omitempty"`
+	ViolationCloseTimer int                `json:"violation_time_limit_seconds,omitempty"`
+	Name                string             `json:"name,omitempty"`
+	Nrql                NrqlQuery          `json:"nrql,omitempty"`
+	RunbookURL          string             `json:"runbook_url,omitempty"`
+	Terms               []ConditionTerm    `json:"terms,omitempty"`
+	Type                string             `json:"type,omitempty"`
+	ValueFunction       ValueFunctionType  `json:"value_function,omitempty"`
+	EntityGUID          *common.EntityGUID `json:"entity_guid,omitempty"`
 }
 
 // NrqlQuery represents a NRQL query to use with a NRQL alert condition

--- a/pkg/alerts/nrql_conditions_test.go
+++ b/pkg/alerts/nrql_conditions_test.go
@@ -4,6 +4,7 @@
 package alerts
 
 import (
+	"github.com/newrelic/newrelic-client-go/pkg/common"
 	"net/http"
 	"testing"
 
@@ -32,12 +33,38 @@ var (
 				"nrql": {
 					"query": "SELECT count(*) FROM Transactions",
 					"since_value": "3"
-				}
+				},
+				"entity_guid": "NDAwQzA0rEFST1BTfENPTkRJVElPTnw3MzUzNjL"
 			}
 		]
 	}`
 
 	testNrqlConditionJSON = `{
+		"nrql_condition": {
+			"type": "static",
+			"id": 12345,
+			"name": "NRQL Test Alert",
+			"enabled": true,
+			"value_function": "single_value",
+			"violation_time_limit_seconds": 3600,
+			"terms": [
+				{
+					"duration": "5",
+					"operator": "above",
+					"priority": "critical",
+					"threshold": "1",
+					"time_function": "all"
+				}
+			],
+			"nrql": {
+				"query": "SELECT count(*) FROM Transactions",
+				"since_value": "3"
+			},
+			"entity_guid": "NDAwQzA0rEFST1BTfENPTkRJVElPTnw3MzUzNjL"
+		}
+	}`
+
+	testNrqlConditionCreateJSON = `{
 		"nrql_condition": {
 			"type": "static",
 			"id": 12345,
@@ -85,6 +112,8 @@ var (
 			"runbook_url": "https://www.example.com/docs"
 		}
 	}`
+
+	testNrqlConditionEntityGUID = common.EntityGUID("NDAwQzA0rEFST1BTfENPTkRJVElPTnw3MzUzNjL")
 )
 
 func TestListNrqlConditions(t *testing.T) {
@@ -113,6 +142,7 @@ func TestListNrqlConditions(t *testing.T) {
 			ID:                  12345,
 			ViolationCloseTimer: 3600,
 			Enabled:             true,
+			EntityGUID:          &testNrqlConditionEntityGUID,
 		},
 	}
 
@@ -148,6 +178,7 @@ func TestGetNrqlCondition(t *testing.T) {
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             true,
+		EntityGUID:          &testNrqlConditionEntityGUID,
 	}
 
 	actual, err := alerts.GetNrqlCondition(123, 12345)
@@ -159,7 +190,7 @@ func TestGetNrqlCondition(t *testing.T) {
 
 func TestCreateNrqlCondition(t *testing.T) {
 	t.Parallel()
-	alerts := newMockResponse(t, testNrqlConditionJSON, http.StatusCreated)
+	alerts := newMockResponse(t, testNrqlConditionCreateJSON, http.StatusCreated)
 	policyID := 333
 
 	condition := NrqlCondition{
@@ -219,6 +250,7 @@ func TestUpdateNrqlCondition(t *testing.T) {
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             true,
+		EntityGUID:          &testNrqlConditionEntityGUID,
 	}
 
 	expected := &NrqlCondition{
@@ -254,7 +286,6 @@ func TestUpdateNrqlCondition(t *testing.T) {
 func TestDeleteNrqlCondition(t *testing.T) {
 	t.Parallel()
 	alerts := newMockResponse(t, testNrqlConditionJSON, http.StatusOK)
-
 	expected := &NrqlCondition{
 		Nrql: NrqlQuery{
 			Query:      "SELECT count(*) FROM Transactions",
@@ -276,6 +307,7 @@ func TestDeleteNrqlCondition(t *testing.T) {
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             true,
+		EntityGUID:          &testNrqlConditionEntityGUID,
 	}
 
 	actual, err := alerts.DeleteNrqlCondition(12345)


### PR DESCRIPTION
This PR will expose EntityGUID on NRQL Alert Conditions. 

These EntityGUIDs will be exposed to consumers of New Relic's Terraform Provider. 

https://newrelic.atlassian.net/browse/AINTER-8515

In addition to the unit test update, I ran this locally to confirm I could see my EntityGUIDs on existing NRQL Conditions 

```
package main

import (
	"fmt"
	"github.com/newrelic/newrelic-client-go/newrelic"
)

func main() {

	client, err := newrelic.New(newrelic.ConfigPersonalAPIKey("YOUR_API_KEY_HERE"))
	if err != nil {
		fmt.Printf("error initializing client:", err)
	}

	conditions, err := client.Alerts.ListNrqlConditions(<Your Policy ID Number Here>)
	if err != nil {
		fmt.Printf("error listing conditions", err)
	}
	for _, condition := range conditions {
		fmt.Println(*condition.EntityGUID)
	}

}
```