### PR TITLE
feat(nrqldroprules): add `source` attribute to drop rules

### DIFF
--- a/pkg/nrqldroprules/example_basic_test.go
+++ b/pkg/nrqldroprules/example_basic_test.go
@@ -33,6 +33,7 @@ func Example_basic() {
 			Action:      NRQLDropRulesActionTypes.DROP_DATA,
 			Description: "NRQL drop rule description",
 			NRQL:        "SELECT * FROM Log WHERE container_name = 'noise'",
+			Source:      "Logging",
 		},
 	}
 

--- a/pkg/nrqldroprules/nrqldroprules_api.go
+++ b/pkg/nrqldroprules/nrqldroprules_api.go
@@ -53,6 +53,7 @@ const NRQLDropRulesCreateMutation = `mutation(
 		description
 		id
 		nrql
+		source
 	}
 } }`
 
@@ -106,6 +107,7 @@ const NRQLDropRulesDeleteMutation = `mutation(
 		description
 		id
 		nrql
+		source
 	}
 } }`
 
@@ -151,5 +153,6 @@ const getListQuery = `query(
 		description
 		id
 		nrql
+		source
 	}
 } } } } }`

--- a/pkg/nrqldroprules/nrqldroprules_integration_test.go
+++ b/pkg/nrqldroprules/nrqldroprules_integration_test.go
@@ -24,16 +24,19 @@ func TestIntegrationDropRules(t *testing.T) {
 		testRuleDescription      = "testRuleDescription_" + rand
 		testOtherRuleDescription = "testRuleOtherDescription_" + rand
 		testRuleNrql             = "SELECT * FROM Log WHERE container_name = 'noise'"
+		testRuleSource           = "Logging"
 		testCreateInput          = []NRQLDropRulesCreateDropRuleInput{
 			{
 				Description: testRuleDescription,
 				NRQL:        testRuleNrql,
 				Action:      NRQLDropRulesActionTypes.DROP_DATA,
+				Source:      testRuleSource,
 			},
 			{
 				Description: testOtherRuleDescription,
 				NRQL:        testRuleNrql,
 				Action:      NRQLDropRulesActionTypes.DROP_DATA,
+				Source:      testRuleSource,
 			},
 		}
 	)

--- a/pkg/nrqldroprules/types.go
+++ b/pkg/nrqldroprules/types.go
@@ -95,6 +95,8 @@ type NRQLDropRulesCreateDropRuleInput struct {
 	Description string `json:"description,omitempty"`
 	// The NRQL string used to match data you want to take the specified action on.
 	NRQL string `json:"nrql"`
+	// The source of the drop rule. Set to `Logging` to display the rule in the Logs UI. Defaults to `NerdGraph`.
+	Source string `json:"source,omitempty"`
 }
 
 // NRQLDropRulesCreateDropRuleResult - The result of which submitted drop rules were successfully and unsuccessfully created.
@@ -115,6 +117,8 @@ type NRQLDropRulesCreateDropRuleSubmission struct {
 	Description string `json:"description,omitempty"`
 	// The NRQL string used to match data you want to take the specified action on.
 	NRQL string `json:"nrql"`
+	// The source of the drop rule. Set to `Logging` to display the rule in the Logs UI. Defaults to `NerdGraph`.
+	Source string `json:"source,omitempty"`
 }
 
 // NRQLDropRulesDeleteDropRuleFailure - Error details about the rule that failed to be deleted and why.
@@ -157,6 +161,8 @@ type NRQLDropRulesDropRule struct {
 	ID string `json:"id"`
 	// The NRQL used to match data that will receive the `action`.
 	NRQL string `json:"nrql"`
+	// The source of the drop rule. Set to `Logging` to display the rule in the Logs UI. Defaults to `NerdGraph`.
+	Source string `json:"source,omitempty"`
 }
 
 // NRQLDropRulesError - Error details when processing drop rule requests.


### PR DESCRIPTION
In order to display drop rules added with the NerdGraph API, the `source` field of the rules needs to be set to `Logging`. (see https://docs.newrelic.com/docs/logs/ui-data/drop-data-drop-filter-rules/#nerdgraph)

This change adds an optional `Source` field to the respective structs, such that the user can change the source of the drop rule and also see them when querying them.