### PR TITLE
feat(alerts): Adds 3 term threshold operators for NRQL conditions

### DIFF
--- a/pkg/alerts/types.go
+++ b/pkg/alerts/types.go
@@ -162,17 +162,29 @@ type AlertsNRQLConditionTermsOperator string
 var AlertsNRQLConditionTermsOperatorTypes = struct {
 	// For comparing values above a threshold.
 	ABOVE AlertsNRQLConditionTermsOperator
+	// For comparing values above or equal to a threshold.
+	ABOVE_OR_EQUALS AlertsNRQLConditionTermsOperator
 	// For comparing values below a threshold.
 	BELOW AlertsNRQLConditionTermsOperator
+	// For comparing values below or equal to a threshold.
+	BELOW_OR_EQUALS AlertsNRQLConditionTermsOperator
 	// For comparing values equal to a threshold.
 	EQUALS AlertsNRQLConditionTermsOperator
+	// For comparing values that do not equal a threshold.
+	NOT_EQUALS AlertsNRQLConditionTermsOperator
 }{
 	// For comparing values above a threshold.
 	ABOVE: "ABOVE",
+	// For comparing values above or equal to a threshold.
+	ABOVE_OR_EQUALS: "ABOVE_OR_EQUALS",
 	// For comparing values below a threshold.
 	BELOW: "BELOW",
+	// For comparing values below or equal to a threshold.
+	BELOW_OR_EQUALS: "BELOW_OR_EQUALS",
 	// For comparing values equal to a threshold.
 	EQUALS: "EQUALS",
+	// For comparing values that do not equal a threshold.
+	NOT_EQUALS: "NOT_EQUALS",
 }
 
 // AlertsMutingRuleConditionGroupInput - A group of MutingRuleConditions combined by an operator.


### PR DESCRIPTION
# Description

Adds support for 3 additional term threshold operators for static NRQL conditions.

See also: https://github.com/newrelic/terraform-provider-newrelic/pull/1797

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

This merely adds 3 values to the `AlertsNRQLConditionTermsOperatorTypes` struct -- testing is in the context of the Terraform provider updates.