### PR TITLE
fix: remove deprecated field from service level query

### DIFF
--- a/pkg/servicelevel/servicelevel_api.go
+++ b/pkg/servicelevel/servicelevel_api.go
@@ -349,7 +349,6 @@ const getIndicatorsQuery = `query(
 			}
 		}
 	}
-	slug
 	updatedAt
 	updatedBy {
 		email


### PR DESCRIPTION
The field is deprecated, we want to remove in the future so we need to remove it from the terraform-provider.