### PR TITLE
fix: omit filter ID when empty

### DIFF
--- a/pkg/workflows/types.go
+++ b/pkg/workflows/types.go
@@ -579,7 +579,7 @@ type AiWorkflowsUpdatedFilterInput struct {
 	// filterInput
 	FilterInput AiWorkflowsFilterInput `json:"filterInput,omitempty"`
 	// id
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 }
 
 // AiWorkflowsWorkflow - Workflow object


### PR DESCRIPTION
This is a fix for https://github.com/newrelic/terraform-provider-newrelic/issues/1986 . When trying to update a workflow via terraform an error is thrown due to the fact that no filter ID (empty) is passed the first time. By allowing this to be omitted when empty (which is still a valid request) the terraform update of a workflow works and results in a valid workflow.