### PR TITLE
fix(nrdb): Use actor.queryHistory NerdGraph endpoint

### DIFF
--- a/pkg/nrdb/nrdb_integration_test.go
+++ b/pkg/nrdb/nrdb_integration_test.go
@@ -48,8 +48,6 @@ func TestIntegrationNrdbQuery(t *testing.T) {
 }
 
 func TestIntegrationNrdbQueryHistoryQuery(t *testing.T) {
-	t.Skipf("This endpoint is going away in favor of actor.queryHistory")
-
 	t.Parallel()
 
 	client := newNrdbIntegrationTestClient(t)

--- a/pkg/nrdb/nrdb_query.go
+++ b/pkg/nrdb/nrdb_query.go
@@ -35,11 +35,11 @@ func (n *Nrdb) QueryHistoryWithContext(ctx context.Context) (*[]NRQLHistoricalQu
 		return nil, err
 	}
 
-	return &respBody.Actor.NRQLQueryHistory, nil
+	return &respBody.Actor.QueryHistory.Nrql, nil
 }
 
 const (
-	gqlNrqlQueryHistoryQuery = `{ actor { nrqlQueryHistory { accountId nrql timestamp } } }`
+	gqlNrqlQueryHistoryQuery = `{ actor { queryHistory { nrql { accountIds query createdAt } } } }`
 
 	gqlNrqlQuery = `query($query: Nrql!, $accountId: Int!) { actor { account(id: $accountId) { nrql(query: $query) {
     currentResults otherResult previousResults results totalResult
@@ -57,6 +57,8 @@ type gqlNrglQueryResponse struct {
 
 type gqlNrglQueryHistoryResponse struct {
 	Actor struct {
-		NRQLQueryHistory []NRQLHistoricalQuery
+		QueryHistory struct {
+			Nrql []NRQLHistoricalQuery
+		}
 	}
 }

--- a/pkg/nrdb/types.go
+++ b/pkg/nrdb/types.go
@@ -225,11 +225,11 @@ type NRQLFacetSuggestion struct {
 // NRQLHistoricalQuery - An NRQL query executed in the past.
 type NRQLHistoricalQuery struct {
 	// The Account ID queried.
-	AccountID int `json:"accountId,omitempty"`
+	AccountIDs []int `json:"accountIds,omitempty"`
 	// The NRQL query executed.
-	NRQL NRQL `json:"nrql,omitempty"`
+	Query NRQL `json:"query,omitempty"`
 	// The time the query was executed.
-	Timestamp nrtime.EpochSeconds `json:"timestamp,omitempty"`
+	CreatedAt nrtime.DateTime `json:"createdAt,omitempty"`
 }
 
 // SuggestedAnomalyBasedNRQLQuery - A query suggestion based on analysis of events within a specific anomalous time


### PR DESCRIPTION
This PR modifies the `QueryHistory` operation to use the  `actor.queryHistory` endpoint instead of the soon-to-be-deprecated `actor.nrqlQueryHistory`.

This PR also re-enables the failing integration test. Running the integration test (targetting only `pkg/nrdb`) shows:
```
$ NEW_RELIC_API_KEY=... gotestsum -f testname --junitfile ./integration.xml --packages "github.com/newrelic/newrelic-client-go/v2/pkg/nrdb"  -- -v -parallel 4 -tags integration -coverprofile ./integration.tmp github.com/newrelic/newrelic-client-go/v2/pkg/nrdb
PASS pkg/nrdb.TestIntegrationNrdbQueryHistoryQuery (0.94s)
PASS pkg/nrdb.TestIntegrationNrdbQuery (0.97s)
coverage: 17.2% of statements
PASS pkg/nrdb

DONE 2 tests in 2.123s
```