### PR TITLE
fix(workflows): allow to remove enrichments from workflows

### DIFF
--- a/pkg/workflows/types.go
+++ b/pkg/workflows/types.go
@@ -531,7 +531,7 @@ func (x *AiWorkflowsTestResponseError) ImplementsAiWorkflowsResponseError() {}
 // AiWorkflowsUpdateEnrichmentsInput - Update Enrichment input object
 type AiWorkflowsUpdateEnrichmentsInput struct {
 	// nrql
-	NRQL []AiWorkflowsNRQLUpdateEnrichmentInput `json:"nrql,omitempty"`
+	NRQL []AiWorkflowsNRQLUpdateEnrichmentInput `json:"nrql"`
 }
 
 // AiWorkflowsUpdateResponseError - Update error description

--- a/pkg/workflows/types_unit_test.go
+++ b/pkg/workflows/types_unit_test.go
@@ -75,6 +75,27 @@ func TestAiWorkflowsUpdateWorkflowResponse_EmptyName_JsonFormat(t *testing.T) {
 	)
 }
 
+// Verify that if the user wants to remove all enrichments name, we explicitly pass an empty value
+func TestAiWorkflowsUpdateWorkflowResponse_EmptyEnrichments_JsonFormat(t *testing.T) {
+	t.Parallel()
+	emptyEnrichments := AiWorkflowsUpdateEnrichmentsInput{
+		NRQL: []AiWorkflowsNRQLUpdateEnrichmentInput{},
+	}
+	input := AiWorkflowsUpdateWorkflowInput{
+		ID:          "10",
+		Enrichments: &emptyEnrichments,
+	}
+
+	serialized, err := json.Marshal(input)
+
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"{\"enrichments\":{\"nrql\":[]},\"id\":\"10\"}",
+		string(serialized),
+	)
+}
+
 // Verify that it is possible to pass an empty value for muting rules
 func TestAiWorkflowsUpdateWorkflowResponse_EmptyMutingRules_JsonFormat(t *testing.T) {
 	t.Parallel()

--- a/pkg/workflows/workflows_integration_test.go
+++ b/pkg/workflows/workflows_integration_test.go
@@ -175,7 +175,28 @@ func TestIntegrationUpdateWorkflow_UpdateEverything(t *testing.T) {
 	require.Equal(t, (*workflowInput.DestinationConfigurations)[0].ChannelId, updatedWorkflow.DestinationConfigurations[0].ChannelId)
 }
 
-// TODO: test enrichment removal (does not work currently)
+func TestIntegrationUpdateWorkflow_RemoveEnrichments(t *testing.T) {
+	t.Parallel()
+
+	// Create stuff to update
+	workflow, destination := createTestWorkflow(t)
+	defer cleanupDestination(t, destination)
+	defer cleanupWorkflow(t, workflow)
+
+	// just assert that the created workflow is enabled
+	require.Equal(t, true, workflow.WorkflowEnabled)
+
+	workflowsClient := newIntegrationTestClient(t)
+	emptyEnrichments := AiWorkflowsUpdateEnrichmentsInput{NRQL: []AiWorkflowsNRQLUpdateEnrichmentInput{}}
+	updatedWorkflow, err := workflowsClient.AiWorkflowsUpdateWorkflow(workflow.AccountID, AiWorkflowsUpdateWorkflowInput{
+		ID:          workflow.ID,
+		Enrichments: &emptyEnrichments,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, updatedWorkflow)
+	require.Empty(t, updatedWorkflow.Workflow.Enrichments)
+}
 
 func TestIntegrationUpdateWorkflow_DisableWorkflow(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Currently, once add enrichments to a workflow you cannot remove them unless you remove the entire workflow.

The reason for this is that:
- A `nil` value for `enrichments` field is treated as 'please don't change anything'
- `{"enrichments": {}}` is not a valid value according to our GraphQL schema definition
- `{"enrichments": {"nrql": []}}` is impossible to pass because we have `omitempty` on `AiWorkflowsUpdateEnrichmentsInput::NRQL`

This commit removes `omitempty`, allowing client users to remove all enrichments from a workflow if needed