### PR TITLE
feat: Remove value_function from NRQL Alert Conditions

### DIFF
--- a/pkg/alerts/example_policy_test.go
+++ b/pkg/alerts/example_policy_test.go
@@ -51,11 +51,10 @@ func Example_policy() {
 
 	// Create a new NRQL alert condition.
 	nc := &NrqlCondition{
-		Name:          "Example NRQL condition",
-		Type:          "static",
-		RunbookURL:    "https://www.example.com/myrunbook",
-		Enabled:       true,
-		ValueFunction: ValueFunctionTypes.SingleValue,
+		Name:       "Example NRQL condition",
+		Type:       "static",
+		RunbookURL: "https://www.example.com/myrunbook",
+		Enabled:    true,
 		Nrql: NrqlQuery{
 			Query:      "FROM Transaction SELECT average(duration) WHERE appName = 'Example Application'",
 			SinceValue: "3",

--- a/pkg/alerts/nrql_conditions.go
+++ b/pkg/alerts/nrql_conditions.go
@@ -131,20 +131,6 @@ var (
 	}
 )
 
-// NrqlConditionValueFunction specifies the value function of NRQL alert condition.
-type NrqlConditionValueFunction string
-
-var (
-	// NrqlConditionValueFunctions enumerates the possible NRQL condition value function values for NRQL alert conditions.
-	NrqlConditionValueFunctions = struct {
-		SingleValue NrqlConditionValueFunction
-		Sum         NrqlConditionValueFunction
-	}{
-		SingleValue: "SINGLE_VALUE",
-		Sum:         "SUM",
-	}
-)
-
 // NrqlConditionViolationTimeLimit specifies the value function of NRQL alert condition.
 type NrqlConditionViolationTimeLimit string
 
@@ -292,9 +278,6 @@ type NrqlConditionCreateInput struct {
 
 	// BaselineDirection ONLY applies to NRQL conditions of type BASELINE.
 	BaselineDirection *NrqlBaselineDirection `json:"baselineDirection,omitempty"`
-
-	// ValueFunction ONLY applies to NRQL conditions of type STATIC.
-	ValueFunction *NrqlConditionValueFunction `json:"valueFunction,omitempty"`
 }
 
 // NrqlConditionUpdateInput represents the input options for updating a Nrql Condition.
@@ -303,9 +286,6 @@ type NrqlConditionUpdateInput struct {
 
 	// BaselineDirection ONLY applies to NRQL conditions of type BASELINE.
 	BaselineDirection *NrqlBaselineDirection `json:"baselineDirection,omitempty"`
-
-	// ValueFunction ONLY applies to NRQL conditions of type STATIC.
-	ValueFunction *NrqlConditionValueFunction `json:"valueFunction,omitempty"`
 }
 
 type NrqlConditionsSearchCriteria struct {
@@ -326,9 +306,6 @@ type NrqlAlertCondition struct {
 
 	// BaselineDirection exists ONLY for NRQL conditions of type BASELINE.
 	BaselineDirection *NrqlBaselineDirection `json:"baselineDirection,omitempty"`
-
-	// ValueFunction is returned ONLY for NRQL conditions of type STATIC.
-	ValueFunction *NrqlConditionValueFunction `json:"valueFunction,omitempty"`
 }
 
 // NrqlCondition represents a New Relic NRQL Alert condition.
@@ -341,7 +318,6 @@ type NrqlCondition struct {
 	RunbookURL          string             `json:"runbook_url,omitempty"`
 	Terms               []ConditionTerm    `json:"terms,omitempty"`
 	Type                string             `json:"type,omitempty"`
-	ValueFunction       ValueFunctionType  `json:"value_function,omitempty"`
 	EntityGUID          *common.EntityGUID `json:"entity_guid,omitempty"`
 }
 
@@ -771,12 +747,6 @@ const (
 		}
 	`
 
-	graphqlFragmentNrqlStaticConditionFields = `
-		... on AlertsNrqlStaticCondition {
-			valueFunction
-		}
-	`
-
 	searchNrqlConditionsQuery = `
 		query($accountId: Int!, $searchCriteria: AlertsNrqlConditionsSearchCriteriaInput, $cursor: String) {
 			actor {
@@ -788,7 +758,6 @@ const (
 							nrqlConditions {` +
 		graphqlNrqlConditionStructFields +
 		graphqlFragmentNrqlBaselineConditionFields +
-		graphqlFragmentNrqlStaticConditionFields +
 		`} } } } } }`
 
 	getNrqlConditionQuery = `
@@ -799,7 +768,6 @@ const (
 						nrqlCondition(id: $id) {` +
 		graphqlNrqlConditionStructFields +
 		graphqlFragmentNrqlBaselineConditionFields +
-		graphqlFragmentNrqlStaticConditionFields +
 		`} } } } }`
 
 	// Baseline
@@ -821,16 +789,14 @@ const (
 	// Static
 	createNrqlConditionStaticMutation = `
 		mutation($accountId: Int!, $policyId: ID!, $condition: AlertsNrqlConditionStaticInput!) {
-			alertsNrqlConditionStaticCreate(accountId: $accountId, policyId: $policyId, condition: $condition) {
-				valueFunction` +
+			alertsNrqlConditionStaticCreate(accountId: $accountId, policyId: $policyId, condition: $condition) {` +
 		graphqlNrqlConditionStructFields +
 		` } }`
 
 	// Static
 	updateNrqlConditionStaticMutation = `
 		mutation($accountId: Int!, $id: ID!, $condition: AlertsNrqlConditionUpdateStaticInput!) {
-			alertsNrqlConditionStaticUpdate(accountId: $accountId, id: $id, condition: $condition) {
-				valueFunction` +
+			alertsNrqlConditionStaticUpdate(accountId: $accountId, id: $id, condition: $condition) {` +
 		graphqlNrqlConditionStructFields +
 		` } }`
 )

--- a/pkg/alerts/nrql_conditions_integration_test.go
+++ b/pkg/alerts/nrql_conditions_integration_test.go
@@ -26,7 +26,6 @@ var (
 	nrqlConditionBaseAggDelay           = 2                                           // needed for setting pointer
 	nrqlConditionBaseAggTimer           = 5                                           // needed for setting pointer
 	nrqlConditionBaseSlideBy            = 30                                          // needed for setting pointer
-	nrqlConditionBaseValueFunction      = NrqlConditionValueFunctions.SingleValue     // needed for setting pointer
 
 	nrqlConditionCreateBase = NrqlConditionCreateBase{
 		Description: "test description",
@@ -252,7 +251,6 @@ func TestIntegrationNrqlConditions(t *testing.T) {
 			Type:                "static",
 			Name:                nrqlConditionName,
 			RunbookURL:          "https://www.example.com",
-			ValueFunction:       "single_value",
 			ViolationCloseTimer: 3600,
 			Enabled:             true,
 		}
@@ -382,11 +380,9 @@ func TestIntegrationNrqlConditions_Static(t *testing.T) {
 		randStr           = mock.RandSeq(5)
 		createStaticInput = NrqlConditionCreateInput{
 			NrqlConditionCreateBase: nrqlConditionCreateBase,
-			ValueFunction:           &NrqlConditionValueFunctions.SingleValue,
 		}
 		updateStaticInput = NrqlConditionUpdateInput{
 			NrqlConditionUpdateBase: nrqlConditionUpdateBase,
-			ValueFunction:           &NrqlConditionValueFunctions.SingleValue,
 		}
 	)
 
@@ -422,80 +418,6 @@ func TestIntegrationNrqlConditions_Static(t *testing.T) {
 	updateStaticInput.Description = "test description updated"
 	_, err = client.UpdateNrqlConditionStaticMutation(testAccountID, readResult.ID, updateStaticInput)
 	require.NoError(t, err)
-
-	// Deferred teardown
-	defer func() {
-		_, err := client.DeletePolicyMutation(testAccountID, policy.ID)
-		if err != nil {
-			t.Logf("error cleaning up alert policy %s (%s): %s", policy.ID, policy.Name, err)
-		}
-	}()
-}
-
-func TestIntegrationNrqlConditions_ErrorScenarios(t *testing.T) {
-	t.Parallel()
-
-	testAccountID, err := mock.GetTestAccountID()
-	if err != nil {
-		t.Skipf("%s", err)
-	}
-
-	var (
-		randStr = mock.RandSeq(5)
-
-		// Invalid NrqlConditionCreateInput (Baseline and ValueFunction cannot exist together)
-		testInvalidMutationCreateInput = NrqlConditionCreateInput{
-			NrqlConditionCreateBase: nrqlConditionCreateBase,
-
-			// Having both of the following fields should result in an error returned from the API
-			BaselineDirection: &NrqlBaselineDirections.LowerOnly,
-			ValueFunction:     &NrqlConditionValueFunctions.SingleValue,
-		}
-
-		// Invalid NrqlConditionUpdateInput (Baseline and ValueFunction cannot exist together)
-		testInvalidMutationUpdateInput = NrqlConditionUpdateInput{
-			NrqlConditionUpdateBase: nrqlConditionUpdateBase,
-
-			// Having both of the following fields should result in an error returned from the API
-			BaselineDirection: &NrqlBaselineDirections.LowerOnly,
-			ValueFunction:     &NrqlConditionValueFunctions.SingleValue,
-		}
-	)
-
-	// Setup
-	client := newIntegrationTestClient(t)
-	testPolicy := AlertsPolicyInput{
-		IncidentPreference: AlertsIncidentPreferenceTypes.PER_POLICY,
-		Name:               fmt.Sprintf("test-alert-policy-%s", randStr),
-	}
-	policy, err := client.CreatePolicyMutation(testAccountID, testPolicy)
-	require.NoError(t, err)
-
-	// Test: Create Invalid (should result in an error)
-	createdBaseline, err := client.CreateNrqlConditionBaselineMutation(testAccountID, policy.ID, testInvalidMutationCreateInput)
-	require.Error(t, err)
-	require.Nil(t, createdBaseline)
-
-	// Test: Update Invalid (should result in an error)
-	updatedBaseline, err := client.UpdateNrqlConditionBaselineMutation(testAccountID, "8675309", testInvalidMutationUpdateInput)
-	require.Error(t, err)
-	require.Nil(t, updatedBaseline)
-
-	// Test: Create Invalid (should result in an error)
-	createdStatic, err := client.CreateNrqlConditionStaticMutation(testAccountID, policy.ID, testInvalidMutationCreateInput)
-	require.Error(t, err)
-	require.Nil(t, createdStatic)
-
-	// Test: Update Invalid (should result in an error)
-	updatedStatic, err := client.UpdateNrqlConditionStaticMutation(testAccountID, "8675309", testInvalidMutationUpdateInput)
-	require.Error(t, err)
-	require.Nil(t, updatedStatic)
-
-	// Test: 'Not Found' error for non-existent condition
-	_, err = client.GetNrqlConditionQuery(testAccountID, "999999999999999")
-	require.Error(t, err)
-	_, ok := err.(*errors.NotFound)
-	require.True(t, ok)
 
 	// Deferred teardown
 	defer func() {
@@ -613,7 +535,6 @@ func TestIntegrationNrqlConditions_CreateStatic(t *testing.T) {
 				},
 				ViolationTimeLimitSeconds: 3600,
 			},
-			ValueFunction: &NrqlConditionValueFunctions.SingleValue,
 		}
 	)
 
@@ -672,7 +593,6 @@ func TestIntegrationNrqlConditions_ZeroValueThreshold(t *testing.T) {
 				},
 				ViolationTimeLimitSeconds: 3600,
 			},
-			ValueFunction: &NrqlConditionValueFunctions.SingleValue,
 		}
 	)
 
@@ -711,11 +631,9 @@ func TestIntegrationNrqlConditions_StreamingMethods(t *testing.T) {
 		randStr                     = mock.RandSeq(5)
 		createStreamingMethodsInput = NrqlConditionCreateInput{
 			NrqlConditionCreateBase: nrqlConditionCreateWithStreamingMethods,
-			ValueFunction:           &NrqlConditionValueFunctions.SingleValue,
 		}
 		updateStreamingMethodsInput = NrqlConditionUpdateInput{
 			NrqlConditionUpdateBase: nrqlConditionUpdateWithStreamingMethods,
-			ValueFunction:           &NrqlConditionValueFunctions.SingleValue,
 		}
 	)
 
@@ -778,66 +696,6 @@ func TestIntegrationNrqlConditions_StreamingMethods(t *testing.T) {
 	require.Nil(t, updatedStaticWithoutStreamingMethods.Signal.AggregationDelay)
 	require.Nil(t, updatedStaticWithoutStreamingMethods.Signal.AggregationTimer)
 	require.Equal(t, &nrqlConditionBaseEvalOffset, updatedStaticWithoutStreamingMethods.Signal.EvaluationOffset)
-
-	// Deferred teardown
-	defer func() {
-		_, err := client.DeletePolicyMutation(testAccountID, policy.ID)
-		if err != nil {
-			t.Logf("error cleaning up alert policy %s (%s): %s", policy.ID, policy.Name, err)
-		}
-	}()
-}
-
-func TestIntegrationNrqlConditions_ValueFunctionOptional(t *testing.T) {
-	t.Parallel()
-
-	testAccountID, err := mock.GetTestAccountID()
-	if err != nil {
-		t.Skipf("%s", err)
-	}
-
-	var (
-		randStr                    = mock.RandSeq(5)
-		createNoValueFunctionInput = NrqlConditionCreateInput{
-			NrqlConditionCreateBase: nrqlConditionCreateBase,
-		}
-		updateToAddValueFunctionInput = NrqlConditionUpdateInput{
-			NrqlConditionUpdateBase: nrqlConditionUpdateBase,
-			ValueFunction:           &NrqlConditionValueFunctions.SingleValue,
-		}
-	)
-
-	// Setup
-	client := newIntegrationTestClient(t)
-	testPolicy := AlertsPolicyInput{
-		IncidentPreference: AlertsIncidentPreferenceTypes.PER_POLICY,
-		Name:               fmt.Sprintf("test-alert-policy-%s", randStr),
-	}
-	policy, err := client.CreatePolicyMutation(testAccountID, testPolicy)
-	require.NoError(t, err)
-
-	// Test: Create (static condition without value function)
-	createdStaticWithoutValueFunction, err := client.CreateNrqlConditionStaticMutation(testAccountID, policy.ID, createNoValueFunctionInput)
-	require.NoError(t, err)
-	require.NotNil(t, createdStaticWithoutValueFunction)
-	require.NotNil(t, createdStaticWithoutValueFunction.ID)
-	require.NotNil(t, createdStaticWithoutValueFunction.PolicyID)
-	// When static condition is created without value function, API returns single value as value function
-	require.Equal(t, &nrqlConditionBaseValueFunction, createdStaticWithoutValueFunction.ValueFunction)
-
-	// Test: Get (static condition without value function)
-	readResult, err := client.GetNrqlConditionQuery(testAccountID, createdStaticWithoutValueFunction.ID)
-	require.NoError(t, err)
-	require.NotNil(t, readResult)
-	// When static condition is created without value function, API returns single value as value function
-	require.Equal(t, &nrqlConditionBaseValueFunction, readResult.ValueFunction)
-
-	// Test: Update (static condition with value function)
-	nrqlConditionSumValueFunction := NrqlConditionValueFunctions.SingleValue // needed for setting pointer
-
-	updatedStaticWithValueFunction, err := client.UpdateNrqlConditionStaticMutation(testAccountID, readResult.ID, updateToAddValueFunctionInput)
-	require.NoError(t, err)
-	require.Equal(t, &nrqlConditionSumValueFunction, updatedStaticWithValueFunction.ValueFunction)
 
 	// Deferred teardown
 	defer func() {

--- a/pkg/alerts/nrql_conditions_test.go
+++ b/pkg/alerts/nrql_conditions_test.go
@@ -20,7 +20,6 @@ var (
 				"id": 12345,
 				"name": "NRQL Test Alert",
 				"enabled": true,
-				"value_function": "single_value",
 				"violation_time_limit_seconds": 3600,
 				"terms": [
 					{
@@ -46,7 +45,6 @@ var (
 			"id": 12345,
 			"name": "NRQL Test Alert",
 			"enabled": true,
-			"value_function": "single_value",
 			"violation_time_limit_seconds": 3600,
 			"terms": [
 				{
@@ -71,7 +69,6 @@ var (
 			"id": 12345,
 			"name": "NRQL Test Alert",
 			"enabled": true,
-			"value_function": "single_value",
 			"violation_time_limit_seconds": 3600,
 			"terms": [
 				{
@@ -95,7 +92,6 @@ var (
 			"id": 12345,
 			"name": "NRQL Test Alert Updated",
 			"enabled": false,
-			"value_function": "single_value",
 			"violation_time_limit_seconds": 3600,
 			"terms": [
 				{
@@ -139,7 +135,6 @@ func TestListNrqlConditions(t *testing.T) {
 			Type:                "static",
 			Name:                "NRQL Test Alert",
 			RunbookURL:          "",
-			ValueFunction:       "single_value",
 			ID:                  12345,
 			ViolationCloseTimer: 3600,
 			Enabled:             true,
@@ -175,7 +170,6 @@ func TestGetNrqlCondition(t *testing.T) {
 		Type:                "static",
 		Name:                "NRQL Test Alert",
 		RunbookURL:          "",
-		ValueFunction:       "single_value",
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             true,
@@ -211,7 +205,6 @@ func TestCreateNrqlCondition(t *testing.T) {
 		Type:                "static",
 		Name:                "NRQL Test Alert",
 		RunbookURL:          "",
-		ValueFunction:       "single_value",
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             true,
@@ -247,7 +240,6 @@ func TestUpdateNrqlCondition(t *testing.T) {
 		Type:                "static",
 		Name:                "NRQL Test Alert",
 		RunbookURL:          "",
-		ValueFunction:       "single_value",
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             true,
@@ -271,7 +263,6 @@ func TestUpdateNrqlCondition(t *testing.T) {
 		Type:                "static",
 		Name:                "NRQL Test Alert Updated",
 		RunbookURL:          "https://www.example.com/docs",
-		ValueFunction:       "single_value",
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             false,
@@ -304,7 +295,6 @@ func TestDeleteNrqlCondition(t *testing.T) {
 		Type:                "static",
 		Name:                "NRQL Test Alert",
 		RunbookURL:          "",
-		ValueFunction:       "single_value",
 		ID:                  12345,
 		ViolationCloseTimer: 3600,
 		Enabled:             true,


### PR DESCRIPTION
[NR-9749]https://issues.newrelic.com/browse/NR-9749

This pull request removes the "value function" field and its "single_value" / "sum" type from NRQL alert conditions. The value function field for NRQL alert conditions is deprecated. Additionally, the "sum" value function is retired and there are no "sum" conditions in production today. 

When users create or update NRQL alert conditions, the Conditions API will add "value function". This eliminates the need for clients to supply the value function when interacting with NRQL Alert Conditions. 


