### PR TITLE
fix(workflows): fix issue that prevents creation of disabled workflows

### DIFF
--- a/pkg/workflows/types.go
+++ b/pkg/workflows/types.go
@@ -374,11 +374,11 @@ type AiWorkflowsCreateWorkflowInput struct {
 	// destinationConfigurations
 	DestinationConfigurations []AiWorkflowsDestinationConfigurationInput `json:"destinationConfigurations,omitempty"`
 	// destinationsEnabled
-	DestinationsEnabled bool `json:"destinationsEnabled,omitempty"`
+	DestinationsEnabled bool `json:"destinationsEnabled"`
 	// enrichments
 	Enrichments *AiWorkflowsEnrichmentsInput `json:"enrichments,omitempty"`
 	// enrichmentsEnabled
-	EnrichmentsEnabled bool `json:"enrichmentsEnabled,omitempty"`
+	EnrichmentsEnabled bool `json:"enrichmentsEnabled"`
 	// issuesFilter
 	IssuesFilter AiWorkflowsFilterInput `json:"issuesFilter,omitempty"`
 	// mutingRulesHandling
@@ -386,7 +386,7 @@ type AiWorkflowsCreateWorkflowInput struct {
 	// name
 	Name string `json:"name"`
 	// workflowEnabled
-	WorkflowEnabled bool `json:"workflowEnabled,omitempty"`
+	WorkflowEnabled bool `json:"workflowEnabled"`
 }
 
 // AiWorkflowsCreateWorkflowResponse - Create workflow mutation response including errors


### PR DESCRIPTION
`omitempty` directive used for boolean fields 'false' was not passed to the backend. 
At the same time, the value for these boolean fields on BE is `true`. 
So it was impossible to create a workflow in a disabled state.

This PR contains a test that reproduces the problem as well as a fix.