### PR TITLE
Revert "feat(Workflow): Add notification triggers"

### DIFF
--- a/pkg/changetracking/changetracking_api_integration_test.go
+++ b/pkg/changetracking/changetracking_api_integration_test.go
@@ -1,10 +1,9 @@
 package changetracking
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/nrtime"

--- a/pkg/entities/tags_integration_test.go
+++ b/pkg/entities/tags_integration_test.go
@@ -4,11 +4,9 @@
 package entities
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestIntegrationListTags(t *testing.T) {

--- a/pkg/workflows/types.go
+++ b/pkg/workflows/types.go
@@ -89,8 +89,6 @@ var AiWorkflowsDestinationTypeTypes = struct {
 	SERVICE_NOW AiWorkflowsDestinationType
 	// Slack Destination Configuration type
 	SLACK AiWorkflowsDestinationType
-	// Slack legacy Destination Configuration type
-	SLACK_LEGACY AiWorkflowsDestinationType
 	// Webhook Destination Configuration type
 	WEBHOOK AiWorkflowsDestinationType
 }{
@@ -112,8 +110,6 @@ var AiWorkflowsDestinationTypeTypes = struct {
 	SERVICE_NOW: "SERVICE_NOW",
 	// Slack Destination Configuration type
 	SLACK: "SLACK",
-	// Slack legacy Destination Configuration type
-	SLACK_LEGACY: "SLACK_LEGACY",
 	// Webhook Destination Configuration type
 	WEBHOOK: "WEBHOOK",
 }
@@ -161,33 +157,6 @@ var AiWorkflowsMutingRulesHandlingTypes = struct {
 	DONT_NOTIFY_FULLY_OR_PARTIALLY_MUTED_ISSUES: "DONT_NOTIFY_FULLY_OR_PARTIALLY_MUTED_ISSUES",
 	// Notify about all issues
 	NOTIFY_ALL_ISSUES: "NOTIFY_ALL_ISSUES",
-}
-
-// AiWorkflowsNotificationTrigger - Notification Triggers for the Destination Configuration
-type AiWorkflowsNotificationTrigger string
-
-var AiWorkflowsNotificationTriggerTypes = struct {
-	// Send a notification when the issue is acknowledged
-	ACKNOWLEDGED AiWorkflowsNotificationTrigger
-	// Send a notification when the issue is activated
-	ACTIVATED AiWorkflowsNotificationTrigger
-	// Send a notification when the issue is closed
-	CLOSED AiWorkflowsNotificationTrigger
-	// Sends notification when the issue has other updates
-	OTHER_UPDATES AiWorkflowsNotificationTrigger
-	// Send a notification when the issue's priority has changed
-	PRIORITY_CHANGED AiWorkflowsNotificationTrigger
-}{
-	// Send a notification when the issue is acknowledged
-	ACKNOWLEDGED: "ACKNOWLEDGED",
-	// Send a notification when the issue is activated
-	ACTIVATED: "ACTIVATED",
-	// Send a notification when the issue is closed
-	CLOSED: "CLOSED",
-	// Sends notification when the issue has other updates
-	OTHER_UPDATES: "OTHER_UPDATES",
-	// Send a notification when the issue's priority has changed
-	PRIORITY_CHANGED: "PRIORITY_CHANGED",
 }
 
 // AiWorkflowsOperator - Type of Filter
@@ -421,8 +390,6 @@ type AiWorkflowsDestinationConfiguration struct {
 	ChannelId string `json:"channelId"`
 	// Name of the Destination Configuration
 	Name string `json:"name"`
-	// Notification triggers of the Destination Configuration
-	NotificationTriggers []AiWorkflowsNotificationTrigger `json:"notificationTriggers"`
 	// Type of the Destination Configuration
 	Type AiWorkflowsDestinationType `json:"type"`
 }
@@ -431,8 +398,6 @@ type AiWorkflowsDestinationConfiguration struct {
 type AiWorkflowsDestinationConfigurationInput struct {
 	// channelId
 	ChannelId string `json:"channelId"`
-	// notificationTriggers
-	NotificationTriggers []AiWorkflowsNotificationTrigger `json:"notificationTriggers"`
 }
 
 // AiWorkflowsEnrichment - Makes it possible to augment the notification with additional data from the New Relic platform
@@ -497,8 +462,6 @@ type AiWorkflowsFilters struct {
 	ID string `json:"id,omitempty"`
 	// name
 	Name string `json:"name,omitempty"`
-	// nameLike
-	NameLike string `json:"nameLike,omitempty"`
 	// workflowEnabled
 	WorkflowEnabled bool `json:"workflowEnabled,omitempty"`
 }
@@ -623,7 +586,7 @@ type AiWorkflowsUpdatedFilterInput struct {
 type AiWorkflowsWorkflow struct {
 	// Account Id of this Workflow
 	AccountID int `json:"accountId"`
-	// The time this workflow was created
+	// The time the Workflow was created
 	CreatedAt nrtime.DateTime `json:"createdAt"`
 	// Specifies where to send the notifications
 	DestinationConfigurations []AiWorkflowsDestinationConfiguration `json:"destinationConfigurations"`
@@ -643,7 +606,7 @@ type AiWorkflowsWorkflow struct {
 	MutingRulesHandling AiWorkflowsMutingRulesHandling `json:"mutingRulesHandling"`
 	// Name of the Workflow
 	Name string `json:"name"`
-	// The time this workflow was updated
+	// The time the Workflow was last updated
 	UpdatedAt nrtime.DateTime `json:"updatedAt"`
 	// Is Workflow enabled
 	WorkflowEnabled bool `json:"workflowEnabled"`

--- a/pkg/workflows/workflows_api.go
+++ b/pkg/workflows/workflows_api.go
@@ -59,7 +59,6 @@ const AiWorkflowsCreateWorkflowMutation = `mutation(
 		destinationConfigurations {
 			channelId
 			name
-			notificationTriggers
 			type
 		}
 		destinationsEnabled
@@ -198,7 +197,6 @@ const AiWorkflowsUpdateWorkflowMutation = `mutation(
 		destinationConfigurations {
 			channelId
 			name
-			notificationTriggers
 			type
 		}
 		destinationsEnabled
@@ -280,7 +278,6 @@ const getWorkflowsQuery = `query(
 		destinationConfigurations {
 			channelId
 			name
-			notificationTriggers
 			type
 		}
 		destinationsEnabled

--- a/pkg/workflows/workflows_unit_test.go
+++ b/pkg/workflows/workflows_unit_test.go
@@ -34,8 +34,7 @@ var (
 			  {
 				"channelId": "0d11fd42-5919-4767-8cf5-e07cb71c1b04",
 				"name": "EMPTY",
-				"type": "EMAIL",
-				"notificationTriggers": ["ACTIVATED"]
+				"type": "EMAIL"
 			  }
 			],
 			"destinationsEnabled": false,
@@ -100,8 +99,7 @@ var (
                   {
                     "channelId": "0d11fd42-5919-4767-8cf5-e07cb71c1b04",
                     "name": "EMPTY",
-                    "type": "EMAIL",
-                    "notificationTriggers": ["ACTIVATED"]
+                    "type": "EMAIL"
                   }
                 ],
                 "destinationsEnabled": false,
@@ -196,7 +194,6 @@ func TestCreateWorkflow(t *testing.T) {
 		ChannelId: channelId,
 		Name:      "EMPTY",
 		Type:      "EMAIL",
-		NotificationTriggers: []AiWorkflowsNotificationTrigger{"ACTIVATED"},
 	}}
 	expectedIssuedFilter := AiWorkflowsFilter{
 		AccountID: accountId,
@@ -260,7 +257,6 @@ func TestGetWorkflow(t *testing.T) {
 		ChannelId: channelId,
 		Name:      "EMPTY",
 		Type:      "EMAIL",
-		NotificationTriggers: []AiWorkflowsNotificationTrigger{"ACTIVATED"},
 	}}
 	expectedEnrichments := []AiWorkflowsEnrichment{{
 		AccountID: accountId,


### PR DESCRIPTION
Reverts newrelic/newrelic-client-go#955

**These changes should only be released once notification triggers are available to all users.**

This NR client always requests all GraphQL fields it knows of, but notification triggers field is behind a feature-flag. The customers with this FF disabled would not be able to use workflows API through this client.

We are reverting this PR temporarily until the flag is fully rolled out. 