### PR TITLE
feat: Add evaluation delay to nrql conditions

### DIFF
--- a/pkg/alerts/nrql_conditions.go
+++ b/pkg/alerts/nrql_conditions.go
@@ -23,6 +23,7 @@ type AlertsNrqlConditionExpiration struct {
 type AlertsNrqlConditionSignal struct {
 	AggregationWindow *int                            `json:"aggregationWindow,omitempty"`
 	EvaluationOffset  *int                            `json:"evaluationOffset,omitempty"`
+	EvaluationDelay   *int                            `json:"evaluationDelay,omitempty"`
 	FillOption        *AlertsFillOption               `json:"fillOption"`
 	FillValue         *float64                        `json:"fillValue"`
 	AggregationMethod *NrqlConditionAggregationMethod `json:"aggregationMethod,omitempty"`
@@ -36,6 +37,7 @@ type AlertsNrqlConditionSignal struct {
 type AlertsNrqlConditionCreateSignal struct {
 	AggregationWindow *int                            `json:"aggregationWindow,omitempty"`
 	EvaluationOffset  *int                            `json:"evaluationOffset,omitempty"`
+	EvaluationDelay   *int                            `json:"evaluationDelay,omitempty"`
 	FillOption        *AlertsFillOption               `json:"fillOption"`
 	FillValue         *float64                        `json:"fillValue"`
 	AggregationMethod *NrqlConditionAggregationMethod `json:"aggregationMethod,omitempty"`
@@ -49,6 +51,7 @@ type AlertsNrqlConditionCreateSignal struct {
 type AlertsNrqlConditionUpdateSignal struct {
 	AggregationWindow *int                            `json:"aggregationWindow,omitempty"`
 	EvaluationOffset  *int                            `json:"evaluationOffset,omitempty"`
+	EvaluationDelay   *int                            `json:"evaluationDelay,omitempty"`
 	FillOption        *AlertsFillOption               `json:"fillOption"`
 	FillValue         *float64                        `json:"fillValue"`
 	AggregationMethod *NrqlConditionAggregationMethod `json:"aggregationMethod"`
@@ -732,6 +735,7 @@ const (
     signal {
 	  aggregationWindow
       evaluationOffset
+ 	  evaluationDelay
       fillOption
       fillValue
       aggregationMethod

--- a/pkg/alerts/nrql_conditions_integration_test.go
+++ b/pkg/alerts/nrql_conditions_integration_test.go
@@ -26,8 +26,8 @@ var (
 	nrqlConditionBaseAggDelay           = 2                                           // needed for setting pointer
 	nrqlConditionBaseAggTimer           = 5                                           // needed for setting pointer
 	nrqlConditionBaseSlideBy            = 30                                          // needed for setting pointer
-
-	nrqlConditionCreateBase = NrqlConditionCreateBase{
+	nrqlConditionEvaluationDelay        = 60                                          // needed for setting pointer
+	nrqlConditionCreateBase             = NrqlConditionCreateBase{
 		Description: "test description",
 		Enabled:     true,
 		Name:        fmt.Sprintf("test-nrql-condition-%s", testNrqlConditionRandomString),
@@ -54,6 +54,7 @@ var (
 		Signal: &AlertsNrqlConditionCreateSignal{
 			AggregationWindow: &nrqlConditionBaseAggWindow,
 			EvaluationOffset:  &nrqlConditionBaseEvalOffset,
+			EvaluationDelay:   &nrqlConditionEvaluationDelay,
 			FillOption:        &AlertsFillOptionTypes.STATIC,
 			FillValue:         &nrqlConditionBaseSignalFillValue,
 		},
@@ -86,6 +87,7 @@ var (
 		Signal: &AlertsNrqlConditionUpdateSignal{
 			AggregationWindow: &nrqlConditionBaseAggWindow,
 			EvaluationOffset:  &nrqlConditionBaseEvalOffset,
+			EvaluationDelay:   &nrqlConditionEvaluationDelay,
 			FillOption:        &AlertsFillOptionTypes.STATIC,
 			FillValue:         &nrqlConditionBaseSignalFillValue,
 		},
@@ -118,6 +120,7 @@ var (
 			AggregationWindow: &nrqlConditionBaseAggWindow,
 			FillOption:        &AlertsFillOptionTypes.STATIC,
 			FillValue:         &nrqlConditionBaseSignalFillValue,
+			EvaluationDelay:   &nrqlConditionEvaluationDelay,
 			AggregationMethod: &nrqlConditionBaseAggMethod,
 			AggregationDelay:  &nrqlConditionBaseAggDelay,
 		},
@@ -151,6 +154,7 @@ var (
 			FillOption:        &AlertsFillOptionTypes.STATIC,
 			FillValue:         &nrqlConditionBaseSignalFillValue,
 			AggregationMethod: &nrqlConditionBaseAggMethod,
+			EvaluationDelay:   &nrqlConditionEvaluationDelay,
 			AggregationDelay:  &nrqlConditionBaseAggDelay,
 		},
 	}
@@ -184,6 +188,7 @@ var (
 			FillValue:         &nrqlConditionBaseSignalFillValue,
 			AggregationMethod: &nrqlConditionBaseAggMethod,
 			AggregationDelay:  &nrqlConditionBaseAggDelay,
+			EvaluationDelay:   &nrqlConditionEvaluationDelay,
 			SlideBy:           &nrqlConditionBaseSlideBy,
 		},
 	}
@@ -217,6 +222,7 @@ var (
 			FillValue:         &nrqlConditionBaseSignalFillValue,
 			AggregationMethod: &nrqlConditionBaseAggMethod,
 			AggregationDelay:  &nrqlConditionBaseAggDelay,
+			EvaluationDelay:   &nrqlConditionEvaluationDelay,
 			SlideBy:           &nrqlConditionBaseSlideBy,
 		},
 	}
@@ -662,6 +668,7 @@ func TestIntegrationNrqlConditions_StreamingMethods(t *testing.T) {
 	require.NotNil(t, readResult)
 	require.Equal(t, &nrqlConditionBaseAggMethod, readResult.Signal.AggregationMethod)
 	require.Equal(t, &nrqlConditionBaseAggDelay, readResult.Signal.AggregationDelay)
+	require.Equal(t, &nrqlConditionEvaluationDelay, readResult.Signal.EvaluationDelay)
 	require.Nil(t, createdStaticWithStreamingMethods.Signal.AggregationTimer)
 
 	// Test: Not found


### PR DESCRIPTION
[NR-58047](https://issues.newrelic.com/browse/NR-58047)

Adds `evaluationDelay` to NRQL Conditions in the New Relic Go client. 

*Note, this new NerdGraph field is protected by a feature flag. I have added the integration testing account to this feature flag. This `evaluationDelay` field will not be added to RPM. 

Users should be able to create, update, read, and delete NRQL Alert Static and Baseline conditions well which have an evaluation delay.

