### PR TITLE
fix(synthetics): resolved error targeting legacy runtimes

### DIFF
--- a/pkg/changetracking/changetracking_api_integration_test.go
+++ b/pkg/changetracking/changetracking_api_integration_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package changetracking
 
 import (

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -808,7 +808,7 @@ type SyntheticsRuntimeInput struct {
 	// The specific version of the runtime type selected
 	RuntimeTypeVersion SemVer `json:"runtimeTypeVersion"`
 	// The programing language that should execute the script
-	ScriptLanguage string `json:"scriptLanguage,omitempty"`
+	ScriptLanguage string `json:"scriptLanguage"`
 }
 
 // SyntheticsScriptAPIMonitor - A Script Api monitor resulting from a Script Api mutation


### PR DESCRIPTION
The _omitempty_ directive is preventing the ScriptLanguage field from being passed to the API when set to an empty string.  According to the documentation an empty string must be specified when targeting the legacy (Node 10) runtime.  This is currently preventing synthetic script monitors that target the legacy runtime from being created.

There is a bit more detail provided in issue #982.  

This pull request includes a fix to remove the _omitempty_ directive, two copied and pasted tests to verify, and a missing integration tag on an unrelated integration test. 