### PR TITLE
feat: facilitate additional service names for NewRelic-Requesting-Services request header via env var

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -74,6 +75,16 @@ func NewClient(cfg config.Config) Client {
 		cfg.ServiceName = defaultServiceName
 	} else {
 		cfg.ServiceName = fmt.Sprintf("%s|%s", cfg.ServiceName, defaultServiceName)
+	}
+
+	// If a requesting service sets the NEW_RELIC_SERVICE_NAME env variable,
+	// we prepend this additional custom service name to the existing service name.
+	// The service name is used to track which requesting service is being utilized.
+	// e.g. We can track usage of the New Relic Deployment Marker GitHub Action by
+	// setting this environment variable when executing a command.
+	customServiceName := os.Getenv("NEW_RELIC_SERVICE_NAME")
+	if customServiceName != "" {
+		cfg.ServiceName = fmt.Sprintf("%s|%s", customServiceName, cfg.ServiceName)
 	}
 
 	r := retryablehttp.NewClient()

--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/google/go-querystring/query"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
@@ -121,6 +122,12 @@ func (r *Request) SetErrorValue(e ErrorResponse) {
 // SetServiceName sets the service name for the request.
 func (r *Request) SetServiceName(serviceName string) {
 	serviceName = fmt.Sprintf("%s|%s", serviceName, defaultServiceName)
+
+	customServiceName := os.Getenv("NEW_RELIC_SERVICE_NAME")
+	if customServiceName != "" {
+		serviceName = fmt.Sprintf("%s|%s", customServiceName, serviceName)
+	}
+
 	r.SetHeader(defaultNewRelicRequestingServiceHeader, serviceName)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,9 @@
 package config
 
 import (
+	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/newrelic/newrelic-client-go/v2/internal/version"
@@ -86,6 +88,19 @@ func (c *Config) SetRegion(reg *region.Region) error {
 	}
 
 	c.region = reg
+
+	return nil
+}
+
+func (c *Config) SetServiceName(serviceName string) error {
+	if c.ServiceName == "" {
+		c.ServiceName = serviceName
+	}
+
+	customServiceName := os.Getenv("NEW_RELIC_SERVICE_NAME")
+	if customServiceName != "" {
+		c.ServiceName = fmt.Sprintf("%s|%s", customServiceName, c.ServiceName)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR enables prepending additional requesting service names to a request header to facilitate tracking additional services that call the client. For example, the CLI we'll be able to know the CLI was called from with our Deployment Marker GitHub Action.