### PR TITLE
fix(alertEventsResponse): change json tag from 'alert_events' to 'recent_events'

### DIFF
--- a/pkg/alerts/events.go
+++ b/pkg/alerts/events.go
@@ -60,5 +60,5 @@ func (a *Alerts) ListAlertEventsWithContext(ctx context.Context, params *ListAle
 }
 
 type alertEventsResponse struct {
-	AlertEvents []*AlertEvent `json:"alert_events,omitempty"`
+	AlertEvents []*AlertEvent `json:"recent_events,omitempty"`
 }


### PR DESCRIPTION
related to: https://github.com/newrelic/newrelic-client-go/issues/995