### PR TITLE
chore(tests): update entity GUIDs to reference entities in new test account

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -20,12 +20,12 @@ test-only: test-unit test-integration
 test-unit: tools
 	@echo "=== $(PROJECT_NAME) === [ test-unit        ]: running unit tests..."
 	@mkdir -p $(COVERAGE_DIR)
-	@$(TEST_RUNNER) -f pkgname -- -v -ldflags=$(LDFLAGS_UNIT) -parallel 6 -tags unit -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/unit.tmp $(GO_PKGS)
+	@$(TEST_RUNNER) -f pkgname -- -v -ldflags=$(LDFLAGS_UNIT) -parallel 10 -tags unit -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/unit.tmp $(GO_PKGS)
 
 test-integration: tools
 	@echo "=== $(PROJECT_NAME) === [ test-integration ]: running integration tests..."
 	@mkdir -p $(COVERAGE_DIR)
-	$(TEST_RUNNER) -f pkgname --packages "$(GO_PKGS)" -- -v -parallel 6 -tags integration -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/integration.tmp $(GO_PKGS)
+	$(TEST_RUNNER) -f pkgname --packages "$(GO_PKGS)" -- -v -parallel 10 -tags integration -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/integration.tmp $(GO_PKGS)
 
 #
 # Coverage

--- a/pkg/alerts/muting_rules_integration_test.go
+++ b/pkg/alerts/muting_rules_integration_test.go
@@ -10,16 +10,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/errors"
-	nr "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestIntegrationAlertsMutingRules(t *testing.T) {
 	t.Parallel()
 
 	a := newIntegrationTestClient(t)
-
-	// DTK terraform account
-	accountID := 2520528
+	accountID := testhelpers.IntegrationTestAccountID
 
 	// Schedule fields
 	startTime, err1 := time.Parse(time.RFC3339, "2021-07-08T12:30:00Z")
@@ -34,7 +32,7 @@ func TestIntegrationAlertsMutingRules(t *testing.T) {
 
 	// Create a muting rule to work with in this test
 	rule := MutingRuleCreateInput{
-		Name:        nr.RandSeq(5),
+		Name:        testhelpers.RandSeq(5),
 		Description: "Mute host-1 violations",
 		Enabled:     true,
 		Schedule: &MutingRuleScheduleCreateInput{
@@ -70,7 +68,7 @@ func TestIntegrationAlertsMutingRules(t *testing.T) {
 	require.True(t, len(listResult) > 0)
 
 	// Test: Update
-	testIntegrationMutingRuleNewName := nr.RandSeq(5)
+	testIntegrationMutingRuleNewName := testhelpers.RandSeq(5)
 	updateRule := MutingRuleUpdateInput{}
 	updateRule.Name = testIntegrationMutingRuleNewName
 

--- a/pkg/alerts/policies_integration_test.go
+++ b/pkg/alerts/policies_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/errors"
-	nr "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestAlertsPolicy_Legacy(t *testing.T) {
@@ -19,7 +19,7 @@ func TestAlertsPolicy_Legacy(t *testing.T) {
 
 	a := newIntegrationTestClient(t)
 
-	testIntegrationPolicyNameRandStr := nr.RandSeq(5)
+	testIntegrationPolicyNameRandStr := testhelpers.RandSeq(5)
 	policy := Policy{
 		IncidentPreference: IncidentPreferenceTypes.PerPolicy,
 		Name:               fmt.Sprintf("test-alert-policy-%s", testIntegrationPolicyNameRandStr),
@@ -64,10 +64,10 @@ func TestAlertsQueryPolicy_GraphQL_Enabled(t *testing.T) {
 	a := newIntegrationTestClient(t)
 
 	// DTK terraform account
-	accountID := 2520528
+	accountID := testhelpers.IntegrationTestAccountID
 
 	// Create a policy to work with in this test
-	testIntegrationPolicyNameRandStr := nr.RandSeq(5)
+	testIntegrationPolicyNameRandStr := testhelpers.RandSeq(5)
 	policy := AlertsPolicyInput{}
 	policy.IncidentPreference = AlertsIncidentPreferenceTypes.PER_POLICY
 	policy.Name = fmt.Sprintf("test-alert-policy-%s", testIntegrationPolicyNameRandStr)

--- a/pkg/changetracking/changetracking_api_integration_test.go
+++ b/pkg/changetracking/changetracking_api_integration_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/nrtime"
-	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestChangeTrackingCreateDeployment_Basic(t *testing.T) {
@@ -25,7 +25,7 @@ func TestChangeTrackingCreateDeployment_Basic(t *testing.T) {
 		DeepLink:       "newrelic-client-go",
 		DeploymentType: ChangeTrackingDeploymentTypeTypes.BASIC,
 		Description:    "This is a test description",
-		EntityGUID:     common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"),
+		EntityGUID:     common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID),
 		GroupId:        "deployment",
 		Timestamp:      nrtime.EpochMilliseconds(time.Now()),
 		User:           "newrelic-go-client",
@@ -50,7 +50,7 @@ func TestChangeTrackingCreateDeployment_TimestampError(t *testing.T) {
 		DeepLink:       "newrelic-client-go",
 		DeploymentType: ChangeTrackingDeploymentTypeTypes.BASIC,
 		Description:    "This is a test description",
-		EntityGUID:     common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"),
+		EntityGUID:     common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID),
 		GroupId:        "deployment",
 		Timestamp:      nrtime.EpochMilliseconds(time.UnixMilli(0)),
 		User:           "newrelic-go-client",
@@ -63,7 +63,7 @@ func TestChangeTrackingCreateDeployment_TimestampError(t *testing.T) {
 }
 
 func newIntegrationTestClient(t *testing.T) Changetracking {
-	tc := mock.NewIntegrationTestConfig(t)
+	tc := testhelpers.NewIntegrationTestConfig(t)
 
 	return New(tc)
 }

--- a/pkg/entities/entity_integration_test.go
+++ b/pkg/entities/entity_integration_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/newrelic/newrelic-client-go/v2/internal/http"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
-	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestIntegrationSearchEntities(t *testing.T) {
@@ -126,7 +126,7 @@ func TestIntegrationGetEntities(t *testing.T) {
 	client := newIntegrationTestClient(t)
 
 	// GUID of Dummy App
-	guids := []common.EntityGUID{"MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"}
+	guids := []common.EntityGUID{testhelpers.IntegrationTestApplicationEntityGUID}
 	actual, err := client.GetEntities(guids)
 
 	if e, ok := err.(*http.GraphQLErrorResponse); ok {
@@ -141,7 +141,7 @@ func TestIntegrationGetEntity(t *testing.T) {
 	t.Parallel()
 
 	// GUID of Dummy App
-	entityGUID := common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
+	entityGUID := common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID)
 	client := newIntegrationTestClient(t)
 
 	result, err := client.GetEntity(entityGUID)
@@ -156,7 +156,7 @@ func TestIntegrationGetEntity(t *testing.T) {
 	actual := (*result).(*ApmApplicationEntity)
 
 	// These are a bit fragile, if the above GUID ever changes...
-	assert.Equal(t, 2520528, actual.AccountID)
+	assert.Equal(t, 3806526, actual.AccountID)
 	assert.Equal(t, "APM", actual.Domain)
 	assert.Equal(t, EntityType("APM_APPLICATION_ENTITY"), actual.EntityType)
 	assert.Equal(t, entityGUID, actual.GUID)
@@ -172,7 +172,7 @@ func TestIntegrationGetEntity_ApmEntity(t *testing.T) {
 	client := newIntegrationTestClient(t)
 
 	// GUID of Dummy App
-	result, err := client.GetEntity("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
+	result, err := client.GetEntity(testhelpers.IntegrationTestApplicationEntityGUID)
 
 	if e, ok := err.(*http.GraphQLErrorResponse); ok {
 		if !e.IsDeprecated() {
@@ -191,7 +191,7 @@ func TestIntegrationGetEntity_ApmEntity(t *testing.T) {
 
 	// These are a bit fragile, if the above GUID ever changes...
 	// from ApmApplicationEntity / ApmApplicationEntityOutline
-	assert.Equal(t, 215037795, actual.ApplicationID)
+	assert.Equal(t, 573482638, actual.ApplicationID)
 	assert.Contains(t, acceptableAlertStatuses, actual.AlertSeverity)
 	assert.Equal(t, "nodejs", actual.Language)
 	assert.NotNil(t, actual.RunningAgentVersions)
@@ -239,7 +239,7 @@ func TestIntegrationGetEntity_MobileEntity(t *testing.T) {
 
 	client := newIntegrationTestClient(t)
 
-	result, err := client.GetEntity("NDQ0NTN8TU9CSUxFfEFQUExJQ0FUSU9OfDE3ODg1NDI")
+	result, err := client.GetEntity("MzgwNjUyNnxNT0JJTEV8QVBQTElDQVRJT058NjAxMzc1OTAx")
 
 	if e, ok := err.(*http.GraphQLErrorResponse); ok {
 		if !e.IsDeprecated() {
@@ -252,13 +252,13 @@ func TestIntegrationGetEntity_MobileEntity(t *testing.T) {
 
 	// These are a bit fragile, if the above GUID ever changes...
 	// from MobileApplicationEntity / MobileApplicationEntityOutline
-	assert.Equal(t, 1788542, actual.ApplicationID)
+	assert.Equal(t, 601375901, actual.ApplicationID)
 	assert.Equal(t, EntityAlertSeverityTypes.NOT_CONFIGURED, actual.AlertSeverity)
 
 }
 
 func newIntegrationTestClient(t *testing.T) Entities {
-	tc := mock.NewIntegrationTestConfig(t)
+	tc := testhelpers.NewIntegrationTestConfig(t)
 
 	return New(tc)
 }

--- a/pkg/entities/tags_integration_test.go
+++ b/pkg/entities/tags_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestIntegrationListTags(t *testing.T) {
@@ -16,7 +17,7 @@ func TestIntegrationListTags(t *testing.T) {
 
 	var (
 		// GUID of Dummy App
-		testGUID = common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
+		testGUID = common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID)
 	)
 
 	client := newIntegrationTestClient(t)
@@ -35,7 +36,7 @@ func TestIntegrationGetTagsForEntity(t *testing.T) {
 
 	var (
 		// GUID of Dummy App
-		testGUID = common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
+		testGUID = common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID)
 	)
 
 	client := newIntegrationTestClient(t)
@@ -47,19 +48,6 @@ func TestIntegrationGetTagsForEntity(t *testing.T) {
 
 	actual, err = client.GetTagsForEntityMutable(testGUID)
 
-	if len(actual) < 1 {
-		tags := []TaggingTagInput{
-			{
-				Key:    "pineapple",
-				Values: []string{"pizza"},
-			},
-		}
-		result, err := client.TaggingAddTagsToEntity(testGUID, tags)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-	}
-
 	require.NoError(t, err)
 	require.Greater(t, len(actual), 0)
 }
@@ -68,7 +56,7 @@ func TestIntegrationTaggingAddTagsToEntity(t *testing.T) {
 	t.Parallel()
 
 	var (
-		testGUID = common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
+		testGUID = common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID)
 	)
 
 	client := newIntegrationTestClient(t)
@@ -90,7 +78,7 @@ func TestIntegrationTaggingReplaceTagsOnEntity(t *testing.T) {
 	t.Parallel()
 
 	var (
-		testGUID = common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
+		testGUID = common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID)
 	)
 
 	client := newIntegrationTestClient(t)
@@ -112,7 +100,7 @@ func TestIntegrationDeleteTags(t *testing.T) {
 	t.Parallel()
 
 	var (
-		testGUID = common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
+		testGUID = common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID)
 	)
 
 	client := newIntegrationTestClient(t)
@@ -129,7 +117,7 @@ func TestIntegrationDeleteTagValues(t *testing.T) {
 	t.Parallel()
 
 	var (
-		testGUID = common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
+		testGUID = common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID)
 	)
 
 	client := newIntegrationTestClient(t)

--- a/pkg/nerdstorage/nerdstorage_integration_test.go
+++ b/pkg/nerdstorage/nerdstorage_integration_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 var (
 	testPackageID           = "8e57e72a-e3ac-4272-9bb8-aea1d71dde3d"
-	testEntityID            = "MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"
 	testCollection          = "myCol"
 	testDocumentID          = "myDoc"
 	testAlternateDocumentID = "myOtherDoc"
@@ -124,30 +124,30 @@ func TestIntegrationNerdStorageWithEntityScope(t *testing.T) {
 
 	client := newIntegrationTestClient(t)
 
-	document, err := client.WriteDocumentWithEntityScope(testEntityID, testWriteInput)
+	document, err := client.WriteDocumentWithEntityScope(testhelpers.IntegrationTestApplicationEntityGUID, testWriteInput)
 	require.NoError(t, err)
 	require.NotNil(t, document)
 
 	testAlternateWriteInput := testWriteInput
 	testAlternateWriteInput.DocumentID = testAlternateDocumentID
 
-	document, err = client.WriteDocumentWithEntityScope(testEntityID, testAlternateWriteInput)
+	document, err = client.WriteDocumentWithEntityScope(testhelpers.IntegrationTestApplicationEntityGUID, testAlternateWriteInput)
 	require.NoError(t, err)
 	require.NotNil(t, document)
 
-	collection, err := client.GetCollectionWithEntityScope(testEntityID, testGetCollectionInput)
+	collection, err := client.GetCollectionWithEntityScope(testhelpers.IntegrationTestApplicationEntityGUID, testGetCollectionInput)
 	require.NoError(t, err)
 	require.NotNil(t, collection)
 
-	document, err = client.GetDocumentWithEntityScope(testEntityID, testGetDocumentInput)
+	document, err = client.GetDocumentWithEntityScope(testhelpers.IntegrationTestApplicationEntityGUID, testGetDocumentInput)
 	require.NoError(t, err)
 	require.NotNil(t, document)
 
-	ok, err := client.DeleteDocumentWithEntityScope(testEntityID, testDeleteDocumentInput)
+	ok, err := client.DeleteDocumentWithEntityScope(testhelpers.IntegrationTestApplicationEntityGUID, testDeleteDocumentInput)
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	ok, err = client.DeleteCollectionWithEntityScope(testEntityID, testDeleteCollectionInput)
+	ok, err = client.DeleteCollectionWithEntityScope(testhelpers.IntegrationTestApplicationEntityGUID, testDeleteCollectionInput)
 	require.NoError(t, err)
 	require.True(t, ok)
 }

--- a/pkg/servicelevel/service_level_integration_test.go
+++ b/pkg/servicelevel/service_level_integration_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
-	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestServiceLevel_Basic(t *testing.T) {
 	t.Parallel()
 
-	testAccountID, err := mock.GetTestAccountID()
+	testAccountID, err := testhelpers.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
 	}
@@ -25,7 +25,7 @@ func TestServiceLevel_Basic(t *testing.T) {
 	client := newIntegrationTestClient(t)
 
 	// GUID of Dummy App
-	guid := common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
+	guid := common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID)
 
 	createInput := ServiceLevelIndicatorCreateInput{
 		Name:        "integration-test-sli",
@@ -84,7 +84,7 @@ func TestServiceLevel_Basic(t *testing.T) {
 func TestServiceLevel_GoodOrBadEventsRequiredError(t *testing.T) {
 	t.Parallel()
 
-	testAccountID, err := mock.GetTestAccountID()
+	testAccountID, err := testhelpers.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
 	}
@@ -92,7 +92,7 @@ func TestServiceLevel_GoodOrBadEventsRequiredError(t *testing.T) {
 	client := newIntegrationTestClient(t)
 
 	// GUID of Dummy App
-	guid := common.EntityGUID("MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1")
+	guid := common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID)
 
 	// This input is missing some required fields to create a service level (i.e. GoodEvents, BadEvents)
 	createInput := ServiceLevelIndicatorCreateInput{
@@ -127,7 +127,7 @@ func TestServiceLevel_GoodOrBadEventsRequiredError(t *testing.T) {
 }
 
 func newIntegrationTestClient(t *testing.T) Servicelevel {
-	tc := mock.NewIntegrationTestConfig(t)
+	tc := testhelpers.NewIntegrationTestConfig(t)
 
 	return New(tc)
 }

--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -12,6 +12,12 @@ var (
 	letters = []rune("abcdefghijklmnopqrstuvwxyz")
 )
 
+// Our integration test Dummy App
+const IntegrationTestApplicationEntityGUID = "MzgwNjUyNnxBUE18QVBQTElDQVRJT058NTczNDgyNjM4"
+
+// Our integration test account ID (v2 account)
+const IntegrationTestAccountID = 3806526
+
 // RandSeq is used to get a string made up of n random lowercase letters.
 func RandSeq(n int) string {
 	rand.Seed(time.Now().UnixNano())


### PR DESCRIPTION
These adjustments are needed due to our testing account migration to a v2 account. The PR updates entity GUID references as well as updates the account numbers we reference to our new account number.