### PR TITLE
fix(apiaccess): fix to the error thrown when API Access Key creation fails

### DIFF
--- a/pkg/apiaccess/types.go
+++ b/pkg/apiaccess/types.go
@@ -648,6 +648,16 @@ type APIAccessKeyErrorInterface interface {
 	GetError() error
 }
 
+type APIAccessKeyErrorResponse struct {
+	// The message with the error cause.
+	Message string `json:"message,omitempty"`
+	// Type of error.
+	Type               string                      `json:"type,omitempty"`
+	UserKeyErrorType   APIAccessUserKeyErrorType   `json:"userErrorType,omitempty"`
+	IngestKeyErrorType APIAccessIngestKeyErrorType `json:"ingestErrorType,omitempty"`
+	Id                 string                      `json:"id,omitempty"`
+}
+
 // UnmarshalAPIAccessKeyErrorInterface unmarshals the interface into the correct type
 // based on __typename provided by GraphQL
 func UnmarshalAPIAccessKeyErrorInterface(b []byte) (*APIAccessKeyErrorInterface, error) {

--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -38,6 +38,12 @@ func GetTestAccountID() (int, error) {
 	return getEnvInt("NEW_RELIC_ACCOUNT_ID")
 }
 
+// GetNonExistentIDs returns two non-existent IDs that can be used to test errors raised
+// when Ingest/User keys which do not exist are updated or deleted.
+func GetNonExistentIDs() (string, string) {
+	return "00000FF000F0FFFF000F0F0000FF0FF0000000F000F00F0FF000FFFFF0FF00F0", "00000HH000H0HHHH000H0H0000HH0HH0000000H000H00H0HH000HHHHH0HH00H0"
+}
+
 // getEnvInt helper to DRY up the other env get calls for integers
 func getEnvInt(name string) (int, error) {
 	if name == "" {


### PR DESCRIPTION
# Description

This PR addresses [NR-97066](https://issues.newrelic.com/browse/NR-97066), comprising
- Fixes and refactoring to methods and structures in the `apiaccess` package to fix irregular errors thrown in the event of create/update/delete API Access Keys, addition of formatting to thee errors and test cases to validate the same
- Refactoring the error thrown - `Error: json: cannot unmarshal object into Go struct field .data.apiAccessCreateKeys.errors of type apiaccess.APIAccessKeyErrorInterface` when create/update operations are performed on API Access Keys to fix the issues listed below

Fixes 
- [#1418](https://github.com/newrelic/terraform-provider-newrelic/issues/1418) in the Terraform Provider
- [#2261](https://github.com/newrelic/terraform-provider-newrelic/issues/2261) in the Terraform Provider
