### PR TITLE
feat(synthetics): add device emulation functionality

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -45,8 +45,6 @@ packages:
       - name: accountManagementUpdateAccount
         max_query_field_depth: 3
 
-
-
   - name: agentApplications
     path: pkg/agentapplications
     import_path: github.com/newrelic/newrelic-client-go/v2/pkg/agentapplications
@@ -96,7 +94,6 @@ packages:
         field_type_override: "*AgentApplicationSettingsBrowserLoaderInput"
       - name: AgentApplicationSettingsBrowserPrivacyInput
         field_type_override: "*AgentApplicationSettingsBrowserPrivacyInput"
-
 
   - name: logconfigurations
     path: pkg/logconfigurations
@@ -174,7 +171,6 @@ packages:
             max_query_field_depth: 1
           - name: "steps"
             max_query_field_depth: 1
-
     mutations:
       - name: syntheticsCreateSecureCredential
         max_query_field_depth: 2

--- a/.tutone.yml
+++ b/.tutone.yml
@@ -216,7 +216,6 @@ packages:
         max_query_field_depth: 2
       - name: syntheticsPurgePrivateLocationQueue
         max_query_field_depth: 2
-
     types:
       - name: EpochMilliseconds
         field_type_override: "*nrtime.EpochMilliseconds"
@@ -225,6 +224,8 @@ packages:
       - name: ID
         field_type_override: string
         skip_type_create: true
+      - name: SyntheticsDeviceEmulationInput
+        field_type_override: "*SyntheticsDeviceEmulationInput"
 
   - name: common
     path: pkg/common

--- a/.tutone.yml
+++ b/.tutone.yml
@@ -226,6 +226,8 @@ packages:
         skip_type_create: true
       - name: SyntheticsDeviceEmulationInput
         field_type_override: "*SyntheticsDeviceEmulationInput"
+      - name: SyntheticsRuntimeInput
+        field_type_override: "*SyntheticsRuntimeInput"
 
   - name: common
     path: pkg/common

--- a/pkg/entities/entity.go
+++ b/pkg/entities/entity.go
@@ -3,6 +3,7 @@ package entities
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -104,4 +105,14 @@ func (d *DashboardWidgetRawConfiguration) UnmarshalJSON(data []byte) error {
 
 	*d = append((*d)[0:0], data...)
 	return nil
+}
+
+func FindTagByKey(tags []EntityTag, key string) []string {
+	for _, t := range tags {
+		if strings.EqualFold(t.Key, key) {
+			return t.Values
+		}
+	}
+
+	return []string{}
 }

--- a/pkg/entities/entity_integration_test.go
+++ b/pkg/entities/entity_integration_test.go
@@ -200,7 +200,6 @@ func TestIntegrationGetEntity_ApmEntity(t *testing.T) {
 	assert.NotNil(t, actual.Settings)
 	assert.NotNil(t, actual.Settings.ApdexTarget)
 	assert.NotNil(t, actual.Settings.ServerSideConfig)
-
 }
 
 // Looking at a Browser Application, and the result set here.
@@ -254,7 +253,34 @@ func TestIntegrationGetEntity_MobileEntity(t *testing.T) {
 	// from MobileApplicationEntity / MobileApplicationEntityOutline
 	assert.Equal(t, 601375901, actual.ApplicationID)
 	assert.Equal(t, EntityAlertSeverityTypes.NOT_CONFIGURED, actual.AlertSeverity)
+}
 
+func TestIntegrationGetEntity_SyntheticsEntity(t *testing.T) {
+	t.Parallel()
+	syntheticsEntityMonitorGUID := "MzgwNjUyNnxTWU5USHxNT05JVE9SfGVhMjA5MWE4LTM3OTktNDAxOC1iMzU5LWJiYTE0NGY3ZjViMw"
+	client := newIntegrationTestClient(t)
+
+	result, err := client.GetEntity(common.EntityGUID(syntheticsEntityMonitorGUID))
+	if err != nil || result == nil {
+		t.Skipf("Entity not found with GUID: %s. Skipping entity integration test for synthetics entity.", syntheticsEntityMonitorGUID)
+	}
+
+	if e, ok := err.(*http.GraphQLErrorResponse); ok {
+		if !e.IsDeprecated() {
+			require.NoError(t, e)
+		}
+	}
+	require.NotNil(t, result)
+
+	entity := (*result).(*SyntheticMonitorEntity)
+	require.NotNil(t, entity)
+
+	deviceOrientation := FindTagByKey(entity.Tags, "deviceOrientation")
+	runtimeType := FindTagByKey(entity.Tags, "runtimeType")
+	runtimeTypeVersion := FindTagByKey(entity.Tags, "runtimeTypeVersion")
+	require.Greater(t, len(deviceOrientation), 0)
+	require.Greater(t, len(runtimeType), 0)
+	require.Greater(t, len(runtimeTypeVersion), 0)
 }
 
 func newIntegrationTestClient(t *testing.T) Entities {

--- a/pkg/entities/entity_test.go
+++ b/pkg/entities/entity_test.go
@@ -1,0 +1,37 @@
+//go:build unit
+
+package entities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindTagByKey(t *testing.T) {
+	t.Parallel()
+
+	entityTags := []EntityTag{
+		{
+			Key:    "test",
+			Values: []string{"someTag"},
+		},
+	}
+
+	result := FindTagByKey(entityTags, "test")
+	require.Equal(t, []string{"someTag"}, result)
+}
+
+func TestFindTagByKeyNotFound(t *testing.T) {
+	t.Parallel()
+
+	entityTags := []EntityTag{
+		{
+			Key:    "test",
+			Values: []string{"someTag"},
+		},
+	}
+
+	result := FindTagByKey(entityTags, "notFound")
+	require.Empty(t, result)
+}

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -58,7 +58,6 @@ func TestSyntheticsSecureCredential_Error(t *testing.T) {
 	require.Greater(t, len(createResp.Errors), 0)
 }
 
-// Test simple browser monitor
 func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 	t.Parallel()
 
@@ -165,7 +164,6 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestSyntheticsSimpleMonitor_Basic function to test simple monitor
 func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
 	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
@@ -263,7 +261,6 @@ func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestSyntheticsScriptApiMonitor_Basic to test the script api monitor
 func TestSyntheticsScriptApiMonitor_Basic(t *testing.T) {
 	t.Parallel()
 
@@ -376,7 +373,6 @@ func TestSyntheticsScriptApiMonitor_Basic(t *testing.T) {
 	require.NotNil(t, deleteScriptApiMonitor)
 }
 
-// TestSyntheticsScriptApiMonitor_Basic to test the script api monitor targeting legacy runtime
 func TestSyntheticsScriptApiMonitorLegacy_Basic(t *testing.T) {
 	t.Parallel()
 
@@ -489,7 +485,6 @@ func TestSyntheticsScriptApiMonitorLegacy_Basic(t *testing.T) {
 	require.NotNil(t, deleteScriptApiMonitor)
 }
 
-// TestSyntheticsScriptBrowserMonitor_Basic function to test script browser monitor
 func TestSyntheticsScriptBrowserMonitor_Basic(t *testing.T) {
 	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
@@ -577,7 +572,77 @@ func TestSyntheticsScriptBrowserMonitor_Basic(t *testing.T) {
 	require.NotNil(t, deleteScriptBrowserMonitor)
 }
 
-// TestSyntheticsScriptBrowserMonitor_Basic function to test script browser monitor targeting legacy runtime
+func TestSyntheticsScriptBrowserMonitor_DeviceEmulation(t *testing.T) {
+	t.Parallel()
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	a := newIntegrationTestClient(t)
+
+	monitorName := mock.RandSeq(5)
+
+	scriptBrowserMonitorInput := SyntheticsCreateScriptBrowserMonitorInput{
+		AdvancedOptions: SyntheticsScriptBrowserMonitorAdvancedOptionsInput{
+			EnableScreenshotOnFailureAndScript: &tv,
+			DeviceEmulation: SyntheticsDeviceEmulationInput{
+				DeviceOrientation: SyntheticsDeviceOrientationTypes.PORTRAIT,
+				DeviceType:        SyntheticsDeviceTypeTypes.MOBILE,
+			},
+		},
+		Locations: SyntheticsScriptedMonitorLocationsInput{
+			Public: []string{"AP_SOUTH_1"},
+		},
+		Name:   monitorName,
+		Period: SyntheticsMonitorPeriodTypes.EVERY_12_HOURS,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Runtime: SyntheticsRuntimeInput{
+			RuntimeTypeVersion: "100",
+			RuntimeType:        "CHROME_BROWSER",
+			ScriptLanguage:     "JAVASCRIPT",
+		},
+		Script: "console.log('test')",
+	}
+
+	createScriptBrowserMonitor, err := a.SyntheticsCreateScriptBrowserMonitor(testAccountID, scriptBrowserMonitorInput)
+	require.NoError(t, err)
+	require.NotNil(t, createScriptBrowserMonitor)
+	require.Equal(t, 0, len(createScriptBrowserMonitor.Errors))
+
+	updatedScriptBrowserMonitorInput := SyntheticsUpdateScriptBrowserMonitorInput{
+		AdvancedOptions: SyntheticsScriptBrowserMonitorAdvancedOptionsInput{
+			EnableScreenshotOnFailureAndScript: &tv,
+			// Test changing device emulation options
+			DeviceEmulation: SyntheticsDeviceEmulationInput{
+				DeviceOrientation: SyntheticsDeviceOrientationTypes.LANDSCAPE,
+				DeviceType:        SyntheticsDeviceTypeTypes.TABLET,
+			},
+		},
+		Locations: SyntheticsScriptedMonitorLocationsInput{
+			Public: []string{"AP_SOUTH_1"},
+		},
+		Name:   monitorName + "-updated",
+		Period: SyntheticsMonitorPeriodTypes.EVERY_12_HOURS,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Runtime: SyntheticsRuntimeInput{
+			RuntimeTypeVersion: "100",
+			RuntimeType:        "CHROME_BROWSER",
+			ScriptLanguage:     "JAVASCRIPT",
+		},
+		Script: "console.log('test)",
+	}
+
+	updateScriptBrowserMonitor, err := a.SyntheticsUpdateScriptBrowserMonitor(createScriptBrowserMonitor.Monitor.GUID, updatedScriptBrowserMonitorInput)
+	require.NoError(t, err)
+	require.NotNil(t, updateScriptBrowserMonitor)
+	require.Equal(t, 0, len(updateScriptBrowserMonitor.Errors))
+
+	deleteScriptBrowserMonitor, err := a.SyntheticsDeleteMonitor(createScriptBrowserMonitor.Monitor.GUID)
+	require.NoError(t, err)
+	require.NotNil(t, deleteScriptBrowserMonitor)
+}
+
 func TestSyntheticsScriptBrowserMonitorLegacy_Basic(t *testing.T) {
 	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
@@ -665,7 +730,6 @@ func TestSyntheticsScriptBrowserMonitorLegacy_Basic(t *testing.T) {
 	require.NotNil(t, deleteScriptBrowserMonitor)
 }
 
-// Integration testing for private location
 func TestSyntheticsPrivateLocation_Basic(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -586,7 +586,7 @@ func TestSyntheticsScriptBrowserMonitor_DeviceEmulation(t *testing.T) {
 	scriptBrowserMonitorInput := SyntheticsCreateScriptBrowserMonitorInput{
 		AdvancedOptions: SyntheticsScriptBrowserMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &tv,
-			DeviceEmulation: SyntheticsDeviceEmulationInput{
+			DeviceEmulation: &SyntheticsDeviceEmulationInput{
 				DeviceOrientation: SyntheticsDeviceOrientationTypes.PORTRAIT,
 				DeviceType:        SyntheticsDeviceTypeTypes.MOBILE,
 			},
@@ -614,7 +614,7 @@ func TestSyntheticsScriptBrowserMonitor_DeviceEmulation(t *testing.T) {
 		AdvancedOptions: SyntheticsScriptBrowserMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &tv,
 			// Test changing device emulation options
-			DeviceEmulation: SyntheticsDeviceEmulationInput{
+			DeviceEmulation: &SyntheticsDeviceEmulationInput{
 				DeviceOrientation: SyntheticsDeviceOrientationTypes.LANDSCAPE,
 				DeviceType:        SyntheticsDeviceTypeTypes.TABLET,
 			},

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -26,19 +26,15 @@ func TestSyntheticsSecureCredential_Basic(t *testing.T) {
 
 	a := newIntegrationTestClient(t)
 
-	// Create a secure credential
 	createResp, err := a.SyntheticsCreateSecureCredential(testAccountID, "test secure credential", "TEST", "secure value")
 	require.NoError(t, err)
 	require.NotNil(t, createResp)
 
-	// Update secure credential
 	updateResp, err := a.SyntheticsUpdateSecureCredential(testAccountID, "test secure credential", "TEST", "new secure value")
 	require.NoError(t, err)
 	require.NotNil(t, updateResp)
 
-	// Delete secure credential
 	deleteResp, err := a.SyntheticsDeleteSecureCredential(testAccountID, "TEST")
-
 	require.Equal(t, "", deleteResp.Key)
 }
 
@@ -52,7 +48,6 @@ func TestSyntheticsSecureCredential_Error(t *testing.T) {
 
 	a := newIntegrationTestClient(t)
 
-	// Create a secure credential
 	createResp, respErr := a.SyntheticsCreateSecureCredential(testAccountID, "test secure credential", "TEST-BAD-KEY", "secure value")
 	require.NoError(t, respErr)
 	require.Greater(t, len(createResp.Errors), 0)
@@ -70,8 +65,6 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 
 	monitorName := mock.RandSeq(5)
 
-	////Simple Browser monitor
-	//Input for simple browser monitor
 	simpleBrowserMonitorInput := SyntheticsCreateSimpleBrowserMonitorInput{
 		Locations: SyntheticsLocationsInput{
 			Public: []string{
@@ -79,7 +72,7 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 			},
 		},
 		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
 		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
 		Tags: []SyntheticsTag{
 			{
@@ -90,7 +83,7 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 			},
 		},
 		Uri: "https://www.one.newrelic.com",
-		Runtime: SyntheticsRuntimeInput{
+		Runtime: &SyntheticsRuntimeInput{
 			RuntimeType:        "CHROME_BROWSER",
 			RuntimeTypeVersion: SemVer("100"),
 			ScriptLanguage:     "JAVASCRIPT",
@@ -108,14 +101,11 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 		},
 	}
 
-	//Test to create simple browser monitor
 	createSimpleBrowserMonitor, err := a.SyntheticsCreateSimpleBrowserMonitor(testAccountID, simpleBrowserMonitorInput)
-
 	require.NoError(t, err)
 	require.NotNil(t, createSimpleBrowserMonitor)
 	require.Equal(t, 0, len(createSimpleBrowserMonitor.Errors))
 
-	//Input for simple browser monitor for updating
 	simpleBrowserMonitorInputUpdated := SyntheticsUpdateSimpleBrowserMonitorInput{
 		AdvancedOptions: SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{
 			CustomHeaders: []SyntheticsCustomHeaderInput{
@@ -134,7 +124,7 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 			},
 		},
 		Name:   monitorName + "-updated",
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
 		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
 		Tags: []SyntheticsTag{
 			{
@@ -145,20 +135,18 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 			},
 		},
 		Uri: "https://www.one.newrelic.com",
-		Runtime: SyntheticsRuntimeInput{
+		Runtime: &SyntheticsRuntimeInput{
 			RuntimeType:        "CHROME_BROWSER",
 			RuntimeTypeVersion: SemVer("100"),
 			ScriptLanguage:     "JAVASCRIPT",
 		},
 	}
 
-	//Test to update simple browser monitor
 	updateSimpleBrowserMonitor, err := a.SyntheticsUpdateSimpleBrowserMonitor(createSimpleBrowserMonitor.Monitor.GUID, simpleBrowserMonitorInputUpdated)
 	require.NoError(t, err)
 	require.NotNil(t, updateSimpleBrowserMonitor)
 	require.Equal(t, 0, len(updateSimpleBrowserMonitor.Errors))
 
-	//Test to delete a simple browser monitor
 	deleteSimpleBrowserMonitor, err := a.SyntheticsDeleteMonitor(createSimpleBrowserMonitor.Monitor.GUID)
 	require.NotNil(t, deleteSimpleBrowserMonitor)
 	require.NoError(t, err)
@@ -175,8 +163,6 @@ func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
 
 	monitorName := mock.RandSeq(5)
 
-	////simple monitor
-	//Input for creating a simple monitor
 	simpleMonitorInput := SyntheticsCreateSimpleMonitorInput{
 		AdvancedOptions: SyntheticsSimpleMonitorAdvancedOptionsInput{
 			CustomHeaders: []SyntheticsCustomHeaderInput{
@@ -196,7 +182,7 @@ func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
 			},
 		},
 		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
 		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
 		Tags: []SyntheticsTag{
 			{
@@ -209,14 +195,12 @@ func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
 		Uri: "https://www.one.newrelic.com",
 	}
 
-	//Test to create simple monitor
 	createSimpleMonitor, err := a.SyntheticsCreateSimpleMonitor(testAccountID, simpleMonitorInput)
 
 	require.NoError(t, err)
 	require.NotNil(t, createSimpleMonitor)
 	require.Equal(t, 0, len(createSimpleMonitor.Errors))
 
-	//Input to update simple monitor
 	simpleMonitorInputUpdated := SyntheticsUpdateSimpleMonitorInput{
 		AdvancedOptions: SyntheticsSimpleMonitorAdvancedOptionsInput{
 			CustomHeaders: []SyntheticsCustomHeaderInput{
@@ -236,7 +220,7 @@ func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
 			},
 		},
 		Name:   monitorName + "-updated",
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
 		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
 		Tags: []SyntheticsTag{
 			{
@@ -249,13 +233,11 @@ func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
 		Uri: "https://www.one.newrelic.com",
 	}
 
-	//Test to update simple monitor
 	updateSimpleMonitor, err := a.SyntheticsUpdateSimpleMonitor(createSimpleMonitor.Monitor.GUID, simpleMonitorInputUpdated)
 	require.NoError(t, err)
 	require.NotNil(t, updateSimpleMonitor)
 	require.Equal(t, 0, len(updateSimpleMonitor.Errors))
 
-	//Test to delete simple monitor
 	deleteSimpleMonitor, err := a.SyntheticsDeleteMonitor(createSimpleMonitor.Monitor.GUID)
 	require.NotNil(t, deleteSimpleMonitor)
 	require.NoError(t, err)
@@ -273,7 +255,6 @@ func TestSyntheticsScriptApiMonitor_Basic(t *testing.T) {
 
 	monitorName := mock.RandSeq(5)
 
-	////Scripted API monitor
 	apiScript := fmt.Sprintf(`
 		const myAccountId = '%s';
 		const myAPIKey = '%s';
@@ -303,7 +284,6 @@ func TestSyntheticsScriptApiMonitor_Basic(t *testing.T) {
 		$http.post(options, callback);
 		`, os.Getenv("NEW_RELIC_ACCOUNT_ID"), os.Getenv("NEW_RELIC_API_KEY"))
 
-	//input for script api monitor
 	scriptApiMonitorInput := SyntheticsCreateScriptAPIMonitorInput{
 		Locations: SyntheticsScriptedMonitorLocationsInput{
 			Public: []string{
@@ -311,8 +291,8 @@ func TestSyntheticsScriptApiMonitor_Basic(t *testing.T) {
 			},
 		},
 		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
 		Script: apiScript,
 		Tags: []SyntheticsTag{
 			{
@@ -322,20 +302,18 @@ func TestSyntheticsScriptApiMonitor_Basic(t *testing.T) {
 				},
 			},
 		},
-		Runtime: SyntheticsRuntimeInput{
+		Runtime: &SyntheticsRuntimeInput{
 			RuntimeTypeVersion: SemVer("16.10"),
 			RuntimeType:        "NODE_API",
 			ScriptLanguage:     "JAVASCRIPT",
 		},
 	}
 
-	//Test to Create scripted api monitor
 	createScriptApiMonitor, err := a.SyntheticsCreateScriptAPIMonitor(testAccountID, scriptApiMonitorInput)
 	require.NoError(t, err)
 	require.NotNil(t, createScriptApiMonitor)
 	require.Equal(t, 0, len(createScriptApiMonitor.Errors))
 
-	//input to update script api monitor
 	updatedScriptApiMonitorInput := SyntheticsUpdateScriptAPIMonitorInput{
 		Locations: SyntheticsScriptedMonitorLocationsInput{
 			Public: []string{
@@ -343,8 +321,8 @@ func TestSyntheticsScriptApiMonitor_Basic(t *testing.T) {
 			},
 		},
 		Name:   monitorName + "-updated",
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
 		Script: apiScript,
 		Tags: []SyntheticsTag{
 			{
@@ -354,20 +332,18 @@ func TestSyntheticsScriptApiMonitor_Basic(t *testing.T) {
 				},
 			},
 		},
-		Runtime: SyntheticsRuntimeInput{
+		Runtime: &SyntheticsRuntimeInput{
 			RuntimeTypeVersion: SemVer("16.10"),
 			RuntimeType:        "NODE_API",
 			ScriptLanguage:     "JAVASCRIPT",
 		},
 	}
 
-	//Test to update scripted api monitor
 	updateScriptApiMonitor, err := a.SyntheticsUpdateScriptAPIMonitor(createScriptApiMonitor.Monitor.GUID, updatedScriptApiMonitorInput)
 	require.NoError(t, err)
 	require.NotNil(t, updateScriptApiMonitor)
 	require.Equal(t, 0, len(updateScriptApiMonitor.Errors))
 
-	//Test to delete scripted api monitor
 	deleteScriptApiMonitor, err := a.SyntheticsDeleteMonitor(createScriptApiMonitor.Monitor.GUID)
 	require.NoError(t, err)
 	require.NotNil(t, deleteScriptApiMonitor)
@@ -385,7 +361,6 @@ func TestSyntheticsScriptApiMonitorLegacy_Basic(t *testing.T) {
 
 	monitorName := mock.RandSeq(5)
 
-	////Scripted API monitor
 	apiScript := fmt.Sprintf(`
 		const myAccountId = '%s';
 		const myAPIKey = '%s';
@@ -415,7 +390,6 @@ func TestSyntheticsScriptApiMonitorLegacy_Basic(t *testing.T) {
 		$http.post(options, callback);
 		`, os.Getenv("NEW_RELIC_ACCOUNT_ID"), os.Getenv("NEW_RELIC_API_KEY"))
 
-	//input for script api monitor
 	scriptApiMonitorInput := SyntheticsCreateScriptAPIMonitorInput{
 		Locations: SyntheticsScriptedMonitorLocationsInput{
 			Public: []string{
@@ -423,8 +397,8 @@ func TestSyntheticsScriptApiMonitorLegacy_Basic(t *testing.T) {
 			},
 		},
 		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
 		Script: apiScript,
 		Tags: []SyntheticsTag{
 			{
@@ -434,20 +408,13 @@ func TestSyntheticsScriptApiMonitorLegacy_Basic(t *testing.T) {
 				},
 			},
 		},
-		Runtime: SyntheticsRuntimeInput{
-			RuntimeTypeVersion: "",
-			RuntimeType:        "",
-			ScriptLanguage:     "",
-		},
 	}
 
-	//Test to Create scripted api monitor
 	createScriptApiMonitor, err := a.SyntheticsCreateScriptAPIMonitor(testAccountID, scriptApiMonitorInput)
 	require.NoError(t, err)
 	require.NotNil(t, createScriptApiMonitor)
-	require.Equal(t, 0, len(createScriptApiMonitor.Errors))
+	require.Equal(t, 0, len(createScriptApiMonitor.Errors), createScriptApiMonitor.Errors)
 
-	//input to update script api monitor
 	updatedScriptApiMonitorInput := SyntheticsUpdateScriptAPIMonitorInput{
 		Locations: SyntheticsScriptedMonitorLocationsInput{
 			Public: []string{
@@ -455,8 +422,8 @@ func TestSyntheticsScriptApiMonitorLegacy_Basic(t *testing.T) {
 			},
 		},
 		Name:   monitorName + "-updated",
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
 		Script: apiScript,
 		Tags: []SyntheticsTag{
 			{
@@ -466,20 +433,13 @@ func TestSyntheticsScriptApiMonitorLegacy_Basic(t *testing.T) {
 				},
 			},
 		},
-		Runtime: SyntheticsRuntimeInput{
-			RuntimeTypeVersion: "",
-			RuntimeType:        "",
-			ScriptLanguage:     "",
-		},
 	}
 
-	//Test to update scripted api monitor
 	updateScriptApiMonitor, err := a.SyntheticsUpdateScriptAPIMonitor(createScriptApiMonitor.Monitor.GUID, updatedScriptApiMonitorInput)
 	require.NoError(t, err)
 	require.NotNil(t, updateScriptApiMonitor)
 	require.Equal(t, 0, len(updateScriptApiMonitor.Errors))
 
-	//Test to delete scripted api monitor
 	deleteScriptApiMonitor, err := a.SyntheticsDeleteMonitor(createScriptApiMonitor.Monitor.GUID)
 	require.NoError(t, err)
 	require.NotNil(t, deleteScriptApiMonitor)
@@ -496,7 +456,6 @@ func TestSyntheticsScriptBrowserMonitor_Basic(t *testing.T) {
 
 	monitorName := mock.RandSeq(5)
 
-	//Input to create script browser monitor
 	scriptBrowserMonitorInput := SyntheticsCreateScriptBrowserMonitorInput{
 		AdvancedOptions: SyntheticsScriptBrowserMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &tv,
@@ -507,9 +466,9 @@ func TestSyntheticsScriptBrowserMonitor_Basic(t *testing.T) {
 			},
 		},
 		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
-		Runtime: SyntheticsRuntimeInput{
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Runtime: &SyntheticsRuntimeInput{
 			RuntimeTypeVersion: "100",
 			RuntimeType:        "CHROME_BROWSER",
 			ScriptLanguage:     "JAVASCRIPT",
@@ -525,13 +484,11 @@ func TestSyntheticsScriptBrowserMonitor_Basic(t *testing.T) {
 		Script: "var assert = require('assert');\n\n$browser.get('https://one.newrelic.com')",
 	}
 
-	//test to create script browser monitor
 	createScriptBrowserMonitor, err := a.SyntheticsCreateScriptBrowserMonitor(testAccountID, scriptBrowserMonitorInput)
 	require.NoError(t, err)
 	require.NotNil(t, createScriptBrowserMonitor)
 	require.Equal(t, 0, len(createScriptBrowserMonitor.Errors))
 
-	//Input to update script browser monitor
 	updatedScriptBrowserMonitorInput := SyntheticsUpdateScriptBrowserMonitorInput{
 		AdvancedOptions: SyntheticsScriptBrowserMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &tv,
@@ -542,9 +499,9 @@ func TestSyntheticsScriptBrowserMonitor_Basic(t *testing.T) {
 			},
 		},
 		Name:   monitorName + "-updated",
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
-		Runtime: SyntheticsRuntimeInput{
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Runtime: &SyntheticsRuntimeInput{
 			RuntimeTypeVersion: "100",
 			RuntimeType:        "CHROME_BROWSER",
 			ScriptLanguage:     "JAVASCRIPT",
@@ -560,13 +517,11 @@ func TestSyntheticsScriptBrowserMonitor_Basic(t *testing.T) {
 		Script: "var assert = require('assert');\n\n$browser.get('https://one.newrelic.com')",
 	}
 
-	//test to update script browser monitor
 	updateScriptBrowserMonitor, err := a.SyntheticsUpdateScriptBrowserMonitor(createScriptBrowserMonitor.Monitor.GUID, updatedScriptBrowserMonitorInput)
 	require.NoError(t, err)
 	require.NotNil(t, updateScriptBrowserMonitor)
 	require.Equal(t, 0, len(updateScriptBrowserMonitor.Errors))
 
-	//test to delete script browser monitor
 	deleteScriptBrowserMonitor, err := a.SyntheticsDeleteMonitor(createScriptBrowserMonitor.Monitor.GUID)
 	require.NoError(t, err)
 	require.NotNil(t, deleteScriptBrowserMonitor)
@@ -597,7 +552,7 @@ func TestSyntheticsScriptBrowserMonitor_DeviceEmulation(t *testing.T) {
 		Name:   monitorName,
 		Period: SyntheticsMonitorPeriodTypes.EVERY_12_HOURS,
 		Status: SyntheticsMonitorStatusTypes.ENABLED,
-		Runtime: SyntheticsRuntimeInput{
+		Runtime: &SyntheticsRuntimeInput{
 			RuntimeTypeVersion: "100",
 			RuntimeType:        "CHROME_BROWSER",
 			ScriptLanguage:     "JAVASCRIPT",
@@ -625,7 +580,7 @@ func TestSyntheticsScriptBrowserMonitor_DeviceEmulation(t *testing.T) {
 		Name:   monitorName + "-updated",
 		Period: SyntheticsMonitorPeriodTypes.EVERY_12_HOURS,
 		Status: SyntheticsMonitorStatusTypes.ENABLED,
-		Runtime: SyntheticsRuntimeInput{
+		Runtime: &SyntheticsRuntimeInput{
 			RuntimeTypeVersion: "100",
 			RuntimeType:        "CHROME_BROWSER",
 			ScriptLanguage:     "JAVASCRIPT",
@@ -643,7 +598,7 @@ func TestSyntheticsScriptBrowserMonitor_DeviceEmulation(t *testing.T) {
 	require.NotNil(t, deleteScriptBrowserMonitor)
 }
 
-func TestSyntheticsScriptBrowserMonitorLegacy_Basic(t *testing.T) {
+func TestSyntheticsScriptBrowserMonitor_LegacyRuntime(t *testing.T) {
 	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
@@ -654,77 +609,51 @@ func TestSyntheticsScriptBrowserMonitorLegacy_Basic(t *testing.T) {
 
 	monitorName := mock.RandSeq(5)
 
-	//Input to create script browser monitor
 	scriptBrowserMonitorInput := SyntheticsCreateScriptBrowserMonitorInput{
 		AdvancedOptions: SyntheticsScriptBrowserMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &tv,
 		},
 		Locations: SyntheticsScriptedMonitorLocationsInput{
-			Public: []string{
-				"AP_SOUTH_1",
-			},
-		},
-		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
-		Runtime: SyntheticsRuntimeInput{
-			RuntimeTypeVersion: "",
-			RuntimeType:        "",
-			ScriptLanguage:     "",
-		},
-		Tags: []SyntheticsTag{
-			{
-				Key: "pineapple",
-				Values: []string{
-					"pizza",
+			Private: []SyntheticsPrivateLocationInput{
+				{
+					GUID: "MzgwNjUyNnxTWU5USHxQUklWQVRFX0xPQ0FUSU9OfGNhNmZmNTY3LTJlZWItNGNkNi04ODhhLTAxMTFjMGMzMTBjNA",
 				},
 			},
 		},
-		Script: "var assert = require('assert');\n\n$browser.get('https://one.newrelic.com')",
+		Name:   monitorName,
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Script: "console.log('test')",
+		// Note: Omitting `Runtime` defaults to the legacy runtime
 	}
 
-	//test to create script browser monitor
 	createScriptBrowserMonitor, err := a.SyntheticsCreateScriptBrowserMonitor(testAccountID, scriptBrowserMonitorInput)
 	require.NoError(t, err)
 	require.NotNil(t, createScriptBrowserMonitor)
 	require.Equal(t, 0, len(createScriptBrowserMonitor.Errors))
 
-	//Input to update script browser monitor
 	updatedScriptBrowserMonitorInput := SyntheticsUpdateScriptBrowserMonitorInput{
 		AdvancedOptions: SyntheticsScriptBrowserMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &tv,
 		},
 		Locations: SyntheticsScriptedMonitorLocationsInput{
-			Public: []string{
-				"AP_SOUTH_1",
-			},
-		},
-		Name:   monitorName + "-updated",
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
-		Runtime: SyntheticsRuntimeInput{
-			RuntimeTypeVersion: "",
-			RuntimeType:        "",
-			ScriptLanguage:     "",
-		},
-		Tags: []SyntheticsTag{
-			{
-				Key: "pineapple",
-				Values: []string{
-					"script_browser_pizza",
+			Private: []SyntheticsPrivateLocationInput{
+				{
+					GUID: "MzgwNjUyNnxTWU5USHxQUklWQVRFX0xPQ0FUSU9OfGNhNmZmNTY3LTJlZWItNGNkNi04ODhhLTAxMTFjMGMzMTBjNA",
 				},
 			},
 		},
+		Name:   monitorName + "-updated",
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
 		Script: "var assert = require('assert');\n\n$browser.get('https://one.newrelic.com')",
 	}
 
-	//test to update script browser monitor
 	updateScriptBrowserMonitor, err := a.SyntheticsUpdateScriptBrowserMonitor(createScriptBrowserMonitor.Monitor.GUID, updatedScriptBrowserMonitorInput)
 	require.NoError(t, err)
 	require.NotNil(t, updateScriptBrowserMonitor)
 	require.Equal(t, 0, len(updateScriptBrowserMonitor.Errors))
 
-	//test to delete script browser monitor
 	deleteScriptBrowserMonitor, err := a.SyntheticsDeleteMonitor(createScriptBrowserMonitor.Monitor.GUID)
 	require.NoError(t, err)
 	require.NotNil(t, deleteScriptBrowserMonitor)
@@ -740,21 +669,17 @@ func TestSyntheticsPrivateLocation_Basic(t *testing.T) {
 
 	a := newIntegrationTestClient(t)
 
-	// Test to Create private location
 	createResp, err := a.SyntheticsCreatePrivateLocation(testAccountID, "test secure credential", "TEST", true)
 	require.NoError(t, err)
 	require.NotNil(t, createResp)
 
-	// Test to update private location
 	updateResp, err := a.SyntheticsUpdatePrivateLocation("test secure credential", createResp.GUID, true)
 	require.NoError(t, err)
 	require.NotNil(t, updateResp)
 
-	// Test to purge private location queue
 	purgeresp, err := a.SyntheticsPurgePrivateLocationQueue(createResp.GUID)
 	require.NotNil(t, purgeresp)
 
-	// Test to delete private location
 	deleteResp, err := a.SyntheticsDeletePrivateLocation(createResp.GUID)
 	require.NotNil(t, deleteResp)
 }
@@ -771,8 +696,8 @@ func TestSyntheticsBrokenLinksMonitor_Basic(t *testing.T) {
 	monitorName := fmt.Sprintf("client-integration-test-%s", mock.RandSeq(5))
 	monitorInput := SyntheticsCreateBrokenLinksMonitorInput{
 		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.DISABLED),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatusTypes.DISABLED,
 		Locations: SyntheticsLocationsInput{
 			Public: []string{"AP_SOUTH_1"},
 		},
@@ -826,8 +751,8 @@ func TestSyntheticsCertCheckMonitor_Basic(t *testing.T) {
 	monitorName := fmt.Sprintf("client-integration-test-%s", mock.RandSeq(5))
 	monitorInput := SyntheticsCreateCertCheckMonitorInput{
 		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.DISABLED),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatusTypes.DISABLED,
 		Locations: SyntheticsLocationsInput{
 			Public: []string{"AP_SOUTH_1"},
 		},
@@ -885,8 +810,8 @@ func TestSyntheticsStepMonitor_Basic(t *testing.T) {
 	enableScreenshotOnFailureAndScript := true
 	monitorInput := SyntheticsCreateStepMonitorInput{
 		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_DAY),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.DISABLED),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_DAY,
+		Status: SyntheticsMonitorStatusTypes.DISABLED,
 		AdvancedOptions: SyntheticsStepMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &enableScreenshotOnFailureAndScript,
 		},
@@ -967,8 +892,8 @@ func TestSyntheticsStepMonitor_GetSteps(t *testing.T) {
 	enableScreenshotOnFailureAndScript := true
 	monitorInput := SyntheticsCreateStepMonitorInput{
 		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_DAY),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.DISABLED),
+		Period: SyntheticsMonitorPeriodTypes.EVERY_DAY,
+		Status: SyntheticsMonitorStatusTypes.DISABLED,
 		AdvancedOptions: SyntheticsStepMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &enableScreenshotOnFailureAndScript,
 		},
@@ -1026,9 +951,9 @@ func TestSyntheticsStepMonitor_GetScript(t *testing.T) {
 			Public: []string{"AP_SOUTH_1"},
 		},
 		Name:   monitorName,
-		Period: SyntheticsMonitorPeriod(SyntheticsMonitorPeriodTypes.EVERY_HOUR),
-		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
-		Runtime: SyntheticsRuntimeInput{
+		Period: SyntheticsMonitorPeriodTypes.EVERY_HOUR,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Runtime: &SyntheticsRuntimeInput{
 			RuntimeTypeVersion: "100",
 			RuntimeType:        "CHROME_BROWSER",
 			ScriptLanguage:     "JAVASCRIPT",

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -527,6 +527,37 @@ func TestSyntheticsScriptBrowserMonitor_Basic(t *testing.T) {
 	require.NotNil(t, deleteScriptBrowserMonitor)
 }
 
+func TestSyntheticsScriptBrowserMonitor_InvalidRuntimeValues(t *testing.T) {
+	t.Parallel()
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	a := newIntegrationTestClient(t)
+
+	monitorName := mock.RandSeq(5)
+
+	scriptBrowserMonitorInput := SyntheticsCreateScriptBrowserMonitorInput{
+		Locations: SyntheticsScriptedMonitorLocationsInput{
+			Public: []string{"AP_SOUTH_1"},
+		},
+		Name:   monitorName,
+		Period: SyntheticsMonitorPeriodTypes.EVERY_12_HOURS,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Runtime: &SyntheticsRuntimeInput{
+			RuntimeTypeVersion: "12345",
+			RuntimeType:        "CHROME",
+			ScriptLanguage:     "FORTRAN",
+		},
+		Script: "console.log('test')",
+	}
+
+	result, err := a.SyntheticsCreateScriptBrowserMonitor(testAccountID, scriptBrowserMonitorInput)
+	require.Greater(t, len(result.Errors), 0)
+	require.Contains(t, result.Errors[0].Description, "Runtime values are invalid combination")
+}
+
 func TestSyntheticsScriptBrowserMonitor_DeviceEmulation(t *testing.T) {
 	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -953,7 +953,7 @@ type SyntheticsScriptBrowserMonitorAdvancedOptions struct {
 // SyntheticsScriptBrowserMonitorAdvancedOptionsInput - The advanced options inputs available for a Script Browser monitor
 type SyntheticsScriptBrowserMonitorAdvancedOptionsInput struct {
 	// Emulate a device
-	DeviceEmulation SyntheticsDeviceEmulationInput `json:"deviceEmulation,omitempty"`
+	DeviceEmulation *SyntheticsDeviceEmulationInput `json:"deviceEmulation,omitempty"`
 	// Capture a screenshot during job execution
 	EnableScreenshotOnFailureAndScript *bool `json:"enableScreenshotOnFailureAndScript,omitempty"`
 }
@@ -1041,7 +1041,7 @@ type SyntheticsSimpleBrowserMonitorAdvancedOptionsInput struct {
 	// Custom headers to use in monitor job
 	CustomHeaders []SyntheticsCustomHeaderInput `json:"customHeaders,omitempty"`
 	// Emulate a device
-	DeviceEmulation SyntheticsDeviceEmulationInput `json:"deviceEmulation,omitempty"`
+	DeviceEmulation *SyntheticsDeviceEmulationInput `json:"deviceEmulation,omitempty"`
 	// Capture a screenshot during job execution
 	EnableScreenshotOnFailureAndScript *bool `json:"enableScreenshotOnFailureAndScript,omitempty"`
 	// Validation text for monitor to search for at given URI

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -96,17 +96,57 @@ var Nr1CatalogInstallPlanTargetTypeTypes = struct {
 	UNKNOWN: "UNKNOWN",
 }
 
+// SyntheticsDeviceOrientation - enum of Orientations that the user can select for their emulated device
+type SyntheticsDeviceOrientation string
+
+var SyntheticsDeviceOrientationTypes = struct {
+	// This allows the screenshot to be taken in the landscape orientation
+	LANDSCAPE SyntheticsDeviceOrientation
+	// This will disable device emulation
+	NONE SyntheticsDeviceOrientation
+	// This allows the screenshot to be taken in the portrait orientation
+	PORTRAIT SyntheticsDeviceOrientation
+}{
+	// This allows the screenshot to be taken in the landscape orientation
+	LANDSCAPE: "LANDSCAPE",
+	// This will disable device emulation
+	NONE: "NONE",
+	// This allows the screenshot to be taken in the portrait orientation
+	PORTRAIT: "PORTRAIT",
+}
+
+// SyntheticsDeviceType - enum of DeviceTypes that the user can use for device emulation
+type SyntheticsDeviceType string
+
+var SyntheticsDeviceTypeTypes = struct {
+	// This will be dimensions for a typical mobile device
+	MOBILE SyntheticsDeviceType
+	// This will disable device emulation
+	NONE SyntheticsDeviceType
+	// This will be dimensions for a typical tablet device
+	TABLET SyntheticsDeviceType
+}{
+	// This will be dimensions for a typical mobile device
+	MOBILE: "MOBILE",
+	// This will disable device emulation
+	NONE: "NONE",
+	// This will be dimensions for a typical tablet device
+	TABLET: "TABLET",
+}
+
 // SyntheticsMonitorCreateErrorType - Types of errors that can be returned from a create monitor request
 type SyntheticsMonitorCreateErrorType string
 
 var SyntheticsMonitorCreateErrorTypeTypes = struct {
 	// Received a request missing required fields or containing invalid data
 	BAD_REQUEST SyntheticsMonitorCreateErrorType
-	// An unknown error occured while processing request to mutate monitor
+	// An unknown error occurred while processing request to mutate monitor
 	INTERNAL_SERVER_ERROR SyntheticsMonitorCreateErrorType
 	// Monitor not found for given guid (monitor does not exist on account or has already been deleted)
 	NOT_FOUND SyntheticsMonitorCreateErrorType
-	// Monitor tags were not udpated.
+	// Monitor creation exceeds account subscription limits
+	PAYMENT_REQUIRED SyntheticsMonitorCreateErrorType
+	// Monitor tags were not updated.
 	TAGGING_ERROR SyntheticsMonitorCreateErrorType
 	// User does not have authorization to perform monitor mutation.
 	UNAUTHORIZED SyntheticsMonitorCreateErrorType
@@ -115,11 +155,13 @@ var SyntheticsMonitorCreateErrorTypeTypes = struct {
 }{
 	// Received a request missing required fields or containing invalid data
 	BAD_REQUEST: "BAD_REQUEST",
-	// An unknown error occured while processing request to mutate monitor
+	// An unknown error occurred while processing request to mutate monitor
 	INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
 	// Monitor not found for given guid (monitor does not exist on account or has already been deleted)
 	NOT_FOUND: "NOT_FOUND",
-	// Monitor tags were not udpated.
+	// Monitor creation exceeds account subscription limits
+	PAYMENT_REQUIRED: "PAYMENT_REQUIRED",
+	// Monitor tags were not updated.
 	TAGGING_ERROR: "TAGGING_ERROR",
 	// User does not have authorization to perform monitor mutation.
 	UNAUTHORIZED: "UNAUTHORIZED",
@@ -195,13 +237,13 @@ type SyntheticsMonitorUpdateErrorType string
 var SyntheticsMonitorUpdateErrorTypeTypes = struct {
 	// Received a request missing required fields or containing invalid data
 	BAD_REQUEST SyntheticsMonitorUpdateErrorType
-	// An unknown error occured while processing request to mutate monitor
+	// An unknown error occurred while processing request to mutate monitor
 	INTERNAL_SERVER_ERROR SyntheticsMonitorUpdateErrorType
 	// Monitor not found for given guid (monitor does not exist on account or has already been deleted)
 	NOT_FOUND SyntheticsMonitorUpdateErrorType
 	// An error occurred while updating monitor script
 	SCRIPT_ERROR SyntheticsMonitorUpdateErrorType
-	// Monitor tags were not udpated.
+	// Monitor tags were not updated.
 	TAGGING_ERROR SyntheticsMonitorUpdateErrorType
 	// User does not have authorization to perform monitor mutation.
 	UNAUTHORIZED SyntheticsMonitorUpdateErrorType
@@ -210,13 +252,13 @@ var SyntheticsMonitorUpdateErrorTypeTypes = struct {
 }{
 	// Received a request missing required fields or containing invalid data
 	BAD_REQUEST: "BAD_REQUEST",
-	// An unknown error occured while processing request to mutate monitor
+	// An unknown error occurred while processing request to mutate monitor
 	INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
 	// Monitor not found for given guid (monitor does not exist on account or has already been deleted)
 	NOT_FOUND: "NOT_FOUND",
 	// An error occurred while updating monitor script
 	SCRIPT_ERROR: "SCRIPT_ERROR",
-	// Monitor tags were not udpated.
+	// Monitor tags were not updated.
 	TAGGING_ERROR: "TAGGING_ERROR",
 	// User does not have authorization to perform monitor mutation.
 	UNAUTHORIZED: "UNAUTHORIZED",
@@ -230,7 +272,7 @@ type SyntheticsPrivateLocationMutationErrorType string
 var SyntheticsPrivateLocationMutationErrorTypeTypes = struct {
 	// Received a request missing required fields or containing invalid data
 	BAD_REQUEST SyntheticsPrivateLocationMutationErrorType
-	// An unknown error occured while processing request to purge specified private location job queue
+	// An unknown error occurred while processing request to purge specified private location job queue
 	INTERNAL_SERVER_ERROR SyntheticsPrivateLocationMutationErrorType
 	// Private location not found for key (private location does not exist on account or has already been deleted)
 	NOT_FOUND SyntheticsPrivateLocationMutationErrorType
@@ -239,7 +281,7 @@ var SyntheticsPrivateLocationMutationErrorTypeTypes = struct {
 }{
 	// Received a request missing required fields or containing invalid data
 	BAD_REQUEST: "BAD_REQUEST",
-	// An unknown error occured while processing request to purge specified private location job queue
+	// An unknown error occurred while processing request to purge specified private location job queue
 	INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
 	// Private location not found for key (private location does not exist on account or has already been deleted)
 	NOT_FOUND: "NOT_FOUND",
@@ -308,12 +350,9 @@ var SyntheticsStepTypeTypes = struct {
 // Account configuration data is queried through this object, as well as
 // telemetry data that is specific to a single account.
 type Account struct {
-	//
-	ID int `json:"id,omitempty"`
-	//
+	ID         int    `json:"id,omitempty"`
 	LicenseKey string `json:"licenseKey,omitempty"`
-	//
-	Name string `json:"name,omitempty"`
+	Name       string `json:"name,omitempty"`
 	// This field provides access to Synthetics data.
 	Synthetics SyntheticsAccountStitchedFields `json:"synthetics,omitempty"`
 }
@@ -472,7 +511,7 @@ type SyntheticsAccountStitchedFields struct {
 // SyntheticsBrokenLinksMonitor - A Broken Links monitor resulting from a Broken Links monitor mutation
 type SyntheticsBrokenLinksMonitor struct {
 	// The creation time of the monitor in millis
-	CreatedAt nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
 	// The unique client identifier for the Synthetics Monitor in New Relic
 	GUID EntityGUID `json:"guid,omitempty"`
 	// The unique identifier of the monitor within the Synthetics domain
@@ -480,7 +519,7 @@ type SyntheticsBrokenLinksMonitor struct {
 	// The locations the monitor runs from
 	Locations SyntheticsLocations `json:"locations,omitempty"`
 	// The last modification time of the monitor in millis
-	ModifiedAt nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
+	ModifiedAt *nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
 	// The human readable identifier for the monitor
 	Name string `json:"name,omitempty"`
 	// The interval at which the monitor runs in minutes
@@ -510,7 +549,7 @@ type SyntheticsBrokenLinksMonitorUpdateMutationResult struct {
 // SyntheticsCertCheckMonitor - A Cert Check monitor resulting from a Cert Check monitor mutation
 type SyntheticsCertCheckMonitor struct {
 	// The creation time of the monitor in millis
-	CreatedAt nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
 	// The domain of the host that will have its certificate checked
 	Domain string `json:"domain,omitempty"`
 	// The unique client identifier for the Synthetics Monitor in New Relic
@@ -520,7 +559,7 @@ type SyntheticsCertCheckMonitor struct {
 	// The locations the monitor runs from
 	Locations SyntheticsLocations `json:"locations,omitempty"`
 	// The last modification time of the monitor in millis
-	ModifiedAt nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
+	ModifiedAt *nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
 	// The human readable identifier for the monitor
 	Name string `json:"name,omitempty"`
 	// The desired number of remaining days until the certificate expires to trigger a monitor failure
@@ -549,6 +588,8 @@ type SyntheticsCertCheckMonitorUpdateMutationResult struct {
 
 // SyntheticsCreateBrokenLinksMonitorInput - The monitor input values needed to create a Broken Links monitor
 type SyntheticsCreateBrokenLinksMonitorInput struct {
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -565,6 +606,8 @@ type SyntheticsCreateBrokenLinksMonitorInput struct {
 
 // SyntheticsCreateCertCheckMonitorInput - The monitor input values needed to create a Cert Check monitor
 type SyntheticsCreateCertCheckMonitorInput struct {
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The domain of the host that will have its certificate checked
 	Domain string `json:"domain"`
 	// The locations the monitor will run from
@@ -583,6 +626,8 @@ type SyntheticsCreateCertCheckMonitorInput struct {
 
 // SyntheticsCreateScriptAPIMonitorInput - The monitor input values needed to create a Script Api monitor
 type SyntheticsCreateScriptAPIMonitorInput struct {
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsScriptedMonitorLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -603,6 +648,8 @@ type SyntheticsCreateScriptAPIMonitorInput struct {
 type SyntheticsCreateScriptBrowserMonitorInput struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsScriptBrowserMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsScriptedMonitorLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -623,6 +670,8 @@ type SyntheticsCreateScriptBrowserMonitorInput struct {
 type SyntheticsCreateSimpleBrowserMonitorInput struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsSimpleBrowserMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -643,6 +692,8 @@ type SyntheticsCreateSimpleBrowserMonitorInput struct {
 type SyntheticsCreateSimpleMonitorInput struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsSimpleMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -661,6 +712,8 @@ type SyntheticsCreateSimpleMonitorInput struct {
 type SyntheticsCreateStepMonitorInput struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsStepMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsScriptedMonitorLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -691,6 +744,22 @@ type SyntheticsCustomHeaderInput struct {
 	Value string `json:"value"`
 }
 
+// SyntheticsDeviceEmulation - Information related to device emulation
+type SyntheticsDeviceEmulation struct {
+	// The device orientation the user would like to represent
+	DeviceOrientation SyntheticsDeviceOrientation `json:"deviceOrientation"`
+	// The device type that a user can select
+	DeviceType SyntheticsDeviceType `json:"deviceType"`
+}
+
+// SyntheticsDeviceEmulationInput - Information related to device browser emulation
+type SyntheticsDeviceEmulationInput struct {
+	// The device orientation the user would like to represent
+	DeviceOrientation SyntheticsDeviceOrientation `json:"deviceOrientation"`
+	// The device type that a user can select
+	DeviceType SyntheticsDeviceType `json:"deviceType"`
+}
+
 // SyntheticsError - Error object for Synthetics mutations
 type SyntheticsError struct {
 	// Description explaining the cause of the error
@@ -701,7 +770,7 @@ type SyntheticsError struct {
 type SyntheticsLocations struct {
 	// Existing private location(s) in which the monitor will run
 	Private []string `json:"private,omitempty"`
-	// Publicly available location(s) in which the monitor will run
+	// Publicly available location(s) in which the monitor will run. For formatting tips, see [this link](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/#location-field)
 	Public []string `json:"public,omitempty"`
 }
 
@@ -709,7 +778,7 @@ type SyntheticsLocations struct {
 type SyntheticsLocationsInput struct {
 	// Existing private location(s) in which the monitor will run
 	Private []string `json:"private,omitempty"`
-	// Publicly available location(s) in which the monitor will run
+	// Publicly available location(s) in which the monitor will run. For formatting tips, see [this link](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/#location-field)
 	Public []string `json:"public,omitempty"`
 }
 
@@ -782,7 +851,7 @@ type SyntheticsPrivateLocationMutationResult struct {
 	// The name of the private location
 	Name string `json:"name,omitempty"`
 	// Specifies whether the private location requires a password for scripted monitors
-	VerifiedScriptExecution *bool `json:"verifiedScriptExecution,omitempty"`
+	VerifiedScriptExecution bool `json:"verifiedScriptExecution,omitempty"`
 }
 
 // SyntheticsPrivateLocationPurgeQueueResult - Result of a Synthetics purge private location queue mutation
@@ -808,13 +877,13 @@ type SyntheticsRuntimeInput struct {
 	// The specific version of the runtime type selected
 	RuntimeTypeVersion SemVer `json:"runtimeTypeVersion"`
 	// The programing language that should execute the script
-	ScriptLanguage string `json:"scriptLanguage"`
+	ScriptLanguage string `json:"scriptLanguage,omitempty"`
 }
 
 // SyntheticsScriptAPIMonitor - A Script Api monitor resulting from a Script Api mutation
 type SyntheticsScriptAPIMonitor struct {
 	// The creation time of the monitor in millis
-	CreatedAt nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
 	// The unique client identifier for the Synthetics Monitor in New Relic
 	GUID EntityGUID `json:"guid,omitempty"`
 	// The unique identifier of the monitor within the Synthetics domain
@@ -822,7 +891,7 @@ type SyntheticsScriptAPIMonitor struct {
 	// The locations the monitor runs from
 	Locations SyntheticsLocations `json:"locations,omitempty"`
 	// The last modification time of the monitor in millis
-	ModifiedAt nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
+	ModifiedAt *nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
 	// The human readable identifier for the monitor
 	Name string `json:"name,omitempty"`
 	// The interval at which the monitor runs in minutes
@@ -854,7 +923,7 @@ type SyntheticsScriptBrowserMonitor struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsScriptBrowserMonitorAdvancedOptions `json:"advancedOptions,omitempty"`
 	// The creation time of the monitor in millis
-	CreatedAt nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
 	// The unique client identifier for the Synthetics Monitor in New Relic
 	GUID EntityGUID `json:"guid,omitempty"`
 	// The unique identifier of the monitor within the Synthetics domain
@@ -862,7 +931,7 @@ type SyntheticsScriptBrowserMonitor struct {
 	// The locations the monitor runs from
 	Locations SyntheticsLocations `json:"locations,omitempty"`
 	// The last modification time of the monitor in millis
-	ModifiedAt nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
+	ModifiedAt *nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
 	// The human readable identifier for the monitor
 	Name string `json:"name,omitempty"`
 	// The interval at which the monitor runs in minutes
@@ -875,12 +944,16 @@ type SyntheticsScriptBrowserMonitor struct {
 
 // SyntheticsScriptBrowserMonitorAdvancedOptions - The advanced options available for a Script Browser monitor
 type SyntheticsScriptBrowserMonitorAdvancedOptions struct {
+	// Emulate a device
+	DeviceEmulation SyntheticsDeviceEmulation `json:"deviceEmulation,omitempty"`
 	// Capture a screenshot during job execution
 	EnableScreenshotOnFailureAndScript *bool `json:"enableScreenshotOnFailureAndScript,omitempty"`
 }
 
 // SyntheticsScriptBrowserMonitorAdvancedOptionsInput - The advanced options inputs available for a Script Browser monitor
 type SyntheticsScriptBrowserMonitorAdvancedOptionsInput struct {
+	// Emulate a device
+	DeviceEmulation SyntheticsDeviceEmulationInput `json:"deviceEmulation,omitempty"`
 	// Capture a screenshot during job execution
 	EnableScreenshotOnFailureAndScript *bool `json:"enableScreenshotOnFailureAndScript,omitempty"`
 }
@@ -928,7 +1001,7 @@ type SyntheticsSimpleBrowserMonitor struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsSimpleBrowserMonitorAdvancedOptions `json:"advancedOptions,omitempty"`
 	// The creation time of the monitor in millis
-	CreatedAt nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
 	// The unique client identifier for the Synthetics Monitor in New Relic
 	GUID EntityGUID `json:"guid,omitempty"`
 	// The unique identifier of the monitor within the Synthetics domain
@@ -936,7 +1009,7 @@ type SyntheticsSimpleBrowserMonitor struct {
 	// The locations the monitor runs from
 	Locations SyntheticsLocations `json:"locations,omitempty"`
 	// The last modification time of the monitor in millis
-	ModifiedAt nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
+	ModifiedAt *nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
 	// The human readable identifier for the monitor
 	Name string `json:"name,omitempty"`
 	// The interval at which the monitor runs in minutes
@@ -953,6 +1026,8 @@ type SyntheticsSimpleBrowserMonitor struct {
 type SyntheticsSimpleBrowserMonitorAdvancedOptions struct {
 	// Custom headers to use in monitor job
 	CustomHeaders []SyntheticsCustomHeader `json:"customHeaders,omitempty"`
+	// Emulate a device
+	DeviceEmulation SyntheticsDeviceEmulation `json:"deviceEmulation,omitempty"`
 	// Capture a screenshot during job execution
 	EnableScreenshotOnFailureAndScript *bool `json:"enableScreenshotOnFailureAndScript,omitempty"`
 	// Validation text for monitor to search for at given URI
@@ -965,6 +1040,8 @@ type SyntheticsSimpleBrowserMonitorAdvancedOptions struct {
 type SyntheticsSimpleBrowserMonitorAdvancedOptionsInput struct {
 	// Custom headers to use in monitor job
 	CustomHeaders []SyntheticsCustomHeaderInput `json:"customHeaders,omitempty"`
+	// Emulate a device
+	DeviceEmulation SyntheticsDeviceEmulationInput `json:"deviceEmulation,omitempty"`
 	// Capture a screenshot during job execution
 	EnableScreenshotOnFailureAndScript *bool `json:"enableScreenshotOnFailureAndScript,omitempty"`
 	// Validation text for monitor to search for at given URI
@@ -994,7 +1071,7 @@ type SyntheticsSimpleMonitor struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsSimpleMonitorAdvancedOptions `json:"advancedOptions,omitempty"`
 	// The creation time of the monitor in millis
-	CreatedAt nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
 	// The unique client identifier for the Synthetics Monitor in New Relic
 	GUID EntityGUID `json:"guid,omitempty"`
 	// The unique identifier of the monitor within the Synthetics domain
@@ -1002,7 +1079,7 @@ type SyntheticsSimpleMonitor struct {
 	// The locations the monitor runs from
 	Locations SyntheticsLocations `json:"locations,omitempty"`
 	// The last modification time of the monitor in millis
-	ModifiedAt nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
+	ModifiedAt *nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
 	// The human readable identifier for the monitor
 	Name string `json:"name,omitempty"`
 	// The interval at which the monitor runs in minutes
@@ -1074,7 +1151,7 @@ type SyntheticsStepMonitor struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsStepMonitorAdvancedOptions `json:"advancedOptions,omitempty"`
 	// The creation time of the monitor in millis
-	CreatedAt nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
 	// The unique client identifier for the Synthetics Monitor in New Relic
 	GUID EntityGUID `json:"guid,omitempty"`
 	// The unique identifier of the monitor within the Synthetics domain
@@ -1082,7 +1159,7 @@ type SyntheticsStepMonitor struct {
 	// The locations the monitor runs from
 	Locations SyntheticsLocations `json:"locations,omitempty"`
 	// The last modification time of the monitor in millis
-	ModifiedAt nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
+	ModifiedAt *nrtime.EpochMilliseconds `json:"modifiedAt,omitempty"`
 	// The human readable identifier for the monitor
 	Name string `json:"name,omitempty"`
 	// The interval at which the monitor runs in minutes
@@ -1131,6 +1208,8 @@ type SyntheticsTag struct {
 
 // SyntheticsUpdateBrokenLinksMonitorInput - The monitor values that can be updated on a Broken Links monitor
 type SyntheticsUpdateBrokenLinksMonitorInput struct {
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -1147,6 +1226,8 @@ type SyntheticsUpdateBrokenLinksMonitorInput struct {
 
 // SyntheticsUpdateCertCheckMonitorInput - The monitor values that can be updated on a Cert Check monitor
 type SyntheticsUpdateCertCheckMonitorInput struct {
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The domain of the host that will have its certificate checked
 	Domain string `json:"domain,omitempty"`
 	// The locations the monitor will run from
@@ -1165,6 +1246,8 @@ type SyntheticsUpdateCertCheckMonitorInput struct {
 
 // SyntheticsUpdateScriptAPIMonitorInput - The monitor values that can be updated on a Script Api monitor
 type SyntheticsUpdateScriptAPIMonitorInput struct {
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsScriptedMonitorLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -1185,6 +1268,8 @@ type SyntheticsUpdateScriptAPIMonitorInput struct {
 type SyntheticsUpdateScriptBrowserMonitorInput struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsScriptBrowserMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsScriptedMonitorLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -1205,6 +1290,8 @@ type SyntheticsUpdateScriptBrowserMonitorInput struct {
 type SyntheticsUpdateSimpleBrowserMonitorInput struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsSimpleBrowserMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -1225,6 +1312,8 @@ type SyntheticsUpdateSimpleBrowserMonitorInput struct {
 type SyntheticsUpdateSimpleMonitorInput struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsSimpleMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -1243,6 +1332,8 @@ type SyntheticsUpdateSimpleMonitorInput struct {
 type SyntheticsUpdateStepMonitorInput struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsStepMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
+	// The monitor's Apdex target used to populate SLA reports
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsScriptedMonitorLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -1267,6 +1358,11 @@ type stepsResponse struct {
 
 // EntityGUID - An encoded Entity GUID
 type EntityGUID string
+
+// Float - The `Float` scalar type represents signed double-precision fractional
+// values as specified by
+// [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754).
+type Float string
 
 // Nr1CatalogRawNerdletState - Represents JSON nerdlet state data
 type Nr1CatalogRawNerdletState string

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -635,7 +635,7 @@ type SyntheticsCreateScriptAPIMonitorInput struct {
 	// The interval at which the monitor runs in minutes
 	Period SyntheticsMonitorPeriod `json:"period"`
 	// The runtime that the monitor will use to run jobs
-	Runtime SyntheticsRuntimeInput `json:"runtime,omitempty"`
+	Runtime *SyntheticsRuntimeInput `json:"runtime,omitempty"`
 	// The script that the monitor runs
 	Script string `json:"script"`
 	// The run state of the monitor
@@ -657,7 +657,7 @@ type SyntheticsCreateScriptBrowserMonitorInput struct {
 	// The interval at which the monitor runs in minutes
 	Period SyntheticsMonitorPeriod `json:"period"`
 	// The runtime that the monitor will use to run jobs
-	Runtime SyntheticsRuntimeInput `json:"runtime,omitempty"`
+	Runtime *SyntheticsRuntimeInput `json:"runtime,omitempty"`
 	// The script that the monitor runs
 	Script string `json:"script"`
 	// The run state of the monitor
@@ -679,7 +679,7 @@ type SyntheticsCreateSimpleBrowserMonitorInput struct {
 	// The interval at which the monitor runs in minutes
 	Period SyntheticsMonitorPeriod `json:"period"`
 	// The runtime that the monitor will use to run jobs
-	Runtime SyntheticsRuntimeInput `json:"runtime,omitempty"`
+	Runtime *SyntheticsRuntimeInput `json:"runtime,omitempty"`
 	// The run state of the monitor
 	Status SyntheticsMonitorStatus `json:"status"`
 	// The tags that will be associated with the monitor
@@ -1255,7 +1255,7 @@ type SyntheticsUpdateScriptAPIMonitorInput struct {
 	// The interval at which the monitor runs in minutes
 	Period SyntheticsMonitorPeriod `json:"period,omitempty"`
 	// The runtime that the monitor will use to run jobs
-	Runtime SyntheticsRuntimeInput `json:"runtime,omitempty"`
+	Runtime *SyntheticsRuntimeInput `json:"runtime,omitempty"`
 	// The script that the monitor runs
 	Script string `json:"script,omitempty"`
 	// The run state of the monitor
@@ -1277,7 +1277,7 @@ type SyntheticsUpdateScriptBrowserMonitorInput struct {
 	// The interval at which the monitor runs in minutes
 	Period SyntheticsMonitorPeriod `json:"period,omitempty"`
 	// The runtime that the monitor will use to run jobs
-	Runtime SyntheticsRuntimeInput `json:"runtime,omitempty"`
+	Runtime *SyntheticsRuntimeInput `json:"runtime,omitempty"`
 	// The script that the monitor runs
 	Script string `json:"script,omitempty"`
 	// The run state of the monitor
@@ -1299,7 +1299,7 @@ type SyntheticsUpdateSimpleBrowserMonitorInput struct {
 	// The interval at which the monitor runs in minutes
 	Period SyntheticsMonitorPeriod `json:"period,omitempty"`
 	// The runtime that the monitor will use to run jobs
-	Runtime SyntheticsRuntimeInput `json:"runtime,omitempty"`
+	Runtime *SyntheticsRuntimeInput `json:"runtime,omitempty"`
 	// The run state of the monitor
 	Status SyntheticsMonitorStatus `json:"status,omitempty"`
 	// The tags that will be associated with the monitor


### PR DESCRIPTION
This PR adds the ability to provision a Synthetics scripted browser monitor that can emulate different devices, such as mobile or tablet devices. If a monitor has screenshots enabled, those screenshots should also be based on the device emulation if defined. 
 