### PR TITLE
fix(dashboards): addition of the attribute 'Zero' to DashboardWidgetYAxisLeft

### DIFF
--- a/pkg/dashboards/dashboards_types.go
+++ b/pkg/dashboards/dashboards_types.go
@@ -325,8 +325,9 @@ type DashboardWidgetLegend struct {
 }
 
 type DashboardWidgetYAxisLeft struct {
-	Max float64 `json:"max,omitempty"`
-	Min float64 `json:"min"`
+	Max  float64  `json:"max,omitempty"`
+	Min  *float64 `json:"min,omitempty"`
+	Zero *bool    `json:"zero,omitempty"`
 }
 
 type DashboardWidgetNullValues struct {


### PR DESCRIPTION
## Description

This PR addresses [NR-108075](https://issues.newrelic.com/browse/NR-108075), comprising of the following changes - 
- Addition of the attribute `Zero` to `DashboardWidgetYAxisLeft` to be sent to the API whenever set, for which the API is already programmed to fit the graph to scale if `zero=false` or print the graph in the given range of values if `zero=true`

Linked changes in dependencies
**terraform-provider-newrelic** : [PR](https://github.com/newrelic/terraform-provider-newrelic/pull/2329)
**newrelic-cli** : [PR](https://github.com/newrelic/newrelic-cli/pull/1450)