### PR TITLE
chore(cloud): update to queries, types to support azure monitor integration from TF

### DIFF
--- a/pkg/cloud/cloud_api.go
+++ b/pkg/cloud/cloud_api.go
@@ -335,6 +335,7 @@ const CloudConfigureIntegrationMutation = `mutation(
 		}
 		... on CloudAzureMonitorIntegration {
 			__typename
+			enabled
 			excludeTags
 			includeTags
 			inventoryPollingInterval
@@ -834,6 +835,7 @@ type CloudDisableIntegrationQueryResponse struct {
 	CloudDisableIntegrationPayload CloudDisableIntegrationPayload `json:"CloudDisableIntegration"`
 }
 
+// Note: Do not make "$integrations" an optional field (as fetched from Tutone) to avoid a breaking change
 const CloudDisableIntegrationMutation = `mutation(
 	$accountId: Int!,
 	$integrations: CloudDisableIntegrationsInput!,
@@ -1114,6 +1116,7 @@ const CloudDisableIntegrationMutation = `mutation(
 		}
 		... on CloudAzureMonitorIntegration {
 			__typename
+			enabled
 			excludeTags
 			includeTags
 			inventoryPollingInterval
@@ -1816,6 +1819,7 @@ func (a *Cloud) GetLinkedAccountWithContext(
 	return &resp.Actor.Account.Cloud.LinkedAccount, nil
 }
 
+// Note: Do not make "$id" an optional field (as fetched from Tutone) to avoid a breaking change
 const getLinkedAccountQuery = `query(
 	$accountID: Int!,
 	$id: Int!,
@@ -2120,6 +2124,7 @@ const getLinkedAccountQuery = `query(
 		}
 		... on CloudAzureMonitorIntegration {
 			__typename
+			enabled
 			excludeTags
 			includeTags
 			inventoryPollingInterval
@@ -2657,6 +2662,756 @@ const getLinkedAccountsQuery = `query(
 	disabled
 	externalId
 	id
+	integrations {
+		__typename
+		createdAt
+		id
+		linkedAccount {
+			authLabel
+			createdAt
+			disabled
+			externalId
+			id
+			metricCollectionMode
+			name
+			nrAccountId
+			updatedAt
+		}
+		name
+		nrAccountId
+		service {
+			createdAt
+			icon
+			id
+			isEnabled
+			name
+			slug
+			updatedAt
+		}
+		updatedAt
+		... on CloudAlbIntegration {
+			__typename
+			awsRegions
+			fetchExtendedInventory
+			fetchTags
+			inventoryPollingInterval
+			loadBalancerPrefixes
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudApigatewayIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+			stagePrefixes
+			tagKey
+			tagValue
+		}
+		... on CloudAutoscalingIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsAppsyncIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsAthenaIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsCognitoIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsConnectIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsDirectconnectIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsDocdbIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsFsxIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsGlueIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsKinesisanalyticsIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMediaconvertIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMediapackagevodIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMetadataIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMqIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMskIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsNeptuneIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsQldbIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsRoute53resolverIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsStatesIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsTagsGlobalIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsTransitgatewayIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsWafIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsWafv2Integration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsXrayIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAzureApimanagementIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureAppgatewayIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureAppserviceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureContainersIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureCosmosdbIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureCostmanagementIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKeys
+		}
+		... on CloudAzureDatafactoryIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureEventhubIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureExpressrouteIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureFirewallsIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureFrontdoorIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureFunctionsIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureKeyvaultIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureLoadbalancerIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureLogicappsIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureMachinelearningIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureMariadbIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureMonitorIntegration {
+			__typename
+			enabled
+			excludeTags
+			includeTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+			resourceTypes
+		}
+		... on CloudAzureMysqlIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureMysqlflexibleIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzurePostgresqlIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzurePostgresqlflexibleIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzurePowerbidedicatedIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureRediscacheIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureServicebusIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureSqlIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureSqlmanagedIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureStorageIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureVirtualmachineIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureVirtualnetworksIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureVmsIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudAzureVpngatewaysIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			resourceGroups
+		}
+		... on CloudBaseIntegration {
+			__typename
+		}
+		... on CloudBillingIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudCloudfrontIntegration {
+			__typename
+			fetchLambdasAtEdge
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudCloudtrailIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudDynamodbIntegration {
+			__typename
+			awsRegions
+			fetchExtendedInventory
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudEbsIntegration {
+			__typename
+			awsRegions
+			fetchExtendedInventory
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudEc2Integration {
+			__typename
+			awsRegions
+			duplicateEc2Tags
+			fetchIpAddresses
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudEcsIntegration {
+			__typename
+			awsRegions
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudEfsIntegration {
+			__typename
+			awsRegions
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudElasticacheIntegration {
+			__typename
+			awsRegions
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudElasticbeanstalkIntegration {
+			__typename
+			awsRegions
+			fetchExtendedInventory
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudElasticsearchIntegration {
+			__typename
+			awsRegions
+			fetchNodes
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudElbIntegration {
+			__typename
+			awsRegions
+			fetchExtendedInventory
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudEmrIntegration {
+			__typename
+			awsRegions
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudGcpAlloydbIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpAppengineIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpBigqueryIntegration {
+			__typename
+			fetchTableMetrics
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpBigtableIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpComposerIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpDataflowIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpDataprocIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpDatastoreIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpFirebasedatabaseIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpFirebasehostingIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpFirebasestorageIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpFirestoreIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpFunctionsIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpInterconnectIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpKubernetesIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpLoadbalancingIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpMemcacheIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpPubsubIntegration {
+			__typename
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpRedisIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpRouterIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpRunIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpSpannerIntegration {
+			__typename
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpSqlIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpStorageIntegration {
+			__typename
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpVmsIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudGcpVpcaccessIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudHealthIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudIamIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudIotIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudKinesisFirehoseIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudKinesisIntegration {
+			__typename
+			awsRegions
+			fetchShards
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudLambdaIntegration {
+			__typename
+			awsRegions
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudRdsIntegration {
+			__typename
+			awsRegions
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudRedshiftIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudRoute53Integration {
+			__typename
+			fetchExtendedInventory
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudS3Integration {
+			__typename
+			fetchExtendedInventory
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+		... on CloudSesIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudSnsIntegration {
+			__typename
+			awsRegions
+			fetchExtendedInventory
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudSqsIntegration {
+			__typename
+			awsRegions
+			fetchExtendedInventory
+			fetchTags
+			inventoryPollingInterval
+			metricsPollingInterval
+			queuePrefixes
+			tagKey
+			tagValue
+		}
+		... on CloudTrustedadvisorIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudVpcIntegration {
+			__typename
+			awsRegions
+			fetchNatGateway
+			fetchVpn
+			inventoryPollingInterval
+			metricsPollingInterval
+			tagKey
+			tagValue
+		}
+	}
 	metricCollectionMode
 	name
 	nrAccountId
@@ -2672,6 +3427,7 @@ const getLinkedAccountsQuery = `query(
 			id
 			isEnabled
 			name
+			slug
 			updatedAt
 		}
 		slug

--- a/pkg/cloud/cloud_api_integration_test.go
+++ b/pkg/cloud/cloud_api_integration_test.go
@@ -4,12 +4,12 @@
 package cloud
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
 
 	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCloudAccount_Basic(t *testing.T) {

--- a/pkg/cloud/cloud_api_unit_test.go
+++ b/pkg/cloud/cloud_api_unit_test.go
@@ -3,12 +3,13 @@ package cloud
 import (
 	"encoding/json"
 	"fmt"
-	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"net/http"
 	"strconv"
 	"testing"
+
+	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
+	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/pkg/cloud/cloud_api_unit_test.go
+++ b/pkg/cloud/cloud_api_unit_test.go
@@ -1,0 +1,150 @@
+package cloud
+
+import (
+	"encoding/json"
+	"fmt"
+	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+var (
+	testCreateAzureMonitorIntegration = `{
+				"__typename": "CloudAzureMonitorIntegration",
+				"createdAt": 1682411205,
+				"enabled": true,
+				"excludeTags": ["env:staging", "env:testing"],
+				"id": 1709478,
+				"includeTags": ["env:production"],
+				"inventoryPollingInterval": null,
+				"metricsPollingInterval": 1200,
+				"name": "Azure Monitor metrics",
+				"nrAccountId": ` + nrAccountID + `,
+				"resourceGroups": ["resource_groups"],
+				"resourceTypes": ["microsoft.datashare/accounts"],
+				"updatedAt": 1682413262
+				}`
+	testDeleteAzureMonitorDisabledIntegration = `{
+				"__typename": "CloudAzureMonitorIntegration",
+				"createdAt": 1682437459,
+				"enabled": true,
+				"excludeTags": ["env:staging"],
+				"id": 1709859,
+				"includeTags": ["env:production", "env:testing"],
+				"inventoryPollingInterval": null,
+				"metricsPollingInterval": 1200,
+				"name": "Azure Monitor metrics",
+				"nrAccountId": ` + nrAccountID + `,
+				"resourceGroups": ["resource_groups"],
+				"resourceTypes": ["microsoft.datashare/accounts"],
+				"updatedAt": 1682437515
+			}`
+
+	testDeleteAzureMonitor = `{
+	"data": {
+		"cloudDisableIntegration": {
+			"disabledIntegrations": [` + testDeleteAzureMonitorDisabledIntegration + `],
+			"errors": []
+		}
+	}
+  }`
+	testCreateAzureMonitor = `{
+	"data": {
+		"cloudConfigureIntegration": {
+			"errors": [],
+			"integrations": [` + testCreateAzureMonitorIntegration + `]
+		}
+	}
+  }`
+	linkedAccountID = fmt.Sprintf("%06d", rand.Int63n(1e6))
+	nrAccountID     = fmt.Sprintf("%06d", rand.Int63n(1e6))
+)
+
+// Unit Test to test the creation of an Azure Monitor.
+// Applies to update too, as create and update use the same mutation 'CloudConfigureIntegration'.
+func TestUnitCreateAzureMonitor(t *testing.T) {
+	t.Parallel()
+	createAzureMonitorResponse := newMockResponse(t, testCreateAzureMonitor, http.StatusCreated)
+	linkedAccountIDAsInt, _ := strconv.Atoi(linkedAccountID)
+	createAzureMonitorInput := CloudIntegrationsInput{
+		Azure: CloudAzureIntegrationsInput{
+			AzureMonitor: []CloudAzureMonitorIntegrationInput{{
+				LinkedAccountId:        linkedAccountIDAsInt,
+				Enabled:                true,
+				ExcludeTags:            []string{"env:staging", "env:testing"},
+				IncludeTags:            []string{"env:production"},
+				MetricsPollingInterval: 1200,
+				ResourceTypes:          []string{"microsoft.datashare/accounts"},
+				ResourceGroups:         []string{"resource_groups"},
+			}},
+		},
+	}
+
+	NRAccountIDInt, _ := strconv.Atoi(nrAccountID)
+	actual, err := createAzureMonitorResponse.CloudConfigureIntegration(NRAccountIDInt, createAzureMonitorInput)
+
+	responseJSON, _ := json.Marshal(actual.Integrations[0])
+	responseJSONAsString := string(responseJSON)
+	objActual, objExpected, objError := unmarshalAzureCloudIntegrationJSON(responseJSONAsString, testCreateAzureMonitorIntegration)
+
+	assert.NoError(t, err)
+	assert.NoError(t, objError)
+	assert.NotNil(t, actual)
+	assert.Equal(t, objActual, objExpected)
+
+}
+
+// Unit Test to test the deletion of an Azure Monitor.
+func TestUnitDeleteAzureMonitor(t *testing.T) {
+	t.Parallel()
+	deleteAzureMonitorResponse := newMockResponse(t, testDeleteAzureMonitor, http.StatusCreated)
+	linkedAccountIDAsInt, _ := strconv.Atoi(linkedAccountID)
+
+	deleteAzureMonitorInput := CloudDisableIntegrationsInput{
+		Azure: CloudAzureDisableIntegrationsInput{
+			AzureMonitor: []CloudDisableAccountIntegrationInput{{
+				LinkedAccountId: linkedAccountIDAsInt,
+			}},
+		},
+	}
+
+	NRAccountIDInt, _ := strconv.Atoi(nrAccountID)
+	actual, err := deleteAzureMonitorResponse.CloudDisableIntegration(NRAccountIDInt, deleteAzureMonitorInput)
+
+	responseJSON, _ := json.Marshal(actual.DisabledIntegrations[0])
+	responseJSONAsString := string(responseJSON)
+
+	objActual, objExpected, objError := unmarshalAzureCloudIntegrationJSON(responseJSONAsString, testDeleteAzureMonitorDisabledIntegration)
+
+	assert.NoError(t, err)
+	assert.NoError(t, objError)
+	assert.NotNil(t, actual)
+	assert.Equal(t, objActual, objExpected)
+
+}
+
+func unmarshalAzureCloudIntegrationJSON(actualJSONString string, expectedJSONString string) (CloudAzureMonitorIntegration, CloudAzureMonitorIntegration, error) {
+	var actual, expected CloudAzureMonitorIntegration
+
+	errActual := json.Unmarshal([]byte(actualJSONString), &actual)
+	errExpected := json.Unmarshal([]byte(expectedJSONString), &expected)
+
+	if errActual != nil {
+		return actual, expected, errActual
+	}
+
+	if errExpected != nil {
+		return actual, expected, errExpected
+	}
+	return actual, expected, nil
+}
+
+func newMockResponse(t *testing.T, mockJSONResponse string, statusCode int) Cloud {
+	ts := mock.NewMockServer(t, mockJSONResponse, statusCode)
+	tc := mock.NewTestConfig(t, ts)
+
+	return New(tc)
+}

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -33,13 +33,10 @@ type Account struct {
 	//
 	// For details and query examples visit
 	// [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/manage-your-aws-azure-google-cloud-integrations-graphql-api).
-	Cloud CloudAccountFields `json:"cloud,omitempty"`
-	//
-	ID int `json:"id,omitempty"`
-	//
-	LicenseKey string `json:"licenseKey,omitempty"`
-	//
-	Name string `json:"name,omitempty"`
+	Cloud      CloudAccountFields `json:"cloud,omitempty"`
+	ID         int                `json:"id,omitempty"`
+	LicenseKey string             `json:"licenseKey,omitempty"`
+	Name       string             `json:"name,omitempty"`
 }
 
 // Actor - The `Actor` object contains fields that are scoped to the API user's access level.
@@ -127,7 +124,6 @@ type CloudAccountMutationError struct {
 	Type string `json:"type"`
 }
 
-// CloudActorFields -
 type CloudActorFields struct {
 	// Get all linked cloud provider accounts scoped to the Actor.
 	LinkedAccounts []CloudLinkedAccount `json:"linkedAccounts,omitempty"`
@@ -645,6 +641,20 @@ type CloudAwsGlueIntegrationInput struct {
 	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
 }
 
+// CloudAwsGovCloudLinkAccountInput - Information required to link an AWS GovCloud account to a NewRelic account.
+type CloudAwsGovCloudLinkAccountInput struct {
+	// The key used to make requests to AWS service APIs
+	AccessKeyId string `json:"accessKeyId"`
+	// The AWS account id
+	AwsAccountId string `json:"awsAccountId"`
+	// How metrics will be collected.
+	MetricCollectionMode CloudMetricCollectionMode `json:"metricCollectionMode,omitempty"`
+	// The linked account name.
+	Name string `json:"name"`
+	// The secret key used to make requests to AWS service APIs
+	SecretAccessKey SecureValue `json:"secretAccessKey"`
+}
+
 // CloudAwsGovCloudProvider - The Amazon Web Services cloud provider (GovCloud)
 type CloudAwsGovCloudProvider struct {
 	// The AWS Account ID
@@ -755,20 +765,6 @@ type CloudAwsGovcloudIntegrationsInput struct {
 	Sns []CloudSnsIntegrationInput `json:"sns,omitempty"`
 	// SQS integration
 	Sqs []CloudSqsIntegrationInput `json:"sqs,omitempty"`
-}
-
-// CloudAwsGovcloudLinkAccountInput - Information required to link an AWS GovCloud account to a NewRelic account.
-type CloudAwsGovcloudLinkAccountInput struct {
-	// The key used to make requests to AWS service APIs
-	AccessKeyId string `json:"accessKeyId"`
-	// The AWS account id
-	AwsAccountId string `json:"awsAccountId"`
-	// How metrics will be collected.
-	MetricCollectionMode CloudMetricCollectionMode `json:"metricCollectionMode,omitempty"`
-	// The linked account name.
-	Name string `json:"name"`
-	// The secret key used to make requests to AWS service APIs
-	SecretAccessKey SecureValue `json:"secretAccessKey"`
 }
 
 // CloudAwsIntegrationsInput - List of integrations
@@ -2281,6 +2277,8 @@ type CloudAzureMariadbIntegrationInput struct {
 type CloudAzureMonitorIntegration struct {
 	// The object creation date, in epoch (Unix) time
 	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// Specify if integration is active
+	Enabled bool `json:"enabled,omitempty"`
 	// Specify resource tags (in 'key:value' form) associated with the resources that you want to exclude from monitoring. Exclusion takes precedence over inclusion.
 	ExcludeTags []string `json:"excludeTags,omitempty"`
 	// The cloud service integration identifier.
@@ -2311,6 +2309,8 @@ func (x *CloudAzureMonitorIntegration) ImplementsCloudIntegration() {}
 
 // CloudAzureMonitorIntegrationInput - Azure Monitor metrics
 type CloudAzureMonitorIntegrationInput struct {
+	// Specify if integration is active
+	Enabled bool `json:"enabled,omitempty"`
 	// Specify resource tags (in 'key:value' form) associated with the resources that you want to exclude from monitoring. Exclusion takes precedence over inclusion.
 	ExcludeTags []string `json:"excludeTags,omitempty"`
 	// Specify resource tags (in 'key:value' form) associated with the resources that you want to monitor. If empty, all resources will be monitored.
@@ -5017,8 +5017,8 @@ type CloudLinkAccountPayload struct {
 type CloudLinkCloudAccountsInput struct {
 	// Aws provider
 	Aws []CloudAwsLinkAccountInput `json:"aws,omitempty"`
-	// AwsGovcloud provider
-	AwsGovcloud []CloudAwsGovcloudLinkAccountInput `json:"awsGovcloud,omitempty"`
+	// AwsGovCloud provider
+	AwsGovcloud []CloudAwsGovCloudLinkAccountInput `json:"awsGovcloud,omitempty"`
 	// Azure provider
 	Azure []CloudAzureLinkAccountInput `json:"azure,omitempty"`
 	// Gcp provider


### PR DESCRIPTION
This PR addresses [NR-110266](https://issues.newrelic.com/browse/NR-110266), go-client changes to facilitate the addition of a new Azure integration ```azureMonitor``` to Terraform, and comprises the following - 
- Changes fetched from Tutone to update the schema of queries/mutations linked to ```cloudConfigureIntegration``` and its counterpart to disable cloud integrations
- Addition of unit tests and integration tests to check if the ```azureMonitor``` integration is created/updated/deleted as expected

[Integration Test Results](https://github.com/newrelic/newrelic-client-go/actions/runs/4818569428/jobs/8580721871#step:6:295)
[Unit Test Results](https://github.com/newrelic/newrelic-client-go/actions/runs/4818569428/jobs/8580722034#step:6:233)

**Note**
The integration test added in this PR will probably not function (see results in Git Integration Tests) since the variables needed to link an Azure account to New Relic (i.e. Azure account credentials) are not present in the environment running these tests. However, this has been tested locally, and the following screenshots show the results.

The integration test **succeeds** when a valid Azure account linked to New Relic is provided. 

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/127438038/234501846-f5e1c891-7c8e-491f-a9de-1e15bd902b13.png">

The integration test **fails** if an invalid Azure account (that does not exist and is not linked to New Relic) is provided.

<img width="817" alt="image" src="https://user-images.githubusercontent.com/127438038/234502051-07d88444-8a3b-4ab2-8a0c-5e4049a72853.png">
