### PR TITLE
fix(dashboards): remove omitempty on widgets to allow creating pages with no widgets

### DIFF
--- a/pkg/dashboards/types.go
+++ b/pkg/dashboards/types.go
@@ -259,7 +259,7 @@ type DashboardPageInput struct {
 	// The name of the page.
 	Name string `json:"name"`
 	// A nested block of all widgets belonging to the page.
-	Widgets []DashboardWidgetInput `json:"widgets,omitempty"`
+	Widgets []DashboardWidgetInput `json:"widgets"`
 }
 
 // DashboardPieWidgetConfigurationInput - Configuration for visualization type 'viz.pie'.  Learn more about [pie](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#pie) widget.
@@ -313,7 +313,7 @@ type DashboardUpdatePageInput struct {
 	// Page name.
 	Name string `json:"name"`
 	// Page widgets.
-	Widgets []DashboardWidgetInput `json:"widgets,omitempty"`
+	Widgets []DashboardWidgetInput `json:"widgets"`
 }
 
 // DashboardUpdatePageResult - Result of updatePage operation.

--- a/pkg/dashboards/types.go
+++ b/pkg/dashboards/types.go
@@ -258,6 +258,11 @@ type DashboardPageInput struct {
 	GUID common.EntityGUID `json:"guid,omitempty"`
 	// The name of the page.
 	Name string `json:"name"`
+
+	// NOTE: The JSON description of the following attribute, "Widgets" has been modified manually
+	// (removal of "omitempty") to facilitate creating pages with no widgets (empty pages).
+	// Please DO NOT regenerate/modify this attribute and its datatype via Tutone (which would add "omitempty" back).
+
 	// A nested block of all widgets belonging to the page.
 	Widgets []DashboardWidgetInput `json:"widgets"`
 }
@@ -312,6 +317,11 @@ type DashboardUpdatePageInput struct {
 	Description string `json:"description,omitempty"`
 	// Page name.
 	Name string `json:"name"`
+
+	// NOTE: The JSON description of the following attribute, "Widgets" has been modified manually
+	// (removal of "omitempty") to facilitate creating pages with no widgets (empty pages).
+	// Please DO NOT regenerate/modify this attribute and its datatype via Tutone (which would add "omitempty" back).
+
 	// Page widgets.
 	Widgets []DashboardWidgetInput `json:"widgets"`
 }


### PR DESCRIPTION
- This PR addresses a fix to an issue in the Terraform Provider : https://github.com/newrelic/terraform-provider-newrelic/issues/2376 to enable creating a dashboard with pages comprising no widgets.
- For this, **omitempty** has been removed next to the relevant datatype, and a test has been added to validate this change.
- For a more detailed explanation on the necessity of these changes, please see this Terraform PR: https://github.com/newrelic/terraform-provider-newrelic/pull/2397