### PR TITLE
chore(apiKeys): Add createdAt to apiAccessKey base fields

### DIFF
--- a/pkg/apiaccess/keys.go
+++ b/pkg/apiaccess/keys.go
@@ -221,6 +221,7 @@ const (
 		key
 		name
 		notes
+		createdAt
 		type
 		... on ApiAccessIngestKey {
 			id

--- a/pkg/apiaccess/keys_integration_test.go
+++ b/pkg/apiaccess/keys_integration_test.go
@@ -111,6 +111,7 @@ func TestIntegrationAPIAccess_UserKeys(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Greater(t, len(searchResult), 0)
+	require.Greater(t, len(searchResult[0].CreatedAt), 0)
 
 	// Test: Update
 	updateResult, err := client.UpdateAPIAccessKeys(APIAccessUpdateInput{

--- a/pkg/apiaccess/types.go
+++ b/pkg/apiaccess/types.go
@@ -578,7 +578,7 @@ type APIAccessUserKeyError struct {
 func (x *APIAccessUserKeyError) ImplementsAPIAccessKeyError() {}
 
 // EpochSeconds - The `EpochSeconds` scalar represents the number of seconds since the Unix epoch
-type EpochSeconds string
+type EpochSeconds int
 
 // APIAccessKey - A key for accessing New Relic APIs.
 type APIAccessKeyInterface interface {


### PR DESCRIPTION
Added `createdAt` to field list returned by `keySearch` NG query