### PR TITLE
chore(apiaccess): Updated CreatedAt attr to nrtime.EpochSeconds

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -330,6 +330,12 @@ packages:
       - name: AccountReference
         field_type_override: accounts.AccountReference
         skip_type_create: true
+      - name: EpochSeconds
+        field_type_override: nrtime.EpochSeconds
+        skip_type_create: true
+      - name: EpochMilliseconds
+        field_type_override: nrtime.EpochMilliseconds
+        skip_type_create: true
       - name: UserReference
         field_type_override: users.UserReference
         skip_type_create: true

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
+	//nolint:staticcheck // SA1019 "io/ioutil" has been deprecated since Go 1.16
 	"io/ioutil"
 	"net/http"
 	"os"

--- a/internal/http/graphql.go
+++ b/internal/http/graphql.go
@@ -94,7 +94,8 @@ func (r *GraphQLErrorResponse) IsPaymentRequired(resp *http.Response) bool {
 // is deprecated.  We want to bubble that up, but not stop returning data
 //
 // Example deprecation message:
-//   This field is deprecated! Please use `relatedEntities` instead.
+//
+//	This field is deprecated! Please use `relatedEntities` instead.
 func (r *GraphQLErrorResponse) IsDeprecated() bool {
 	for _, err := range r.Errors {
 		if strings.HasPrefix(err.Message, "This field is deprecated!") {

--- a/newrelic/doc.go
+++ b/newrelic/doc.go
@@ -3,13 +3,12 @@ Package newrelic is a convenience package that provides a programmatic API surfa
 area for interacting with all the New Relic One products encompassed by this project.
 Refer to each package's documentation to learn more about its capabilities.
 
-Authentication
+# Authentication
 
 You will need a valid Personal API to communicate with the backend New Relic
 APIs that this client communicates with.  See the API key documentation below
 for more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package newrelic

--- a/pkg/accountmanagement/accountmanagement_integration_test.go
+++ b/pkg/accountmanagement/accountmanagement_integration_test.go
@@ -3,8 +3,9 @@ package accountmanagement
 import (
 	"testing"
 
-	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
+
+	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestIntegrationCreateAccount(t *testing.T) {

--- a/pkg/accounts/doc.go
+++ b/pkg/accounts/doc.go
@@ -2,13 +2,12 @@
 Package accounts provides a programmatic API for interacting with New Relic accounts.
 It can be used to retrieve details about all accounts the user is authorized to view.
 
-Authentication
+# Authentication
 
 You will need a valid Personal API key to communicate with the backend New Relic
 API that provides this functionality.  See the API key documentation below for
 more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package accounts

--- a/pkg/agentapplications/agentapplications_integration_test.go
+++ b/pkg/agentapplications/agentapplications_integration_test.go
@@ -6,9 +6,10 @@ package agentapplications
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
-	"github.com/stretchr/testify/require"
 )
 
 // GUID for Dummy App in integration test account

--- a/pkg/alerts/doc.go
+++ b/pkg/alerts/doc.go
@@ -22,7 +22,7 @@ Alerts product.  It can be used for a variety of operations, including:
 
 - Associating one or more alert conditions with a policy
 
-Authentication
+# Authentication
 
 You will need a valid API key to communicate with the backend New Relic APIs
 that provide this functionality.  Use a Personal API key for authentication.
@@ -30,6 +30,5 @@ See the API key documentation below for more information on how to locate this
 key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package alerts

--- a/pkg/alerts/nrql_conditions_integration_test.go
+++ b/pkg/alerts/nrql_conditions_integration_test.go
@@ -228,7 +228,7 @@ var (
 	}
 )
 
-//REST API integration test (deprecated)
+// REST API integration test (deprecated)
 func TestIntegrationNrqlConditions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/apiaccess/insights_keys_integration_test.go
+++ b/pkg/apiaccess/insights_keys_integration_test.go
@@ -73,7 +73,7 @@ func TestIntegrationAPIAccess_InsightsQueryKeys(t *testing.T) {
 	require.NotNil(t, deleteResult)
 }
 
-//nolint: unused
+// nolint: unused
 func newIntegrationTestClient(t *testing.T) APIAccess {
 	tc := mock.NewIntegrationTestConfig(t)
 

--- a/pkg/apiaccess/keys.go
+++ b/pkg/apiaccess/keys.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/newrelic/newrelic-client-go/v2/internal/http"
 )
 
@@ -220,6 +221,7 @@ const (
 		id
 		key
 		name
+		createdAt
 		notes
 		type
 		... on ApiAccessIngestKey {

--- a/pkg/apiaccess/keys_integration_test.go
+++ b/pkg/apiaccess/keys_integration_test.go
@@ -4,11 +4,13 @@
 package apiaccess
 
 import (
-	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
-	"github.com/stretchr/testify/require"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestIntegrationAPIAccess_IngestKeys(t *testing.T) {

--- a/pkg/apiaccess/types.go
+++ b/pkg/apiaccess/types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/accounts"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/nrtime"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/users"
 )
 
@@ -296,16 +297,16 @@ type APIAccessIngestKey struct {
 	// The account attached to the ingest key. Agents using this key will report to the account the key belongs to.
 	AccountID int `json:"accountId,omitempty"`
 	// The UNIX epoch when the key was created, in seconds.
-	CreatedAt EpochSeconds `json:"createdAt,omitempty"`
+	CreatedAt nrtime.EpochSeconds `json:"createdAt,omitempty"`
 	// The ID of the ingest key. This can be used to identify a key without revealing the key itself (used to update and delete).
 	ID string `json:"id,omitempty"`
 	// The type of ingest key, which dictates what types of agents can use it to report.
 	IngestType APIAccessIngestKeyType `json:"ingestType,omitempty"`
 	// The keystring of the key.
 	Key string `json:"key,omitempty"`
-	// The name of the key.
+	// The name of the key. Limited to 120 characters.
 	Name string `json:"name,omitempty"`
-	// Any notes can be attached to an key.
+	// Any notes can be attached to an key. Limited to 120 characters.
 	Notes string `json:"notes,omitempty"`
 	// The type of key, indicating what New Relic APIs it can be used to access.
 	Type APIAccessKeyType `json:"type,omitempty"`
@@ -334,12 +335,12 @@ func (x *APIAccessIngestKeyError) ImplementsAPIAccessKeyError() {}
 // APIAccessKey - A key for accessing New Relic APIs.
 type APIAccessKey struct {
 	// The UNIX epoch when the key was created, in seconds.
-	CreatedAt EpochSeconds `json:"createdAt,omitempty"`
+	CreatedAt nrtime.EpochSeconds `json:"createdAt,omitempty"`
 	// The ID of the key. This can be used to identify a key without revealing the key itself (used to update and delete).
 	ID string `json:"id,omitempty"`
 	// The keystring of the key.
 	Key string `json:"key,omitempty"`
-	// The name of the key. This can be used a short identifier for easy reference.
+	// The name of the key. This can be used as a short identifier for easy reference.
 	Name string `json:"name,omitempty"`
 	// Any notes can be attached to a key. This is intended for more a more detailed description of the key use if desired.
 	Notes string `json:"notes,omitempty"`
@@ -540,14 +541,14 @@ type APIAccessUserKey struct {
 	// The account ID of the key.
 	AccountID int `json:"accountId,omitempty"`
 	// The UNIX epoch when the key was created, in seconds.
-	CreatedAt EpochSeconds `json:"createdAt,omitempty"`
+	CreatedAt nrtime.EpochSeconds `json:"createdAt,omitempty"`
 	// The ID of the user key. This can be used to identify a key without revealing the key itself (used to update and delete).
 	ID string `json:"id,omitempty"`
 	// The keystring of the key.
 	Key string `json:"key,omitempty"`
-	// The name of the key.
+	// The name of the key. Limited to 120 characters.
 	Name string `json:"name,omitempty"`
-	// Any notes can be attached to a key.
+	// Any notes can be attached to a key. Limited to 120 characters.
 	Notes string `json:"notes,omitempty"`
 	// The type of key, indicating what New Relic APIs it can be used to access.
 	Type APIAccessKeyType `json:"type,omitempty"`
@@ -577,8 +578,15 @@ type APIAccessUserKeyError struct {
 
 func (x *APIAccessUserKeyError) ImplementsAPIAccessKeyError() {}
 
-// EpochSeconds - The `EpochSeconds` scalar represents the number of seconds since the Unix epoch
-type EpochSeconds string
+type APIAccessKeyErrorResponse struct {
+	// The message with the error cause.
+	Message string `json:"message,omitempty"`
+	// Type of error.
+	Type               string                      `json:"type,omitempty"`
+	UserKeyErrorType   APIAccessUserKeyErrorType   `json:"userErrorType,omitempty"`
+	IngestKeyErrorType APIAccessIngestKeyErrorType `json:"ingestErrorType,omitempty"`
+	Id                 string                      `json:"id,omitempty"`
+}
 
 // APIAccessKey - A key for accessing New Relic APIs.
 type APIAccessKeyInterface interface {
@@ -646,16 +654,6 @@ func UnmarshalAPIAccessKeyInterface(b []byte) (*APIAccessKeyInterface, error) {
 type APIAccessKeyErrorInterface interface {
 	ImplementsAPIAccessKeyError()
 	GetError() error
-}
-
-type APIAccessKeyErrorResponse struct {
-	// The message with the error cause.
-	Message string `json:"message,omitempty"`
-	// Type of error.
-	Type               string                      `json:"type,omitempty"`
-	UserKeyErrorType   APIAccessUserKeyErrorType   `json:"userErrorType,omitempty"`
-	IngestKeyErrorType APIAccessIngestKeyErrorType `json:"ingestErrorType,omitempty"`
-	Id                 string                      `json:"id,omitempty"`
 }
 
 // UnmarshalAPIAccessKeyErrorInterface unmarshals the interface into the correct type

--- a/pkg/apm/doc.go
+++ b/pkg/apm/doc.go
@@ -10,7 +10,7 @@ APM product.  It can be used for a variety of operations, including:
 
 - Creating, reading, and deleting APM labels
 
-Authentication
+# Authentication
 
 You will need a valid Personal API key to communicate with the backend New Relic
 APIs that provide this functionality. See the API key documentation below for
@@ -18,7 +18,7 @@ more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
 
-Labels
+# Labels
 
 New Relic One entity tags are currently the preferred method for organizing your
 New Relic resources.  Consider using entity tags via the `entities` package if
@@ -26,6 +26,5 @@ you are just getting started.  More information about entity tags and APM labels
 can be found at the following URL:
 
 https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor#labels
-
 */
 package apm

--- a/pkg/cloud/cloud_api_integration_test.go
+++ b/pkg/cloud/cloud_api_integration_test.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
+
+	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestCloudAccount_Basic(t *testing.T) {

--- a/pkg/cloud/cloud_api_unit_test.go
+++ b/pkg/cloud/cloud_api_unit_test.go
@@ -8,8 +8,9 @@ import (
 	"strconv"
 	"testing"
 
-	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/assert"
+
+	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 var (

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -2,13 +2,12 @@
 Package config provides a configuration surface area for configuring the underlying
 client.
 
-Authentication
+# Authentication
 
 You will need a valid Personal API key to communicate with the backend New Relic
 APIs that power the client. See the API key documentation below for more
 information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package config

--- a/pkg/dashboards/doc.go
+++ b/pkg/dashboards/doc.go
@@ -6,13 +6,12 @@ on working with these resources:
 
 https://docs.newrelic.com/docs/insights/insights-api/manage-dashboards/insights-dashboard-api
 
-Authentication
+# Authentication
 
 You will need a Personal API key to communicate with the backend New Relic API
 that provides this functionality. See the API key documentation below for
 more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package dashboards

--- a/pkg/edge/doc.go
+++ b/pkg/edge/doc.go
@@ -3,13 +3,12 @@ Package edge provides a programmatic API for interacting with New Relic Edge wit
 infinite tracing. It can be used to enable New Relic Edge and retrieve relevant
 config parameters.
 
-Authentication
+# Authentication
 
 You will need a valid Personal API key to communicate with the backend New Relic
 API that provides this functionality.  See the API key documentation below for
 more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package edge

--- a/pkg/entities/doc.go
+++ b/pkg/entities/doc.go
@@ -6,13 +6,12 @@ entities.  It can be used for a variety of operations, including:
 
 - Creating, reading, updating, and deleting New Relic One entity tags
 
-Authentication
+# Authentication
 
 You will need a valid Personal API key to communicate with the backend New Relic
 API that provides this functionality.  See the API key documentation below for
 more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package entities

--- a/pkg/entities/entities_api.go
+++ b/pkg/entities/entities_api.go
@@ -9,9 +9,10 @@ import (
 )
 
 // Adds the provided tags to your specified entity, without deleting existing ones.
-//  The maximum number of tag-values per entity is 100; if the sum of existing and new tag-values if over the limit this mutation will fail.
 //
-//  For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
+//	The maximum number of tag-values per entity is 100; if the sum of existing and new tag-values if over the limit this mutation will fail.
+//
+//	For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
 func (a *Entities) TaggingAddTagsToEntity(
 	gUID common.EntityGUID,
 	tags []TaggingTagInput,
@@ -23,9 +24,10 @@ func (a *Entities) TaggingAddTagsToEntity(
 }
 
 // Adds the provided tags to your specified entity, without deleting existing ones.
-//  The maximum number of tag-values per entity is 100; if the sum of existing and new tag-values if over the limit this mutation will fail.
 //
-//  For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
+//	The maximum number of tag-values per entity is 100; if the sum of existing and new tag-values if over the limit this mutation will fail.
+//
+//	For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
 func (a *Entities) TaggingAddTagsToEntityWithContext(
 	ctx context.Context,
 	gUID common.EntityGUID,
@@ -64,7 +66,7 @@ const TaggingAddTagsToEntityMutation = `mutation(
 
 // Delete specific tag keys from the entity.
 //
-//  For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
+//	For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
 func (a *Entities) TaggingDeleteTagFromEntity(
 	gUID common.EntityGUID,
 	tagKeys []string,
@@ -77,7 +79,7 @@ func (a *Entities) TaggingDeleteTagFromEntity(
 
 // Delete specific tag keys from the entity.
 //
-//  For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
+//	For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
 func (a *Entities) TaggingDeleteTagFromEntityWithContext(
 	ctx context.Context,
 	gUID common.EntityGUID,
@@ -116,7 +118,7 @@ const TaggingDeleteTagFromEntityMutation = `mutation(
 
 // Delete specific tag key-values from the entity.
 //
-//  For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
+//	For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
 func (a *Entities) TaggingDeleteTagValuesFromEntity(
 	gUID common.EntityGUID,
 	tagValues []TaggingTagValueInput,
@@ -129,7 +131,7 @@ func (a *Entities) TaggingDeleteTagValuesFromEntity(
 
 // Delete specific tag key-values from the entity.
 //
-//  For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
+//	For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
 func (a *Entities) TaggingDeleteTagValuesFromEntityWithContext(
 	ctx context.Context,
 	gUID common.EntityGUID,
@@ -167,9 +169,10 @@ const TaggingDeleteTagValuesFromEntityMutation = `mutation(
 } }`
 
 // Replaces the entity's entire set of tags with the provided tag set.
-//  The maximum number of tag-values per entity is 100; if more than 100 tag-values are provided this mutation will fail.
 //
-//  For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
+//	The maximum number of tag-values per entity is 100; if more than 100 tag-values are provided this mutation will fail.
+//
+//	For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
 func (a *Entities) TaggingReplaceTagsOnEntity(
 	gUID common.EntityGUID,
 	tags []TaggingTagInput,
@@ -181,9 +184,10 @@ func (a *Entities) TaggingReplaceTagsOnEntity(
 }
 
 // Replaces the entity's entire set of tags with the provided tag set.
-//  The maximum number of tag-values per entity is 100; if more than 100 tag-values are provided this mutation will fail.
 //
-//  For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
+//	The maximum number of tag-values per entity is 100; if more than 100 tag-values are provided this mutation will fail.
+//
+//	For details and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
 func (a *Entities) TaggingReplaceTagsOnEntityWithContext(
 	ctx context.Context,
 	gUID common.EntityGUID,

--- a/pkg/events/doc.go
+++ b/pkg/events/doc.go
@@ -1,13 +1,12 @@
 /*
 Package events provides a programmatic API for creating custom events in New Relic.
 
-Authentication
+# Authentication
 
 You will need a valid Insights insert key to communicate with the backend New Relic
 API that provides this functionality.  See the API key documentation below for
 more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package events

--- a/pkg/events/events_batch.go
+++ b/pkg/events/events_batch.go
@@ -136,11 +136,9 @@ func (e *Events) Flush() error {
 	return nil
 }
 
-//
 // batchWorker reads []byte from the queue until a threshold is passed,
 // then copies the []byte it has read and sends that batch along to Insights
 // in its own goroutine.
-//
 func (e *Events) batchWorker(ctx context.Context, id int) (err error) {
 	if e == nil {
 		return errors.New("batchWorker: invalid Events, unable to start worker")
@@ -173,10 +171,8 @@ func (e *Events) batchWorker(ctx context.Context, id int) (err error) {
 	}
 }
 
-//
 // watchdog has a Timer that will send the results once the
 // it has expired.
-//
 func (e *Events) watchdog(ctx context.Context) (err error) {
 	if e.eventTimer == nil {
 		return errors.New("invalid timer for watchdog()")

--- a/pkg/logconfigurations/grok_pattern_check_integration_test.go
+++ b/pkg/logconfigurations/grok_pattern_check_integration_test.go
@@ -4,9 +4,11 @@
 package logconfigurations
 
 import (
-	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestIntegrationTestGrok_WithMatch(t *testing.T) {

--- a/pkg/logs/example_log_batch_test.go
+++ b/pkg/logs/example_log_batch_test.go
@@ -16,7 +16,7 @@ const (
 	BatchTimeoutSeconds = 5
 )
 
-//func TestExample_log_batch(t *testing.T) {
+// func TestExample_log_batch(t *testing.T) {
 func Example_basic() {
 	// Initialize the client configuration.  A New Relic License Key is required to communicate with the backend API.
 	cfg := config.New()

--- a/pkg/logs/logs_batch.go
+++ b/pkg/logs/logs_batch.go
@@ -130,11 +130,9 @@ func (e *Logs) Flush() error {
 	return nil
 }
 
-//
 // batchWorker reads []byte from the queue until a threshold is passed,
 // then copies the []byte it has read and sends that batch along to Logs
 // in its own goroutine.
-//
 func (e *Logs) batchWorker(ctx context.Context, id int) (err error) {
 	e.logger.Trace("batchWorker")
 
@@ -166,10 +164,8 @@ func (e *Logs) batchWorker(ctx context.Context, id int) (err error) {
 	}
 }
 
-//
 // watchdog has a Timer that will send the results once the
 // it has expired.
-//
 func (e *Logs) watchdog(ctx context.Context) (err error) {
 	e.logger.Trace("watchdog")
 	if e.logTimer == nil {

--- a/pkg/nerdgraph/doc.go
+++ b/pkg/nerdgraph/doc.go
@@ -6,13 +6,12 @@ the NerdGraph API:
 
 https://api.newrelic.com/graphiql?#
 
-Authentication
+# Authentication
 
 You will need a valid Personal API key to communicate with the backend New Relic
 API that provides this functionality.  See the API key documentation below for
 more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package nerdgraph

--- a/pkg/nerdstorage/doc.go
+++ b/pkg/nerdstorage/doc.go
@@ -8,13 +8,12 @@ documentation:
 
 https://developer.newrelic.com/build-tools/new-relic-one-applications/nerdstorage
 
-Authentication
+# Authentication
 
 You will need a valid Personal API key to communicate with the backend New Relic
 API that provides this functionality.  See the API key documentation below for
 more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package nerdstorage

--- a/pkg/nrdb/doc.go
+++ b/pkg/nrdb/doc.go
@@ -5,13 +5,12 @@ the New Relic Query Language are available here:
 
 https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql
 
-Authentication
+# Authentication
 
 You will need a valid Personal API key to communicate with the backend New Relic
 API that provides this functionality.  See the API key documentation below for
 more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package nrdb

--- a/pkg/plugins/doc.go
+++ b/pkg/plugins/doc.go
@@ -8,13 +8,12 @@ Plugins product.  It can be used for a variety of operations, including:
 
 - Reading plugin component metric data
 
-Authentication
+# Authentication
 
 You will need a Personal API key to communicate with the backend New Relic APIs
 that provide this functionality. See the API key documentation below for more
 information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package plugins

--- a/pkg/synthetics/doc.go
+++ b/pkg/synthetics/doc.go
@@ -16,14 +16,12 @@ More information can be found here:
 
 https://discuss.newrelic.com/t/end-of-life-notice-synthetics-labels-and-synthetics-apm-group-by-tag/103781
 
-
-Authentication
+# Authentication
 
 You will need a Personal API key to communicate with the backend New Relic API
 that provides this functionality.  See the API key documentation below for more
 information on how to locate this keys:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package synthetics

--- a/pkg/synthetics/monitor_scripts.go
+++ b/pkg/synthetics/monitor_scripts.go
@@ -37,8 +37,9 @@ func (s *Synthetics) GetMonitorScriptWithContext(ctx context.Context, monitorID 
 }
 
 // Deprecated: Use one of following instead:
-//    synthetics.SyntheticsUpdateScriptAPIMonitor
-//    synthetics.SyntheticsUpdateScriptBrowserMonitor
+//
+//	synthetics.SyntheticsUpdateScriptAPIMonitor
+//	synthetics.SyntheticsUpdateScriptBrowserMonitor
 //
 // UpdateMonitorScript is used to add a script to an existing New Relic Synthetics monitor_script.
 func (s *Synthetics) UpdateMonitorScript(monitorID string, script MonitorScript) (*MonitorScript, error) {
@@ -46,8 +47,9 @@ func (s *Synthetics) UpdateMonitorScript(monitorID string, script MonitorScript)
 }
 
 // Deprecated: Use one of following instead:
-//    synthetics.SyntheticsUpdateScriptAPIMonitorWithContext
-//    synthetics.SyntheticsUpdateScriptBrowserMonitorWithContext
+//
+//	synthetics.SyntheticsUpdateScriptAPIMonitorWithContext
+//	synthetics.SyntheticsUpdateScriptBrowserMonitorWithContext
 //
 // UpdateMonitorScriptWithContext is used to add a script to an existing New Relic Synthetics monitor_script.
 func (s *Synthetics) UpdateMonitorScriptWithContext(ctx context.Context, monitorID string, script MonitorScript) (*MonitorScript, error) {

--- a/pkg/synthetics/monitors.go
+++ b/pkg/synthetics/monitors.go
@@ -128,25 +128,25 @@ func (s *Synthetics) GetMonitorWithContext(ctx context.Context, monitorID string
 }
 
 // CreateMonitor is used to create a New Relic Synthetics monitor.
-//Deprecated: Use one of the following methods instead based on your needs -
-//syntheticsCreateBrokenLinksMonitor(Broken links monitor),
-//syntheticsCreateCertCheckMonitor(Cert Check Monitor),
+// Deprecated: Use one of the following methods instead based on your needs -
+// syntheticsCreateBrokenLinksMonitor(Broken links monitor),
+// syntheticsCreateCertCheckMonitor(Cert Check Monitor),
 // syntheticsCreateScriptBrowserMonitor(Script Browser Monitor),
-//syntheticsCreateSimpleBrowserMonitor(Simple Browser Monitor),
-//syntheticsCreateSimpleMonitor(Simple Monitor),
-//syntheticsCreateStepMonitor(Step Monitor).
+// syntheticsCreateSimpleBrowserMonitor(Simple Browser Monitor),
+// syntheticsCreateSimpleMonitor(Simple Monitor),
+// syntheticsCreateStepMonitor(Step Monitor).
 func (s *Synthetics) CreateMonitor(monitor Monitor) (*Monitor, error) {
 	return s.CreateMonitorWithContext(context.Background(), monitor)
 }
 
 // CreateMonitorWithContext is used to create a New Relic Synthetics monitor.
-//Deprecated: Use one of the following methods instead based on your needs -
-//syntheticsCreateBrokenLinksMonitorWithContext(Broken links monitor),
-//syntheticsCreateCertCheckMonitorWithContext(Cert Check Monitor),
+// Deprecated: Use one of the following methods instead based on your needs -
+// syntheticsCreateBrokenLinksMonitorWithContext(Broken links monitor),
+// syntheticsCreateCertCheckMonitorWithContext(Cert Check Monitor),
 // syntheticsCreateScriptBrowserMonitorWithContext(Script Browser Monitor),
-//syntheticsCreateSimpleBrowserMonitorWithContext(Simple Browser Monitor),
-//syntheticsCreateSimpleMonitorWithContext(Simple Monitor),
-//syntheticsCreateStepMonitorWithContext(Step Monitor).
+// syntheticsCreateSimpleBrowserMonitorWithContext(Simple Browser Monitor),
+// syntheticsCreateSimpleMonitorWithContext(Simple Monitor),
+// syntheticsCreateStepMonitorWithContext(Step Monitor).
 func (s *Synthetics) CreateMonitorWithContext(ctx context.Context, monitor Monitor) (*Monitor, error) {
 	resp, err := s.client.PostWithContext(ctx, s.config.Region().SyntheticsURL("/v4/monitors"), nil, &monitor, nil)
 
@@ -163,25 +163,25 @@ func (s *Synthetics) CreateMonitorWithContext(ctx context.Context, monitor Monit
 }
 
 // UpdateMonitor is used to update a New Relic Synthetics monitor.
-//Deprecated: Use one of the following methods instead based on your needs -
-//syntheticsUpdateBrokenLinksMonitor(Broken links monitor),
-//syntheticsUpdateCertCheckMonitor(Cert Check Monitor),
+// Deprecated: Use one of the following methods instead based on your needs -
+// syntheticsUpdateBrokenLinksMonitor(Broken links monitor),
+// syntheticsUpdateCertCheckMonitor(Cert Check Monitor),
 // syntheticsUpdateScriptBrowserMonitor(Script Browser Monitor),
-//syntheticsUpdateSimpleBrowserMonitor(Simple Browser Monitor),
-//syntheticsUpdateSimpleMonitor(Simple Monitor),
-//syntheticsUpdateStepMonitor(Step Monitor).
+// syntheticsUpdateSimpleBrowserMonitor(Simple Browser Monitor),
+// syntheticsUpdateSimpleMonitor(Simple Monitor),
+// syntheticsUpdateStepMonitor(Step Monitor).
 func (s *Synthetics) UpdateMonitor(monitor Monitor) (*Monitor, error) {
 	return s.UpdateMonitorWithContext(context.Background(), monitor)
 }
 
 // UpdateMonitorWithContext is used to update a New Relic Synthetics monitor.
-//Deprecated: Use one of the following methods instead based on your needs -
-//syntheticsUpdateBrokenLinksMonitorWithContext(Broken links monitor),
-//syntheticsUpdateCertCheckMonitorWithContext(Cert Check Monitor),
+// Deprecated: Use one of the following methods instead based on your needs -
+// syntheticsUpdateBrokenLinksMonitorWithContext(Broken links monitor),
+// syntheticsUpdateCertCheckMonitorWithContext(Cert Check Monitor),
 // syntheticsUpdateScriptBrowserMonitorWithContext(Script Browser Monitor),
-//syntheticsUpdateSimpleBrowserMonitorWithContext(Simple Browser Monitor),
-//syntheticsUpdateSimpleMonitorWithContext(Simple Monitor),
-//syntheticsUpdateStepMonitorWithContext(Step Monitor).
+// syntheticsUpdateSimpleBrowserMonitorWithContext(Simple Browser Monitor),
+// syntheticsUpdateSimpleMonitorWithContext(Simple Monitor),
+// syntheticsUpdateStepMonitorWithContext(Step Monitor).
 func (s *Synthetics) UpdateMonitorWithContext(ctx context.Context, monitor Monitor) (*Monitor, error) {
 	_, err := s.client.PutWithContext(ctx, s.config.Region().SyntheticsURL("/v4/monitors", monitor.ID), nil, &monitor, nil)
 
@@ -194,14 +194,14 @@ func (s *Synthetics) UpdateMonitorWithContext(ctx context.Context, monitor Monit
 
 // DeleteMonitor is used to delete a New Relic Synthetics monitor.
 // Deprecated: Use the following method to delete all New Relic Synthetics Monitors.
-//SyntheticsDeleteMonitor
+// SyntheticsDeleteMonitor
 func (s *Synthetics) DeleteMonitor(monitorID string) error {
 	return s.DeleteMonitorWithContext(context.Background(), monitorID)
 }
 
 // DeleteMonitorWithContext is used to delete a New Relic Synthetics monitor.
 // Deprecated: Use the following method to delete all New Relic Synthetics Monitors.
-//SyntheticsDeleteMonitorWithContext
+// SyntheticsDeleteMonitorWithContext
 func (s *Synthetics) DeleteMonitorWithContext(ctx context.Context, monitorID string) error {
 	_, err := s.client.DeleteWithContext(ctx, s.config.Region().SyntheticsURL("/v4/monitors", monitorID), nil, nil)
 

--- a/pkg/users/doc.go
+++ b/pkg/users/doc.go
@@ -2,13 +2,12 @@
 Package users provides a programmatic API for interacting with New Relic users.
 It can be used to retrieve details about the user.
 
-Authentication
+# Authentication
 
 You will need a valid Personal API key to communicate with the backend New Relic
 API that provides this functionality.  See the API key documentation below for
 more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package users

--- a/pkg/workflows/workflows_unit_test.go
+++ b/pkg/workflows/workflows_unit_test.go
@@ -193,9 +193,9 @@ func TestCreateWorkflow(t *testing.T) {
 	}
 
 	expectedDestinationConfiguration := []AiWorkflowsDestinationConfiguration{{
-		ChannelId: channelId,
-		Name:      "EMPTY",
-		Type:      "EMAIL",
+		ChannelId:            channelId,
+		Name:                 "EMPTY",
+		Type:                 "EMAIL",
 		NotificationTriggers: []AiWorkflowsNotificationTrigger{"ACTIVATED"},
 	}}
 	expectedIssuedFilter := AiWorkflowsFilter{
@@ -257,9 +257,9 @@ func TestGetWorkflow(t *testing.T) {
 	workflows := newMockResponse(t, respJSON, http.StatusOK)
 
 	expectedDestinationConfiguration := []AiWorkflowsDestinationConfiguration{{
-		ChannelId: channelId,
-		Name:      "EMPTY",
-		Type:      "EMAIL",
+		ChannelId:            channelId,
+		Name:                 "EMPTY",
+		Type:                 "EMAIL",
 		NotificationTriggers: []AiWorkflowsNotificationTrigger{"ACTIVATED"},
 	}}
 	expectedEnrichments := []AiWorkflowsEnrichment{{

--- a/pkg/workloads/doc.go
+++ b/pkg/workloads/doc.go
@@ -2,13 +2,12 @@
 Package workloads provides a programmatic API for interacting with New Relic One
 workloads.  It can be used to create, read, update, and delete workloads.
 
-Authentication
+# Authentication
 
 You will need a valid Personal API key to communicate with the backend New Relic
 API that provides this functionality.  See the API key documentation below for
 more information on how to locate this key:
 
 https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys
-
 */
 package workloads


### PR DESCRIPTION
Changed EpochSeconds to nrtime.EpochSeconds.  This appears to be the correct golang time to handle `createdAt` fields returned in NerdGraph responses

Many of the files touched were a result of running `go fmt` to satisfy linter checks