### PR TITLE
fix(GenericEntityOutline): addition of tags to attributes returned

### DIFF
--- a/pkg/entities/entities_api.go
+++ b/pkg/entities/entities_api.go
@@ -2105,6 +2105,10 @@ const getEntitySearchByQuery = `query(
 			}
 			... on GenericEntityOutline {
 				__typename
+				tags {
+					key
+					values
+				}
 			}
 			... on GenericInfrastructureEntityOutline {
 				__typename


### PR DESCRIPTION
This PR addresses the addition of **tags** to **GenericEntityOutline** in order to make **tags** accessible by Terraform, which is needed to facilitate a change in the Terraform Provider to the data source **newrelic_synthetics_private_location**, in which the key of a private location is to be retrieved from the tags returned.

(note: given that Tutone is running into errors when trying to refetch the `entities` package, this change has been manually added).

unblocks 
https://github.com/newrelic/terraform-provider-newrelic/pull/2446 
https://github.com/newrelic/terraform-provider-newrelic/pull/2453 (same PR but reopened)