### PR TITLE
Update device emulation test for Simple Browser monitor synthetics

### DIFF
--- a/pkg/agentapplications/types.go
+++ b/pkg/agentapplications/types.go
@@ -33,7 +33,7 @@ var AgentApplicationBrowserLoaderTypes = struct {
 	SPA: "SPA",
 }
 
-// AgentApplicationSettingsBrowserLoader - Determines which browser loader will be configured. Some allowed return values are specified for backwards-compatability and do not represent currently allowed values for new applications.
+// AgentApplicationSettingsBrowserLoader - Determines which browser loader will be configured. Some allowed return values are specified for backwards-compatibility and do not represent currently allowed values for new applications.
 // See [documentation](https://docs.newrelic.com/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#agent-types) for further information.
 type AgentApplicationSettingsBrowserLoader string
 
@@ -50,7 +50,7 @@ var AgentApplicationSettingsBrowserLoaderTypes = struct {
 	RUM AgentApplicationSettingsBrowserLoader
 	// Pro+SPA: This is the default installed agent when you enable browser monitoring. Gives you access to all of the Browser Pro features and to Single Page App (SPA) monitoring. Provides detailed page timing data and the most up-to-date New Relic features, including distributed tracing, for all types of applications.
 	SPA AgentApplicationSettingsBrowserLoader
-	// This value is specified for backwards-compatability.
+	// This value is specified for backwards-compatibility.
 	XHR AgentApplicationSettingsBrowserLoader
 }{
 	// Use PRO instead

--- a/pkg/synthetics/synthetics_api.go
+++ b/pkg/synthetics/synthetics_api.go
@@ -1419,7 +1419,7 @@ const getScriptQuery = `query(
 	text
 } } } } }`
 
-// Query that fetches the steps used by the specified Step Monitor
+// visiblity(flag:Synthetics/setGraphqlCustomerVisible) Query that fetches the steps used by the specified Step Monitor
 func (a *Synthetics) GetSteps(
 	accountID int,
 	monitorGUID EntityGUID,
@@ -1430,7 +1430,7 @@ func (a *Synthetics) GetSteps(
 	)
 }
 
-// Query that fetches the steps used by the specified Step Monitor
+// visiblity(flag:Synthetics/setGraphqlCustomerVisible) Query that fetches the steps used by the specified Step Monitor
 func (a *Synthetics) GetStepsWithContext(
 	ctx context.Context,
 	accountID int,

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -100,8 +100,8 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 			UseTlsValidation: &tv,
 			DeviceEmulation: &SyntheticsDeviceEmulationInput{
 				DeviceOrientation: SyntheticsDeviceOrientationTypes.PORTRAIT,
-				DeviceType: SyntheticDeviceTypeTypes.MOBILE,
-			}
+				DeviceType:        SyntheticDeviceTypeTypes.MOBILE,
+			},
 		},
 	}
 

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -100,7 +100,7 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 			UseTlsValidation: &tv,
 			DeviceEmulation: &SyntheticsDeviceEmulationInput{
 				DeviceOrientation: SyntheticsDeviceOrientationTypes.PORTRAIT,
-				DeviceType:        SyntheticsDeviceTypeTypes.MOBILE, SyntheticsDeviceType
+				DeviceType:        SyntheticsDeviceTypeTypes.MOBILE, SyntheticsDeviceType,
 			},
 		},
 	}

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -98,6 +98,10 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 				},
 			},
 			UseTlsValidation: &tv,
+			DeviceEmulation: &SyntheticsDeviceEmulationInput{
+				DeviceOrientation: SyntheticsDeviceOrientationTypes.PORTRAIT,
+				DeviceType: SyntheticDeviceTypeTypes.MOBILE,
+			}
 		},
 	}
 
@@ -117,6 +121,11 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 			EnableScreenshotOnFailureAndScript: &tv,
 			ResponseValidationText:             "Success",
 			UseTlsValidation:                   &tv,
+			// Test changing device emulation options
+			DeviceEmulation: &SyntheticsDeviceEmulationInput{
+				DeviceOrientation: SyntheticsDeviceOrientationTypes.LANDSCAPE,
+				DeviceType:        SyntheticsDeviceTypeTypes.TABLET,
+			},
 		},
 		Locations: SyntheticsLocationsInput{
 			Public: []string{

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -100,7 +100,7 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 			UseTlsValidation: &tv,
 			DeviceEmulation: &SyntheticsDeviceEmulationInput{
 				DeviceOrientation: SyntheticsDeviceOrientationTypes.PORTRAIT,
-				DeviceType:        SyntheticDeviceTypeTypes.MOBILE,
+				DeviceType:        SyntheticsDeviceTypeTypes.MOBILE, SyntheticsDeviceType
 			},
 		},
 	}

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -100,7 +100,7 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 			UseTlsValidation: &tv,
 			DeviceEmulation: &SyntheticsDeviceEmulationInput{
 				DeviceOrientation: SyntheticsDeviceOrientationTypes.PORTRAIT,
-				DeviceType:        SyntheticsDeviceTypeTypes.MOBILE, SyntheticsDeviceType,
+				DeviceType:        SyntheticsDeviceTypeTypes.MOBILE,
 			},
 		},
 	}

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -241,6 +241,8 @@ var SyntheticsMonitorUpdateErrorTypeTypes = struct {
 	INTERNAL_SERVER_ERROR SyntheticsMonitorUpdateErrorType
 	// Monitor not found for given guid (monitor does not exist on account or has already been deleted)
 	NOT_FOUND SyntheticsMonitorUpdateErrorType
+	// Monitor update exceeds account subscription limits
+	PAYMENT_REQUIRED SyntheticsMonitorUpdateErrorType
 	// An error occurred while updating monitor script
 	SCRIPT_ERROR SyntheticsMonitorUpdateErrorType
 	// Monitor tags were not updated.
@@ -256,6 +258,8 @@ var SyntheticsMonitorUpdateErrorTypeTypes = struct {
 	INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
 	// Monitor not found for given guid (monitor does not exist on account or has already been deleted)
 	NOT_FOUND: "NOT_FOUND",
+	// Monitor update exceeds account subscription limits
+	PAYMENT_REQUIRED: "PAYMENT_REQUIRED",
 	// An error occurred while updating monitor script
 	SCRIPT_ERROR: "SCRIPT_ERROR",
 	// Monitor tags were not updated.


### PR DESCRIPTION
Originally, this was motivated by the need to have the `device emulation` option enabled for the `Simple Browser Monitor` synthetics, but the functionality seems already present. We just need to complete it in the TF provider. However, a couple of minor updates are in this PR, including updating the related test with the `device emulation` fields.