### PR TITLE
chore(synthetics): addition of schema and functions for synthetics automated tests

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -171,6 +171,8 @@ packages:
             max_query_field_depth: 1
           - name: "steps"
             max_query_field_depth: 1
+          - name: "automatedTestResult"
+            max_query_field_depth: 6
     mutations:
       - name: syntheticsCreateSecureCredential
         max_query_field_depth: 2
@@ -216,6 +218,8 @@ packages:
         max_query_field_depth: 2
       - name: syntheticsPurgePrivateLocationQueue
         max_query_field_depth: 2
+      - name: syntheticsStartAutomatedTest
+        max_query-field_depth: 4
     types:
       - name: EpochMilliseconds
         field_type_override: "*nrtime.EpochMilliseconds"
@@ -228,6 +232,38 @@ packages:
         field_type_override: "*SyntheticsDeviceEmulationInput"
       - name: SyntheticsRuntimeInput
         field_type_override: "*SyntheticsRuntimeInput"
+      # overrides and specifications of fields associated with the syntheticsStartAutomatedTest mutation start here
+      - name: SyntheticsAutomatedTestConfigInput
+        struct_tags:
+          - json
+          - yaml
+      - name: SyntheticsAutomatedTestMonitorInput
+        struct_tags:
+          - json
+          - yaml
+      - name: SyntheticsAutomatedTestMonitorConfigInput
+        struct_tags:
+          - json
+          - yaml
+      - name: SyntheticsAutomatedTestOverridesInput
+        field_type_override: "*SyntheticsAutomatedTestOverridesInput"
+        struct_tags:
+          - json
+          - yaml
+      - name: SyntheticsScriptDomainOverrideInput
+        struct_tags:
+          - json
+          - yaml
+      - name: SyntheticsSecureCredentialOverrideInput
+        struct_tags:
+          - json
+          - yaml
+      # overrides and specifications of fields associated with the automatedTestResults query start here
+      - name: Milliseconds
+        field_type_override: int
+      - name: SyntheticsAutomatedTestOverrides
+        field_type_override: "*SyntheticsAutomatedTestOverrides"
+
 
   - name: common
     path: pkg/common

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -4,12 +4,14 @@
 package synthetics
 
 import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"fmt"
-	"os"
 
 	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
@@ -1021,4 +1023,326 @@ func newIntegrationTestClient(t *testing.T) Synthetics {
 	tc := mock.NewIntegrationTestConfig(t)
 
 	return New(tc)
+}
+
+// TestSyntheticsStartAutomatedTest_Basic performs a test by creating three monitors and using the
+// syntheticsStartAutomatedTest mutation to create a batch with these three monitors. The expected
+// behaviour of this test is to return a valid batchId and throw no error.
+func TestSyntheticsStartAutomatedTest_Basic(t *testing.T) {
+	t.Parallel()
+
+	a := newIntegrationTestClient(t)
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	// Defining the first monitor
+	monitorOneName := fmt.Sprintf("newrelic-client-go-syntheticStartAutomatedTest-test-monitor-%s", mock.RandSeq(5))
+	monitorOneInput := SyntheticsCreateScriptBrowserMonitorInput{
+		Locations: SyntheticsScriptedMonitorLocationsInput{
+			Public: []string{"AP_SOUTH_1"},
+		},
+		Name:   monitorOneName,
+		Period: SyntheticsMonitorPeriodTypes.EVERY_HOUR,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Runtime: &SyntheticsRuntimeInput{
+			RuntimeTypeVersion: "100",
+			RuntimeType:        "CHROME_BROWSER",
+			ScriptLanguage:     "JAVASCRIPT",
+		},
+		Script: "$browser.get(\"https://www.example.com\").then(function() {\n  // Simulate a failure scenario by deliberately causing an error\n  throw new Error(\"Synthetics CLI Failure scenario Testing !!!\");\n});\n",
+	}
+
+	// Defining the second monitor
+	monitorTwoName := fmt.Sprintf("newrelic-client-go-syntheticStartAutomatedTest-test-monitor-%s", mock.RandSeq(5))
+	monitorTwoInput := SyntheticsCreateSimpleBrowserMonitorInput{
+		Locations: SyntheticsLocationsInput{
+			Public: []string{
+				"AP_SOUTH_1",
+			},
+		},
+		Name:   monitorTwoName,
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
+		Tags: []SyntheticsTag{
+			{
+				Key: "random-key",
+				Values: []string{
+					"random-value",
+				},
+			},
+		},
+		Uri: "https://www.one.newrelic.com",
+		Runtime: &SyntheticsRuntimeInput{
+			RuntimeType:        "CHROME_BROWSER",
+			RuntimeTypeVersion: SemVer("100"),
+			ScriptLanguage:     "JAVASCRIPT",
+		},
+		AdvancedOptions: SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{
+			EnableScreenshotOnFailureAndScript: &tv,
+			ResponseValidationText:             "SUCCESS",
+			CustomHeaders: []SyntheticsCustomHeaderInput{
+				{
+					Name:  "Monitor",
+					Value: "synthetics",
+				},
+			},
+			UseTlsValidation: &tv,
+		},
+	}
+
+	// Defining the third monitor
+	monitorThreeName := fmt.Sprintf("newrelic-client-go-syntheticStartAutomatedTest-test-monitor-%s", mock.RandSeq(5))
+	monitorThreeInput := SyntheticsCreateSimpleMonitorInput{
+		AdvancedOptions: SyntheticsSimpleMonitorAdvancedOptionsInput{
+			CustomHeaders: []SyntheticsCustomHeaderInput{
+				{
+					Name:  monitorThreeName,
+					Value: "Synthetics",
+				},
+			},
+			ResponseValidationText:  "Success",
+			RedirectIsFailure:       &tv,
+			ShouldBypassHeadRequest: &tv,
+			UseTlsValidation:        &tv,
+		},
+		Locations: SyntheticsLocationsInput{
+			Public: []string{
+				"AP_SOUTH_1",
+			},
+		},
+		Name:   monitorThreeName,
+		Period: SyntheticsMonitorPeriodTypes.EVERY_5_MINUTES,
+		Status: SyntheticsMonitorStatus(SyntheticsMonitorStatusTypes.ENABLED),
+		Tags: []SyntheticsTag{
+			{
+				Key: "random-key",
+				Values: []string{
+					"random-value",
+				},
+			},
+		},
+		Uri: "https://www.one.newrelic.com",
+	}
+
+	// Creating all three monitors
+	monitorThree, _ := a.SyntheticsCreateSimpleMonitor(testAccountID, monitorThreeInput)
+	monitorTwo, _ := a.SyntheticsCreateSimpleBrowserMonitor(testAccountID, monitorTwoInput)
+	monitorOne, _ := a.SyntheticsCreateScriptBrowserMonitor(testAccountID, monitorOneInput)
+
+	log.Println(monitorThree.Monitor.GUID)
+	log.Println(monitorTwo.Monitor.GUID)
+	log.Println(monitorOne.Monitor.GUID)
+
+	configInput := SyntheticsAutomatedTestConfigInput{
+		BatchName:  "some-batch",
+		Branch:     "some-branch",
+		Commit:     "some-commit",
+		DeepLink:   "some-deeplink",
+		Platform:   "some-platform",
+		Repository: "some-repository",
+	}
+
+	var testsInput []SyntheticsAutomatedTestMonitorInput
+	testsInput = append(testsInput, SyntheticsAutomatedTestMonitorInput{
+		Config:      SyntheticsAutomatedTestMonitorConfigInput{},
+		MonitorGUID: monitorOne.Monitor.GUID,
+	})
+	testsInput = append(testsInput, SyntheticsAutomatedTestMonitorInput{
+		Config:      SyntheticsAutomatedTestMonitorConfigInput{},
+		MonitorGUID: monitorTwo.Monitor.GUID,
+	})
+	testsInput = append(testsInput, SyntheticsAutomatedTestMonitorInput{
+		Config:      SyntheticsAutomatedTestMonitorConfigInput{},
+		MonitorGUID: monitorThree.Monitor.GUID,
+	})
+
+	result, err := a.SyntheticsStartAutomatedTest(configInput, testsInput)
+	require.NoError(t, err)
+
+	log.Println("Created Batch ID: ", result.BatchId)
+
+	// Deleting all three monitors
+	a.SyntheticsDeleteMonitor(monitorThree.Monitor.GUID)
+	a.SyntheticsDeleteMonitor(monitorTwo.Monitor.GUID)
+	a.SyntheticsDeleteMonitor(monitorOne.Monitor.GUID)
+}
+
+// TestSyntheticsStartAutomatedTest_Error performs a test on the syntheticsStartAutomatedTest mutation by specifying
+// an invalid GUID in the input field of a monitor to obtain an error, in alignment with expected behaviour.
+func TestSyntheticsStartAutomatedTest_Error(t *testing.T) {
+	t.Parallel()
+	a := newIntegrationTestClient(t)
+
+	configInput := SyntheticsAutomatedTestConfigInput{}
+	var testsInput []SyntheticsAutomatedTestMonitorInput
+	testsInput = append(testsInput, SyntheticsAutomatedTestMonitorInput{
+		Config:      SyntheticsAutomatedTestMonitorConfigInput{},
+		MonitorGUID: "invalid-GUID",
+	})
+
+	result, err := a.SyntheticsStartAutomatedTest(configInput, testsInput)
+	log.Println(result)
+	require.Error(t, errors.New("Expected type \"EntityGuid!\", found"), err)
+}
+
+// TestSyntheticsAutomatedTestResults_TwoMonitorsTest performs a test by creating two scripted browser monitors,
+// creating a batch with those monitors, querying the batch and evaluating the status accordingly.
+func TestSyntheticsAutomatedTestResults_TwoMonitorsTest(t *testing.T) {
+	t.Parallel()
+
+	a := newIntegrationTestClient(t)
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	// Defining the first monitor
+	monitorOneName := fmt.Sprintf("newrelic-client-go-automatedTestResults-test-monitor-failure%s", mock.RandSeq(5))
+	monitorOneInput := SyntheticsCreateScriptBrowserMonitorInput{
+		Locations: SyntheticsScriptedMonitorLocationsInput{
+			Public: []string{"AP_SOUTH_1"},
+		},
+		Name:   monitorOneName,
+		Period: SyntheticsMonitorPeriodTypes.EVERY_HOUR,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Runtime: &SyntheticsRuntimeInput{
+			RuntimeTypeVersion: "100",
+			RuntimeType:        "CHROME_BROWSER",
+			ScriptLanguage:     "JAVASCRIPT",
+		},
+		Script: "$browser.get(\"https://www.example.com\").then(function() {\n  // Simulate a failure scenario by deliberately causing an error\n  throw new Error(\"Synthetics CLI Failure scenario Testing.\");\n});\n",
+	}
+
+	// Defining the second monitor
+	monitorTwoName := fmt.Sprintf("newrelic-client-go-automatedTestResults-test-monitor-failure%s", mock.RandSeq(5))
+	monitorTwoInput := SyntheticsCreateScriptBrowserMonitorInput{
+		Locations: SyntheticsScriptedMonitorLocationsInput{
+			Public: []string{"AP_SOUTH_1"},
+		},
+		Name:   monitorTwoName,
+		Period: SyntheticsMonitorPeriodTypes.EVERY_HOUR,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Runtime: &SyntheticsRuntimeInput{
+			RuntimeTypeVersion: "100",
+			RuntimeType:        "CHROME_BROWSER",
+			ScriptLanguage:     "JAVASCRIPT",
+		},
+		Script: "$browser.get(\"https://www.example.com\").then(function() {\n  // Intentionally introduce a delay to simulate a timeout\n  return new Promise(function(resolve, reject) {\n    setTimeout(function() {\n // Do not resolve or reject the promise, causing a timeout\n    }, 90000); // 5 minutes delay\n  });\n});",
+	}
+
+	monitorTwo, _ := a.SyntheticsCreateScriptBrowserMonitor(testAccountID, monitorTwoInput)
+	monitorOne, _ := a.SyntheticsCreateScriptBrowserMonitor(testAccountID, monitorOneInput)
+
+	configInput := SyntheticsAutomatedTestConfigInput{}
+	var testsInput []SyntheticsAutomatedTestMonitorInput
+
+	testsInput = append(testsInput, SyntheticsAutomatedTestMonitorInput{
+		Config:      SyntheticsAutomatedTestMonitorConfigInput{},
+		MonitorGUID: monitorOne.Monitor.GUID,
+	})
+
+	testsInput = append(testsInput, SyntheticsAutomatedTestMonitorInput{
+		Config:      SyntheticsAutomatedTestMonitorConfigInput{},
+		MonitorGUID: monitorTwo.Monitor.GUID,
+	})
+
+	result, err := a.SyntheticsStartAutomatedTest(configInput, testsInput)
+	require.NoError(t, err)
+
+	log.Println("Created Batch ID: ", result.BatchId)
+
+	// time interval needed between the creation of a batch and querying it
+	time.Sleep(time.Second * 5)
+
+	queryResult, err := a.GetAutomatedTestResult(testAccountID, result.BatchId)
+
+	// deletion of monitors placed here to avoid being prevented by an erroneous result above
+	a.SyntheticsDeleteMonitor(monitorTwo.Monitor.GUID)
+	a.SyntheticsDeleteMonitor(monitorOne.Monitor.GUID)
+
+	require.NoError(t, err)
+
+	// this step will fail, as the API is currently unstable and is throwing "PASSED" even if
+	// the second monitor is in progress in the background. After the API is stable, the test shall pass.
+	require.Equal(t, SyntheticsAutomatedTestStatusTypes.IN_PROGRESS, queryResult.Status)
+}
+
+// TestSyntheticsAutomatedTestResults_OneMonitorsTest performs a test by creating one blocking scripted browser monitor,
+// creating a batch with the monitor, querying the batch and evaluating the status accordingly. Since the scripted
+// browser monitor is bound to fail, this tests inspects the consolidated status and the status of the monitor.
+func TestSyntheticsAutomatedTestResults_OneMonitorTest(t *testing.T) {
+	t.Parallel()
+
+	a := newIntegrationTestClient(t)
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	// Defining the first monitor
+	monitorOneName := fmt.Sprintf("newrelic-client-go-automatedTestResults-test-monitor-failure%s", mock.RandSeq(5))
+	monitorOneInput := SyntheticsCreateScriptBrowserMonitorInput{
+		Locations: SyntheticsScriptedMonitorLocationsInput{
+			Public: []string{"AP_SOUTH_1"},
+		},
+		Name:   monitorOneName,
+		Period: SyntheticsMonitorPeriodTypes.EVERY_HOUR,
+		Status: SyntheticsMonitorStatusTypes.ENABLED,
+		Runtime: &SyntheticsRuntimeInput{
+			RuntimeTypeVersion: "100",
+			RuntimeType:        "CHROME_BROWSER",
+			ScriptLanguage:     "JAVASCRIPT",
+		},
+		Script: "$browser.get(\"https://www.example.com\").then(function() {\n  // Simulate a failure scenario by deliberately causing an error\n  throw new Error(\"Synthetics CLI Failure scenario Testing.\");\n});\n",
+	}
+
+	monitorOne, _ := a.SyntheticsCreateScriptBrowserMonitor(testAccountID, monitorOneInput)
+
+	configInput := SyntheticsAutomatedTestConfigInput{}
+	var testsInput []SyntheticsAutomatedTestMonitorInput
+
+	testsInput = append(testsInput, SyntheticsAutomatedTestMonitorInput{
+		Config: SyntheticsAutomatedTestMonitorConfigInput{
+			IsBlocking: true,
+			Overrides:  nil,
+		},
+		MonitorGUID: monitorOne.Monitor.GUID,
+	})
+
+	result, err := a.SyntheticsStartAutomatedTest(configInput, testsInput)
+	require.NoError(t, err)
+
+	log.Println("Created Batch ID: ", result.BatchId)
+
+	// time interval needed between the creation of a batch and querying it
+	time.Sleep(time.Second * 5)
+
+	queryResult, err := a.GetAutomatedTestResult(testAccountID, result.BatchId)
+
+	// deletion of monitor placed here to avoid being prevented by an erroneous result above
+	a.SyntheticsDeleteMonitor(monitorOne.Monitor.GUID)
+
+	require.NoError(t, err)
+	require.Equal(t, SyntheticsJobStatusTypes.FAILED, queryResult.Tests[0].Result)
+
+	// this step will fail, as the API is currently unstable and is throwing "PASSED" even if
+	// the monitor has status "FAILED" and is a blocking monitor. After the API is stable, the test shall pass.
+	require.Equal(t, SyntheticsAutomatedTestStatusTypes.FAILED, queryResult.Status)
+}
+
+// TestSyntheticsAutomatedTestResults_ErrorTest performs a test on the automatedTestResults query by
+// specifying an invalid batchId, which is expected to throw an error.
+func TestSyntheticsAutomatedTestResults_ErrorTest(t *testing.T) {
+	t.Parallel()
+
+	a := newIntegrationTestClient(t)
+	testAccountID, fetchErr := mock.GetTestAccountID()
+	if fetchErr != nil {
+		t.Skipf("%s", fetchErr)
+	}
+
+	_, err := a.GetAutomatedTestResult(testAccountID, "invalid_batchId")
+	require.Error(t, errors.New("No automated test results found for batchId"), err)
 }

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -1030,6 +1030,10 @@ func newIntegrationTestClient(t *testing.T) Synthetics {
 // behaviour of this test is to return a valid batchId and throw no error.
 func TestSyntheticsStartAutomatedTest_Basic(t *testing.T) {
 	t.Parallel()
+	t.Skipf(
+		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
+			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
+	`)
 
 	a := newIntegrationTestClient(t)
 	testAccountID, err := mock.GetTestAccountID()
@@ -1173,6 +1177,10 @@ func TestSyntheticsStartAutomatedTest_Basic(t *testing.T) {
 // an invalid GUID in the input field of a monitor to obtain an error, in alignment with expected behaviour.
 func TestSyntheticsStartAutomatedTest_Error(t *testing.T) {
 	t.Parallel()
+	t.Skipf(
+		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
+			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
+	`)
 	a := newIntegrationTestClient(t)
 
 	configInput := SyntheticsAutomatedTestConfigInput{}
@@ -1191,6 +1199,10 @@ func TestSyntheticsStartAutomatedTest_Error(t *testing.T) {
 // creating a batch with those monitors, querying the batch and evaluating the status accordingly.
 func TestSyntheticsAutomatedTestResults_TwoMonitorsTest(t *testing.T) {
 	t.Parallel()
+	t.Skipf(
+		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
+			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
+	`)
 
 	a := newIntegrationTestClient(t)
 	testAccountID, err := mock.GetTestAccountID()
@@ -1274,6 +1286,10 @@ func TestSyntheticsAutomatedTestResults_TwoMonitorsTest(t *testing.T) {
 // browser monitor is bound to fail, this tests inspects the consolidated status and the status of the monitor.
 func TestSyntheticsAutomatedTestResults_OneMonitorTest(t *testing.T) {
 	t.Parallel()
+	t.Skipf(
+		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
+			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
+	`)
 
 	a := newIntegrationTestClient(t)
 	testAccountID, err := mock.GetTestAccountID()
@@ -1336,6 +1352,10 @@ func TestSyntheticsAutomatedTestResults_OneMonitorTest(t *testing.T) {
 // specifying an invalid batchId, which is expected to throw an error.
 func TestSyntheticsAutomatedTestResults_ErrorTest(t *testing.T) {
 	t.Parallel()
+	t.Skipf(
+		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
+			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
+	`)
 
 	a := newIntegrationTestClient(t)
 	testAccountID, fetchErr := mock.GetTestAccountID()

--- a/pkg/synthetics/synthetics_api_unit_test.go
+++ b/pkg/synthetics/synthetics_api_unit_test.go
@@ -241,6 +241,11 @@ var (
 
 func TestUnit_SyntheticsStartAutomatedTest(t *testing.T) {
 	t.Parallel()
+	t.Skipf(
+		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
+			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
+	`)
+
 	synthetics := newMockResponse(t, mockSyntheticsStartAutomatedTestResponse, http.StatusOK)
 
 	expected := SyntheticsAutomatedTestStartResult{BatchId: mockBatchID}
@@ -253,6 +258,11 @@ func TestUnit_SyntheticsStartAutomatedTest(t *testing.T) {
 
 func TestUnit_AutomatedTestResults_Failure(t *testing.T) {
 	t.Parallel()
+	t.Skipf(
+		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
+			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
+	`)
+
 	synthetics := newMockResponse(t, mockAutomatedTestResultsResponse, http.StatusOK)
 
 	expected := automatedTestResults
@@ -268,6 +278,10 @@ func TestUnit_AutomatedTestResults_Failure(t *testing.T) {
 
 func TestUnit_AutomatedTestResults(t *testing.T) {
 	t.Parallel()
+	t.Skipf(
+		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
+			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
+	`)
 	synthetics := newMockResponse(t, mockAutomatedTestResultsResponse, http.StatusOK)
 
 	expected := automatedTestResults

--- a/pkg/synthetics/synthetics_api_unit_test.go
+++ b/pkg/synthetics/synthetics_api_unit_test.go
@@ -1,0 +1,303 @@
+//go:build unit
+// +build unit
+
+package synthetics
+
+import (
+	"math/rand"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	mockSyntheticsStartAutomatedTestResponse = `{
+	"data": {
+		"syntheticsStartAutomatedTest": {
+			"batchId": "` + mockBatchID + `"
+			}
+		}
+	}`
+
+	mockAutomatedTestResultsResponse = `{
+	   "data": {
+		  "actor": {
+			 "account": {
+				"synthetics": {
+				   "automatedTestResult": {
+					  "config": {
+						 "batchName": "sample-batch",
+						 "branch": "sample-branch",
+						 "commit": "sample-commit",
+						 "deepLink": "sample-deepLink",
+						 "platform": "sample-platform",
+						 "repository": "sample-repository"
+					  },
+					  "status": "FAILED",
+					  "tests": [
+						 {
+							"automatedTestMonitorConfig": {
+							   "isBlocking": true,
+							   "overrides": {
+								  "domain": [
+									 {
+										"domain": "sample-domain",
+										"override": "sample-override"
+									 }
+								  ],
+								  "location": "sample-location",
+								  "secureCredential": [
+									 {
+										"key": "sample-key",
+										"overrideKey": "sample-override-key"
+									 }
+								  ],
+								  "startingUrl": "sample-starting-url.com"
+							   }
+							},
+							"batchId": "` + mockBatchID + `",
+							"duration": 0,
+							"error": "An unexpected error occurred",
+							"id": "55bb193c-f0d0-4eed-b0de-45590949c99e",
+							"location": "AWS_US_WEST_2",
+							"locationLabel": "Portland, OR, USA",
+							"monitorGuid": "` + monitorOneGUID + `",
+							"monitorId": "` + monitorOneID + `",
+							"monitorName": "Test Monitor One",
+							"result": "FAILED",
+							"resultsUrl": "sample-results-url.com",
+							"type": "SCRIPT_BROWSER",
+							"typeLabel": "Scripted Browser"
+						 },
+						 {
+							"automatedTestMonitorConfig": {
+							   "isBlocking": false,
+							   "overrides": null
+							},
+							"batchId": "` + mockBatchID + `",
+							"duration": 0,
+							"error": "",
+							"id": "6ce400b2-cba2-43cf-b139-1267d26c522f",
+							"location": "AWS_US_WEST_2",
+							"locationLabel": "Portland, OR, USA",
+							"monitorGuid": "` + monitorTwoGUID + `",
+							"monitorId": "` + monitorTwoID + `",
+							"monitorName": "Test Monitor Two",
+							"result": "SUCCESS",
+							"resultsUrl": "sample-results-url.com",
+							"type": "SCRIPT_BROWSER",
+							"typeLabel": "Scripted Browser"
+						 },
+						 {
+							"automatedTestMonitorConfig": {
+							   "isBlocking": false,
+							   "overrides": null
+							},
+							"batchId": "` + mockBatchID + `",
+							"duration": 0,
+							"error": "Unknown Error",
+							"id": "9000dd3e-eaa6-42fb-8cda-aad0b54147c8",
+							"location": "AWS_US_WEST_2",
+							"locationLabel": "Portland, OR, USA",
+							"monitorGuid": "` + monitorThreeGUID + `",
+							"monitorId": "` + monitorThreeID + `",
+							"monitorName": "Test Monitor Three",
+							"result": "FAILED",
+							"resultsUrl": "sample-results-url.com",
+							"type": "SCRIPT_BROWSER",
+							"typeLabel": "Scripted Browser"
+						 }
+					  ]
+				   }
+				}
+			 }
+		  }
+	   }
+	}`
+
+	monitorOneGUID   = "McUyMDUyOHxTWU5USHxNT05JVE9SfGE0MTk2MzRhLWRhNzgtNGQzNC1hN2NmLTBmMDE1MjQyAjA2AA"
+	monitorTwoGUID   = "McUyMDUyOHxTWU5USHxNT05JVE9SfDA1YjVkZDQ4LTJlNzQtNDhjMi05OTQ0LTdkYTU2YTc3BmByBB"
+	monitorThreeGUID = "McUyMDUyOHxTWU5USHxNT05JVE9SfDljMmUwMzAxLTBiNWMtNGZmMy05M2JhLTE4ODg5MGVkCzCzCC"
+
+	monitorOneID   = "3ffb2a4f-459d-49c2-85df-726e86a3d773"
+	monitorTwoID   = "12b5c6a8-331f-4609-926e-ca6adb8fb6af"
+	monitorThreeID = "942e0948-0ab1-4a19-8177-3288259e4cc6"
+
+	mockBatchID = "d0622283-87b7-44a1-9622-0d66971b0c1d"
+	// random seven digit number
+	mockAccountID = rand.Intn(999999) + 1000000
+
+	configInput = SyntheticsAutomatedTestConfigInput{
+		BatchName:  "sample-batch",
+		Branch:     "sample-branch",
+		Commit:     "sample-commit",
+		DeepLink:   "sample-deepLink",
+		Platform:   "sample-platform",
+		Repository: "sample-repository",
+	}
+
+	testsInput = []SyntheticsAutomatedTestMonitorInput{
+		{
+			Config: SyntheticsAutomatedTestMonitorConfigInput{
+				IsBlocking: true,
+				Overrides: &SyntheticsAutomatedTestOverridesInput{
+					Domain: SyntheticsScriptDomainOverrideInput{
+						Domain:   "sample-domain",
+						Override: "sample-override",
+					},
+					SecureCredential: SyntheticsSecureCredentialOverrideInput{
+						Key:         "sample-key",
+						OverrideKey: "sample-override-key",
+					},
+					StartingURL: "sample-starting-url.com",
+					Location:    "sample-location",
+				},
+			},
+			MonitorGUID: EntityGUID(monitorOneGUID),
+		},
+		{
+			Config:      SyntheticsAutomatedTestMonitorConfigInput{},
+			MonitorGUID: EntityGUID(monitorTwoGUID),
+		},
+		{
+			Config:      SyntheticsAutomatedTestMonitorConfigInput{},
+			MonitorGUID: EntityGUID(monitorThreeGUID),
+		},
+	}
+
+	automatedTestResults = SyntheticsAutomatedTestResult{
+		Config: SyntheticsAutomatedTestConfig{
+			BatchName:  "sample-batch",
+			Branch:     "sample-branch",
+			Commit:     "sample-commit",
+			DeepLink:   "sample-deepLink",
+			Platform:   "sample-platform",
+			Repository: "sample-repository",
+		},
+		Status: "FAILED",
+		Tests: []SyntheticsAutomatedTestJobResult{
+			// the first monitor has incorrect values (which are dissmilar to those specified in the mock response)
+			{
+				AutomatedTestMonitorConfig: SyntheticsAutomatedTestMonitorConfig{
+					IsBlocking: true,
+					Overrides:  nil,
+				},
+				BatchId:       mockBatchID,
+				Duration:      0,
+				Error:         "An unexpected error occurred",
+				ID:            "55bb193c-f0d0-4eed-b0de-45590949c99e",
+				Location:      "AWS_US_WEST_2",
+				LocationLabel: "Columbus, OH, USA",
+				MonitorGUID:   EntityGUID(monitorOneGUID),
+				MonitorId:     monitorOneID,
+				MonitorName:   "Test Monitor One",
+				Result:        "PASSED",
+				ResultsURL:    "sample-results-url.com",
+				Type:          "SCRIPT_BROWSER",
+				TypeLabel:     "Scripted Browser",
+			},
+			{
+				AutomatedTestMonitorConfig: SyntheticsAutomatedTestMonitorConfig{
+					IsBlocking: false,
+					Overrides:  nil,
+				},
+				BatchId:       mockBatchID,
+				Duration:      0,
+				Error:         "",
+				ID:            "6ce400b2-cba2-43cf-b139-1267d26c522f",
+				Location:      "AWS_US_WEST_2",
+				LocationLabel: "Portland, OR, USA",
+				MonitorGUID:   EntityGUID(monitorTwoGUID),
+				MonitorId:     monitorTwoID,
+				MonitorName:   "Test Monitor Two",
+				Result:        "SUCCESS",
+				ResultsURL:    "sample-results-url.com",
+				Type:          "SCRIPT_BROWSER",
+				TypeLabel:     "Scripted Browser",
+			},
+			{
+				AutomatedTestMonitorConfig: SyntheticsAutomatedTestMonitorConfig{
+					IsBlocking: false,
+					Overrides:  nil,
+				},
+				BatchId:       mockBatchID,
+				Duration:      0,
+				Error:         "Unknown Error",
+				ID:            "9000dd3e-eaa6-42fb-8cda-aad0b54147c8",
+				Location:      "AWS_US_WEST_2",
+				LocationLabel: "Portland, OR, USA",
+				MonitorGUID:   EntityGUID(monitorThreeGUID),
+				MonitorId:     monitorThreeID,
+				MonitorName:   "Test Monitor Three",
+				Result:        "FAILED",
+				ResultsURL:    "sample-results-url.com",
+				Type:          "SCRIPT_BROWSER",
+				TypeLabel:     "Scripted Browser",
+			},
+		},
+	}
+)
+
+func TestUnit_SyntheticsStartAutomatedTest(t *testing.T) {
+	t.Parallel()
+	synthetics := newMockResponse(t, mockSyntheticsStartAutomatedTestResponse, http.StatusOK)
+
+	expected := SyntheticsAutomatedTestStartResult{BatchId: mockBatchID}
+	actual, err := synthetics.SyntheticsStartAutomatedTest(configInput, testsInput)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+	assert.Equal(t, expected, *actual)
+}
+
+func TestUnit_AutomatedTestResults_Failure(t *testing.T) {
+	t.Parallel()
+	synthetics := newMockResponse(t, mockAutomatedTestResultsResponse, http.StatusOK)
+
+	expected := automatedTestResults
+	actual, err := synthetics.GetAutomatedTestResult(mockAccountID, mockBatchID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+
+	// The expected and actual responses are expected to be dissimilar, given that
+	// the first test in the list of tests comprises incorrect values of attributes
+	assert.NotEqual(t, expected, *actual)
+}
+
+func TestUnit_AutomatedTestResults(t *testing.T) {
+	t.Parallel()
+	synthetics := newMockResponse(t, mockAutomatedTestResultsResponse, http.StatusOK)
+
+	expected := automatedTestResults
+
+	// Since the test TestUnit_AutomatedTestResults_Failure is seen to fail due to dissimilarities
+	// between the expected and actual responses, the following lines of code correct the
+	// erroneous fields accordingly.
+
+	expected.Tests[0].AutomatedTestMonitorConfig.Overrides = &SyntheticsAutomatedTestOverrides{
+		Domain: []SyntheticsScriptDomainOverride{
+			{
+				Domain:   "sample-domain",
+				Override: "sample-override",
+			},
+		},
+		SecureCredential: []SyntheticsSecureCredentialOverride{
+			{
+				Key:         "sample-key",
+				OverrideKey: "sample-override-key",
+			},
+		},
+		StartingURL: "sample-starting-url.com",
+		Location:    "sample-location",
+	}
+	expected.Tests[0].LocationLabel = "Portland, OR, USA"
+	expected.Tests[0].Result = SyntheticsJobStatusTypes.FAILED
+
+	actual, err := synthetics.GetAutomatedTestResult(mockAccountID, mockBatchID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+	assert.Equal(t, expected, *actual)
+}

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -96,6 +96,29 @@ var Nr1CatalogInstallPlanTargetTypeTypes = struct {
 	UNKNOWN: "UNKNOWN",
 }
 
+// SyntheticsAutomatedTestStatus - Enum of automated test status
+type SyntheticsAutomatedTestStatus string
+
+var SyntheticsAutomatedTestStatusTypes = struct {
+	// At least one blocking job in the automated test has failed
+	FAILED SyntheticsAutomatedTestStatus
+	// Indicates jobs in the automated test are still running
+	IN_PROGRESS SyntheticsAutomatedTestStatus
+	// All blocking jobs in the automated test has passed
+	PASSED SyntheticsAutomatedTestStatus
+	// Some jobs in the automated test failed to provide a status within the timeout
+	TIMEOUT SyntheticsAutomatedTestStatus
+}{
+	// At least one blocking job in the automated test has failed
+	FAILED: "FAILED",
+	// Indicates jobs in the automated test are still running
+	IN_PROGRESS: "IN_PROGRESS",
+	// All blocking jobs in the automated test has passed
+	PASSED: "PASSED",
+	// Some jobs in the automated test failed to provide a status within the timeout
+	TIMEOUT: "TIMEOUT",
+}
+
 // SyntheticsDeviceOrientation - enum of Orientations that the user can select for their emulated device
 type SyntheticsDeviceOrientation string
 
@@ -132,6 +155,29 @@ var SyntheticsDeviceTypeTypes = struct {
 	NONE: "NONE",
 	// This will be dimensions for a typical tablet device
 	TABLET: "TABLET",
+}
+
+// SyntheticsJobStatus - Enum of job status
+type SyntheticsJobStatus string
+
+var SyntheticsJobStatusTypes = struct {
+	// Indicates the job has failed
+	FAILED SyntheticsJobStatus
+	// Indicates an in-progress job
+	PENDING SyntheticsJobStatus
+	// Indicates the job has succeeded
+	SUCCESS SyntheticsJobStatus
+	// Indicates the job status was lost or unknown
+	UNKNOWN SyntheticsJobStatus
+}{
+	// Indicates the job has failed
+	FAILED: "FAILED",
+	// Indicates an in-progress job
+	PENDING: "PENDING",
+	// Indicates the job has succeeded
+	SUCCESS: "SUCCESS",
+	// Indicates the job status was lost or unknown
+	UNKNOWN: "UNKNOWN",
 }
 
 // SyntheticsMonitorCreateErrorType - Types of errors that can be returned from a create monitor request
@@ -229,6 +275,41 @@ var SyntheticsMonitorStatusTypes = struct {
 	ENABLED: "ENABLED",
 	// Alerts muted status of a monitor
 	MUTED: "MUTED",
+}
+
+// SyntheticsMonitorType - Enum of monitor types
+type SyntheticsMonitorType string
+
+var SyntheticsMonitorTypeTypes = struct {
+	// Broken links monitor
+	BROKEN_LINKS SyntheticsMonitorType
+	// Simple browser monitor
+	BROWSER SyntheticsMonitorType
+	// Certificate Check
+	CERT_CHECK SyntheticsMonitorType
+	// Script API monitor
+	SCRIPT_API SyntheticsMonitorType
+	// Script browser monitor
+	SCRIPT_BROWSER SyntheticsMonitorType
+	// Simple (ping) monitor
+	SIMPLE SyntheticsMonitorType
+	// Step Monitor
+	STEP_MONITOR SyntheticsMonitorType
+}{
+	// Broken links monitor
+	BROKEN_LINKS: "BROKEN_LINKS",
+	// Simple browser monitor
+	BROWSER: "BROWSER",
+	// Certificate Check
+	CERT_CHECK: "CERT_CHECK",
+	// Script API monitor
+	SCRIPT_API: "SCRIPT_API",
+	// Script browser monitor
+	SCRIPT_BROWSER: "SCRIPT_BROWSER",
+	// Simple (ping) monitor
+	SIMPLE: "SIMPLE",
+	// Step Monitor
+	STEP_MONITOR: "STEP_MONITOR",
 }
 
 // SyntheticsMonitorUpdateErrorType - Types of errors that can be returned from a Monitor mutation request
@@ -354,9 +435,12 @@ var SyntheticsStepTypeTypes = struct {
 // Account configuration data is queried through this object, as well as
 // telemetry data that is specific to a single account.
 type Account struct {
-	ID         int    `json:"id,omitempty"`
+	//
+	ID int `json:"id,omitempty"`
+	//
 	LicenseKey string `json:"licenseKey,omitempty"`
-	Name       string `json:"name,omitempty"`
+	//
+	Name string `json:"name,omitempty"`
 	// This field provides access to Synthetics data.
 	Synthetics SyntheticsAccountStitchedFields `json:"synthetics,omitempty"`
 }
@@ -506,10 +590,140 @@ func (x *Nr1CatalogTargetedInstallPlanDirective) ImplementsNr1CatalogInstallPlan
 
 // SyntheticsAccountStitchedFields - Nerdgraph account field
 type SyntheticsAccountStitchedFields struct {
+	// Query that fetches results for an automated test
+	AutomatedTestResult SyntheticsAutomatedTestResult `json:"automatedTestResult,omitempty"`
 	// Query that fetches the script of a specific scripted monitor
 	Script SyntheticsMonitorScriptQueryResponse `json:"script,omitempty"`
 	// visiblity(flag:Synthetics/setGraphqlCustomerVisible) Query that fetches the steps used by the specified Step Monitor
 	Steps []SyntheticsStep `json:"steps"`
+}
+
+// SyntheticsAutomatedTestConfig - Global automated test config
+type SyntheticsAutomatedTestConfig struct {
+	// An identifier for the automated test run
+	BatchName string `json:"batchName,omitempty"`
+	// Branch metadata to indicate what triggered the automated test
+	Branch string `json:"branch,omitempty"`
+	// Commit metadata to indicate what commit triggered the automated test
+	Commit string `json:"commit,omitempty"`
+	// Metadata for the automated test
+	DeepLink string `json:"deepLink,omitempty"`
+	// Metadata about the platform target the automated test will run against
+	Platform string `json:"platform,omitempty"`
+	// The unique client identifier for the Synthetics Monitor in New Relic
+	Repository string `json:"repository,omitempty"`
+}
+
+// SyntheticsAutomatedTestConfigInput - Global automated test config
+type SyntheticsAutomatedTestConfigInput struct {
+	// An identifier for the automated test run
+	BatchName string `json:"batchName,omitempty" yaml:"batchName,omitempty"`
+	// Branch metadata to indicate what triggered the automated test
+	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
+	// Commit metadata to indicate what commit triggered the automated test
+	Commit string `json:"commit,omitempty" yaml:"commit,omitempty"`
+	// Metadata for the automated test
+	DeepLink string `json:"deepLink,omitempty" yaml:"deepLink,omitempty"`
+	// Metadata about the platform target the automated test will run against
+	Platform string `json:"platform,omitempty" yaml:"platform,omitempty"`
+	// The unique client identifier for the Synthetics Monitor in New Relic
+	Repository string `json:"repository,omitempty" yaml:"repository,omitempty"`
+}
+
+// SyntheticsAutomatedTestJobResult - Information on a job that was apart of a batch of automated test jobs
+type SyntheticsAutomatedTestJobResult struct {
+	// Test overrides
+	AutomatedTestMonitorConfig SyntheticsAutomatedTestMonitorConfig `json:"automatedTestMonitorConfig,omitempty"`
+	// Job batch Id
+	BatchId string `json:"batchId,omitempty"`
+	// Job duration
+	Duration int `json:"duration,omitempty"`
+	// Job error if any
+	Error string `json:"error,omitempty"`
+	// Job Id
+	ID string `json:"id,omitempty"`
+	// Job location
+	Location string `json:"location,omitempty"`
+	// Job location label
+	LocationLabel string `json:"locationLabel,omitempty"`
+	// Monitor nr1 entity guid
+	MonitorGUID EntityGUID `json:"monitorGuid,omitempty"`
+	// Job monitor Id
+	MonitorId string `json:"monitorId,omitempty"`
+	// Job monitor name
+	MonitorName string `json:"monitorName,omitempty"`
+	// Job result
+	Result SyntheticsJobStatus `json:"result,omitempty"`
+	// Link to job results
+	ResultsURL string `json:"resultsUrl,omitempty"`
+	// Job type
+	Type SyntheticsMonitorType `json:"type,omitempty"`
+	// Job type label
+	TypeLabel string `json:"typeLabel,omitempty"`
+}
+
+// SyntheticsAutomatedTestMonitorConfig - Monitor specific test config
+type SyntheticsAutomatedTestMonitorConfig struct {
+	// Specifies whether a failure of this monitor should fail the entire automated test
+	IsBlocking bool `json:"isBlocking"`
+	// Specific overrides for the given monitor
+	Overrides *SyntheticsAutomatedTestOverrides `json:"overrides"`
+}
+
+// SyntheticsAutomatedTestMonitorConfigInput - Monitor specific test configuration
+type SyntheticsAutomatedTestMonitorConfigInput struct {
+	// Specifies whether a failure of this monitor should fail the entire automated test
+	IsBlocking bool `json:"isBlocking" yaml:"isBlocking"`
+	// Specific overrides for the given monitor
+	Overrides *SyntheticsAutomatedTestOverridesInput `json:"overrides" yaml:"overrides"`
+}
+
+// SyntheticsAutomatedTestMonitorInput - Monitor test definition to be included in the automated test
+type SyntheticsAutomatedTestMonitorInput struct {
+	// The monitor config for an automated test
+	Config SyntheticsAutomatedTestMonitorConfigInput `json:"config,omitempty" yaml:"config,omitempty"`
+	// The unique client identifier for the Synthetics Monitor in New Relic
+	MonitorGUID EntityGUID `json:"monitorGuid" yaml:"monitorGuid"`
+}
+
+// SyntheticsAutomatedTestOverrides - Automated test monitor overrides
+type SyntheticsAutomatedTestOverrides struct {
+	// Override a domain throughout a scripted monitor
+	Domain []SyntheticsScriptDomainOverride `json:"domain,omitempty"`
+	// Override monitor to use a specific location
+	Location string `json:"location,omitempty"`
+	// Override a script secure credential with another credential value
+	SecureCredential []SyntheticsSecureCredentialOverride `json:"secureCredential,omitempty"`
+	// Override a browser monitor starting url
+	StartingURL string `json:"startingUrl,omitempty"`
+}
+
+// SyntheticsAutomatedTestOverridesInput - Automated test monitor overrides
+type SyntheticsAutomatedTestOverridesInput struct {
+	// Override a domain throughout a scripted monitor
+	Domain SyntheticsScriptDomainOverrideInput `json:"domain,omitempty" yaml:"domain,omitempty"`
+	// Override monitor to use a specific location
+	Location string `json:"location,omitempty" yaml:"location,omitempty"`
+	// Override a script secure credential with another credential value
+	SecureCredential SyntheticsSecureCredentialOverrideInput `json:"secureCredential,omitempty" yaml:"secureCredential,omitempty"`
+	// Override a browser monitor starting url
+	StartingURL string `json:"startingUrl,omitempty" yaml:"startingUrl,omitempty"`
+}
+
+// SyntheticsAutomatedTestResult - Results from fetching automated test job
+type SyntheticsAutomatedTestResult struct {
+	// Automated test config
+	Config SyntheticsAutomatedTestConfig `json:"config,omitempty"`
+	// Calculated status of automated test as a whole
+	Status SyntheticsAutomatedTestStatus `json:"status,omitempty"`
+	// List of completed automated test jobs
+	Tests []SyntheticsAutomatedTestJobResult `json:"tests,omitempty"`
+}
+
+// SyntheticsAutomatedTestStartResult - Results from starting automated test job
+type SyntheticsAutomatedTestStartResult struct {
+	// Job batch Id
+	BatchId string `json:"batchId,omitempty"`
 }
 
 // SyntheticsBrokenLinksMonitor - A Broken Links monitor resulting from a Broken Links monitor mutation
@@ -978,6 +1192,22 @@ type SyntheticsScriptBrowserMonitorUpdateMutationResult struct {
 	Monitor SyntheticsScriptBrowserMonitor `json:"monitor,omitempty"`
 }
 
+// SyntheticsScriptDomainOverride - Override a script url domain
+type SyntheticsScriptDomainOverride struct {
+	// The target domain to override
+	Domain string `json:"domain,omitempty"`
+	// The override value for the domain
+	Override string `json:"override,omitempty"`
+}
+
+// SyntheticsScriptDomainOverrideInput - Override a script url domain
+type SyntheticsScriptDomainOverrideInput struct {
+	// The target domain to override
+	Domain string `json:"domain,omitempty" yaml:"domain,omitempty"`
+	// The override value for the domain
+	Override string `json:"override,omitempty" yaml:"override,omitempty"`
+}
+
 // SyntheticsScriptedMonitorLocationsInput - The location(s) from which the scripted monitor runs.
 type SyntheticsScriptedMonitorLocationsInput struct {
 	// The private location(s) that the monitor will run jobs from
@@ -998,6 +1228,22 @@ type SyntheticsSecureCredentialMutationResult struct {
 	Key string `json:"key,omitempty"`
 	// The moment when the secure credential was last updated, represented in milliseconds since the Unix epoch.
 	LastUpdate *nrtime.EpochMilliseconds `json:"lastUpdate,omitempty"`
+}
+
+// SyntheticsSecureCredentialOverride - Override a monitor scripts secure credential key with a different key
+type SyntheticsSecureCredentialOverride struct {
+	// The target secure credential key to override
+	Key string `json:"key,omitempty"`
+	// The secure credential key override
+	OverrideKey string `json:"overrideKey,omitempty"`
+}
+
+// SyntheticsSecureCredentialOverrideInput - Override a monitor scripts secure credential key with a different key
+type SyntheticsSecureCredentialOverrideInput struct {
+	// The target secure credential key to override
+	Key string `json:"key,omitempty" yaml:"key,omitempty"`
+	// The secure credential key override
+	OverrideKey string `json:"overrideKey,omitempty" yaml:"overrideKey,omitempty"`
 }
 
 // SyntheticsSimpleBrowserMonitor - A Simple Browser monitor resulting from a Simple Browser monitor mutation
@@ -1352,6 +1598,10 @@ type SyntheticsUpdateStepMonitorInput struct {
 	Tags []SyntheticsTag `json:"tags,omitempty"`
 }
 
+type automatedTestResultResponse struct {
+	Actor Actor `json:"actor"`
+}
+
 type scriptResponse struct {
 	Actor Actor `json:"actor"`
 }
@@ -1367,6 +1617,9 @@ type EntityGUID string
 // values as specified by
 // [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754).
 type Float string
+
+// Milliseconds - The `Milliseconds` scalar represents a duration in milliseconds
+type Milliseconds string
 
 // Nr1CatalogRawNerdletState - Represents JSON nerdlet state data
 type Nr1CatalogRawNerdletState string


### PR DESCRIPTION
This PR includes 
- changes fetched by Tutone in the **synthetics** package to enable the query `automatedTestResults` and the mutation `syntheticsStartAutomatedTest` and associated types and details.
- tests covering multiple scenarios of the mutation and the query

The changes made have nearly been integrated with the CLI, and have been tested with multiple combinations to ensure the properties of attributes generated and listed in this PR lead to no unexpected behaviour in requests unmarshaled from YAML/responses parsed.

**Note:**
- Except for the removal of the `omitempty` of two fields `IsBlocking` and `Overrides` generated by Tutone, no other manual changes have been made to the code generated. All other datatype/struct tag overrides are as specified and generated from `tutone.yml`.
- The added tests are expected to fail in the CI owing to the fact that the query and mutation are not yet enabled to all customers, and the account that was used to fetch the schema via Tutone is not used in the CI.