### PR TITLE
feat(synthetics): Add device emulation to simple monitor

### DIFF
--- a/pkg/agentapplications/types.go
+++ b/pkg/agentapplications/types.go
@@ -65,7 +65,7 @@ var AgentApplicationSettingsBrowserLoaderTypes = struct {
 	RUM: "RUM",
 	// Pro+SPA: This is the default installed agent when you enable browser monitoring. Gives you access to all of the Browser Pro features and to Single Page App (SPA) monitoring. Provides detailed page timing data and the most up-to-date New Relic features, including distributed tracing, for all types of applications.
 	SPA: "SPA",
-	// This value is specified for backwards-compatability.
+	// This value is specified for backwards-compatibility.
 	XHR: "XHR",
 }
 

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -1120,6 +1120,8 @@ type SyntheticsSimpleMonitorAdvancedOptionsInput struct {
 	ShouldBypassHeadRequest *bool `json:"shouldBypassHeadRequest,omitempty"`
 	// Monitor should validate SSL certificate chain
 	UseTlsValidation *bool `json:"useTlsValidation,omitempty"`
+	// Emulate a device
+	DeviceEmulation *SyntheticsDeviceEmulationInput `json:"deviceEmulation,omitempty"`
 }
 
 // SyntheticsSimpleMonitorUpdateMutationResult - The result of a Simple (ping) monitor update mutation


### PR DESCRIPTION
A follow up to https://github.com/newrelic/newrelic-client-go/pull/1054. Adding device emulation types to the simple monitor synthetics.