### PR TITLE
fix(changetracking): remove customAttributes from response fields to avoid error

### DIFF
--- a/pkg/changetracking/changetracking_api.go
+++ b/pkg/changetracking/changetracking_api.go
@@ -47,7 +47,6 @@ const ChangeTrackingCreateDeploymentMutation = `mutation(
 ) {
 	changelog
 	commit
-	customAttributes
 	deepLink
 	deploymentId
 	deploymentType


### PR DESCRIPTION
Since `customAttributes` is still in limited preview, we can't return this field in the response as it causes an error for customers outside of the limited preview. 