### PR TITLE
fix: integration tests

### DIFF
--- a/pkg/alerts/conditions_integration_test.go
+++ b/pkg/alerts/conditions_integration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIntegrationConditions(t *testing.T) {
-	t.Parallel()
+	t.Skipf("This a legacy API which will be deprecated soon")
 
 	var (
 		testConditionRandStr = nr.RandSeq(5)

--- a/pkg/apm/labels_integration_test.go
+++ b/pkg/apm/labels_integration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIntegrationLabels(t *testing.T) {
-	t.Parallel()
+	t.Skipf("This API is deprecated so it always returns an error")
 
 	client := newIntegrationTestClient(t)
 

--- a/pkg/synthetics/monitor_locations_integration_test.go
+++ b/pkg/synthetics/monitor_locations_integration_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIntegrationGetMonitorLocations(t *testing.T) {
-	t.Parallel()
+	t.Skipf("Synthetics REST API is deprecated")
 
 	tc := mock.NewIntegrationTestConfig(t)
 

--- a/pkg/synthetics/monitors_integration_test.go
+++ b/pkg/synthetics/monitors_integration_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func TestIntegrationMonitors(t *testing.T) {
-	t.Parallel()
+	t.Skipf("Synthetics REST API is deprecated")
 
 	tc := mock.NewIntegrationTestConfig(t)
 

--- a/pkg/synthetics/secure_credentials_integration_test.go
+++ b/pkg/synthetics/secure_credentials_integration_test.go
@@ -24,7 +24,7 @@ var (
 )
 
 func TestIntegrationSecureCredentials(t *testing.T) {
-	t.Parallel()
+	t.Skipf("Synthetics REST API is deprecated")
 
 	tc := mock.NewIntegrationTestConfig(t)
 	synthetics := New(tc)

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -892,16 +892,12 @@ func TestSyntheticsStepMonitor_Basic(t *testing.T) {
 		},
 	}
 
-	time.Sleep(10 * time.Second)
-
 	updatedMonitor, err := a.SyntheticsUpdateStepMonitor(createdMonitor.Monitor.GUID, monitorUpdateInput)
 	require.NoError(t, err)
 	require.NotNil(t, updatedMonitor.Monitor)
 	require.Equal(t, 0, len(updatedMonitor.Errors))
 	require.Equal(t, monitorNameUpdate, updatedMonitor.Monitor.Name)
 	require.Equal(t, 3, len(updatedMonitor.Monitor.Steps))
-
-	time.Sleep(10 * time.Second)
 
 	deletedMonitor, err := a.SyntheticsDeleteMonitor(createdMonitor.Monitor.GUID)
 	require.NoError(t, err)

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -19,8 +19,6 @@ import (
 var tv bool = true
 
 func TestSyntheticsSecureCredential_Basic(t *testing.T) {
-	t.Parallel()
-
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -41,8 +39,6 @@ func TestSyntheticsSecureCredential_Basic(t *testing.T) {
 }
 
 func TestSyntheticsSecureCredential_Error(t *testing.T) {
-	t.Parallel()
-
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -56,7 +52,6 @@ func TestSyntheticsSecureCredential_Error(t *testing.T) {
 }
 
 func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
-	t.Parallel()
 
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
@@ -164,7 +159,6 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 }
 
 func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
-	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -255,7 +249,6 @@ func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
 }
 
 func TestSyntheticsScriptApiMonitor_Basic(t *testing.T) {
-	t.Parallel()
 
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
@@ -361,7 +354,6 @@ func TestSyntheticsScriptApiMonitor_Basic(t *testing.T) {
 }
 
 func TestSyntheticsScriptApiMonitorLegacy_Basic(t *testing.T) {
-	t.Parallel()
 
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
@@ -457,7 +449,6 @@ func TestSyntheticsScriptApiMonitorLegacy_Basic(t *testing.T) {
 }
 
 func TestSyntheticsScriptBrowserMonitor_Basic(t *testing.T) {
-	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -539,7 +530,6 @@ func TestSyntheticsScriptBrowserMonitor_Basic(t *testing.T) {
 }
 
 func TestSyntheticsScriptBrowserMonitor_InvalidRuntimeValues(t *testing.T) {
-	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -570,7 +560,6 @@ func TestSyntheticsScriptBrowserMonitor_InvalidRuntimeValues(t *testing.T) {
 }
 
 func TestSyntheticsScriptBrowserMonitor_DeviceEmulation(t *testing.T) {
-	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -641,7 +630,6 @@ func TestSyntheticsScriptBrowserMonitor_DeviceEmulation(t *testing.T) {
 }
 
 func TestSyntheticsScriptBrowserMonitor_LegacyRuntime(t *testing.T) {
-	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -702,7 +690,6 @@ func TestSyntheticsScriptBrowserMonitor_LegacyRuntime(t *testing.T) {
 }
 
 func TestSyntheticsPrivateLocation_Basic(t *testing.T) {
-	t.Parallel()
 
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
@@ -727,7 +714,6 @@ func TestSyntheticsPrivateLocation_Basic(t *testing.T) {
 }
 
 func TestSyntheticsBrokenLinksMonitor_Basic(t *testing.T) {
-	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -782,7 +768,6 @@ func TestSyntheticsBrokenLinksMonitor_Basic(t *testing.T) {
 }
 
 func TestSyntheticsCertCheckMonitor_Basic(t *testing.T) {
-	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -840,7 +825,6 @@ func TestSyntheticsCertCheckMonitor_Basic(t *testing.T) {
 }
 
 func TestSyntheticsStepMonitor_Basic(t *testing.T) {
-	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -908,12 +892,16 @@ func TestSyntheticsStepMonitor_Basic(t *testing.T) {
 		},
 	}
 
+	time.Sleep(10 * time.Second)
+
 	updatedMonitor, err := a.SyntheticsUpdateStepMonitor(createdMonitor.Monitor.GUID, monitorUpdateInput)
 	require.NoError(t, err)
 	require.NotNil(t, updatedMonitor.Monitor)
 	require.Equal(t, 0, len(updatedMonitor.Errors))
 	require.Equal(t, monitorNameUpdate, updatedMonitor.Monitor.Name)
 	require.Equal(t, 3, len(updatedMonitor.Monitor.Steps))
+
+	time.Sleep(10 * time.Second)
 
 	deletedMonitor, err := a.SyntheticsDeleteMonitor(createdMonitor.Monitor.GUID)
 	require.NoError(t, err)
@@ -922,7 +910,6 @@ func TestSyntheticsStepMonitor_Basic(t *testing.T) {
 }
 
 func TestSyntheticsStepMonitor_GetSteps(t *testing.T) {
-	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -979,7 +966,6 @@ func TestSyntheticsStepMonitor_GetSteps(t *testing.T) {
 }
 
 func TestSyntheticsStepMonitor_GetScript(t *testing.T) {
-	t.Parallel()
 	testAccountID, err := mock.GetTestAccountID()
 	if err != nil {
 		t.Skipf("%s", err)
@@ -1029,7 +1015,6 @@ func newIntegrationTestClient(t *testing.T) Synthetics {
 // syntheticsStartAutomatedTest mutation to create a batch with these three monitors. The expected
 // behaviour of this test is to return a valid batchId and throw no error.
 func TestSyntheticsStartAutomatedTest_Basic(t *testing.T) {
-	t.Parallel()
 	t.Skipf(
 		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
 			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
@@ -1176,7 +1161,6 @@ func TestSyntheticsStartAutomatedTest_Basic(t *testing.T) {
 // TestSyntheticsStartAutomatedTest_Error performs a test on the syntheticsStartAutomatedTest mutation by specifying
 // an invalid GUID in the input field of a monitor to obtain an error, in alignment with expected behaviour.
 func TestSyntheticsStartAutomatedTest_Error(t *testing.T) {
-	t.Parallel()
 	t.Skipf(
 		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
 			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
@@ -1198,7 +1182,6 @@ func TestSyntheticsStartAutomatedTest_Error(t *testing.T) {
 // TestSyntheticsAutomatedTestResults_TwoMonitorsTest performs a test by creating two scripted browser monitors,
 // creating a batch with those monitors, querying the batch and evaluating the status accordingly.
 func TestSyntheticsAutomatedTestResults_TwoMonitorsTest(t *testing.T) {
-	t.Parallel()
 	t.Skipf(
 		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
 			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
@@ -1285,7 +1268,6 @@ func TestSyntheticsAutomatedTestResults_TwoMonitorsTest(t *testing.T) {
 // creating a batch with the monitor, querying the batch and evaluating the status accordingly. Since the scripted
 // browser monitor is bound to fail, this tests inspects the consolidated status and the status of the monitor.
 func TestSyntheticsAutomatedTestResults_OneMonitorTest(t *testing.T) {
-	t.Parallel()
 	t.Skipf(
 		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
 			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.
@@ -1351,7 +1333,6 @@ func TestSyntheticsAutomatedTestResults_OneMonitorTest(t *testing.T) {
 // TestSyntheticsAutomatedTestResults_ErrorTest performs a test on the automatedTestResults query by
 // specifying an invalid batchId, which is expected to throw an error.
 func TestSyntheticsAutomatedTestResults_ErrorTest(t *testing.T) {
-	t.Parallel()
 	t.Skipf(
 		`Temporarily skipping tests associated with the Synthetics Automated Tests feature, ` +
 			`given the API is currently unstable and endpoint access is not configured to all accounts at the moment.

--- a/pkg/workflows/workflows_integration_test.go
+++ b/pkg/workflows/workflows_integration_test.go
@@ -86,7 +86,7 @@ func TestIntegrationCreateWorkflowWithoutNotificationTriggers(t *testing.T) {
 	defer cleanupWorkflow(t, &createResult.Workflow)
 	var createdWorkflow = createResult.Workflow
 
-	require.Equal(t, []AiWorkflowsNotificationTrigger(nil), createdWorkflow.DestinationConfigurations[0].NotificationTriggers)
+	require.Equal(t, []AiWorkflowsNotificationTrigger{"ACKNOWLEDGED", "ACTIVATED", "CLOSED", "PRIORITY_CHANGED"}, createdWorkflow.DestinationConfigurations[0].NotificationTriggers)
 }
 
 func TestIntegrationDeleteWorkflow_CanDeleteChannels(t *testing.T) {
@@ -235,7 +235,7 @@ func TestIntegrationUpdateWorkflow_UpdateEverything(t *testing.T) {
 				Name: "filter-test-update",
 				Type: AiWorkflowsFilterTypeTypes.FILTER,
 				Predicates: []AiWorkflowsPredicateInput{{
-					Attribute: "source",
+					Attribute: "accumulations.sources",
 					Operator:  AiWorkflowsOperatorTypes.CONTAINS,
 					Values:    []string{"servicenow"},
 				}},
@@ -453,7 +453,7 @@ func generateCreateWorkflowInput(channel *notifications.AiNotificationsChannel, 
 		Name: "filter-test",
 		Type: AiWorkflowsFilterTypeTypes.FILTER,
 		Predicates: []AiWorkflowsPredicateInput{{
-			Attribute: "source",
+			Attribute: "accumulations.sources",
 			Operator:  AiWorkflowsOperatorTypes.CONTAINS,
 			Values:    []string{"newrelic"},
 		}},


### PR DESCRIPTION
This PR fixes the failing integration tests.

1. Tests for deprecated APIs that always throw errors are skipped
2. The Workflows API has some changes we needed to make for v2 users and it is now working again
3. Synthetics tests need to be run sequentially else they throw errors
4. Some tests for cloud and entity tags remain flakey and fail intermittently 