### PR TITLE
fix: When using a testserver, ensure the Insights API is mocked

### DIFF
--- a/pkg/testhelpers/config.go
+++ b/pkg/testhelpers/config.go
@@ -33,6 +33,7 @@ func NewTestConfig(t *testing.T, testServer *httptest.Server) config.Config {
 
 	if testServer != nil {
 		cfg.Region().SetInfrastructureBaseURL(testServer.URL)
+		cfg.Region().SetInsightsBaseURL(testServer.URL)
 		cfg.Region().SetNerdGraphBaseURL(testServer.URL)
 		cfg.Region().SetRestBaseURL(testServer.URL)
 		cfg.Region().SetSyntheticsBaseURL(testServer.URL)


### PR DESCRIPTION
We were using the `testhelpers` package to setup a `NewTestConfig` and noticed when trying to test the Insights API calls, it was not being mocked. I believe this is not intentional, so this is a quick fix, but please let me know if this is intentional.

Fixes https://github.com/newrelic/newrelic-client-go/issues/1107