### PR TITLE
feat: synthetic monitors `MUTED` status EOL in newrelic-client-go

### DIFF
--- a/pkg/entities/types.go
+++ b/pkg/entities/types.go
@@ -2730,14 +2730,12 @@ var SyntheticMonitorStatusTypes = struct {
 	DISABLED SyntheticMonitorStatus
 	ENABLED  SyntheticMonitorStatus
 	FAULTY   SyntheticMonitorStatus
-	MUTED    SyntheticMonitorStatus
 	PAUSED   SyntheticMonitorStatus
 }{
 	DELETED:  "DELETED",
 	DISABLED: "DISABLED",
 	ENABLED:  "ENABLED",
 	FAULTY:   "FAULTY",
-	MUTED:    "MUTED",
 	PAUSED:   "PAUSED",
 }
 

--- a/pkg/synthetics/monitors.go
+++ b/pkg/synthetics/monitors.go
@@ -69,11 +69,9 @@ var (
 	// MonitorStatus specifies the possible Synthetics monitor status types.
 	MonitorStatus = struct {
 		Enabled  MonitorStatusType
-		Muted    MonitorStatusType
 		Disabled MonitorStatusType
 	}{
 		Enabled:  "ENABLED",
-		Muted:    "MUTED",
 		Disabled: "DISABLED",
 	}
 )

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -328,15 +328,11 @@ var SyntheticsMonitorStatusTypes = struct {
 	DISABLED SyntheticsMonitorStatus
 	// Enabled status of a monitor
 	ENABLED SyntheticsMonitorStatus
-	// Alerts muted status of a monitor
-	MUTED SyntheticsMonitorStatus
 }{
 	// Monitor disabled runs status of a monitor
 	DISABLED: "DISABLED",
 	// Enabled status of a monitor
 	ENABLED: "ENABLED",
-	// Alerts muted status of a monitor
-	MUTED: "MUTED",
 }
 
 // SyntheticsMonitorType - Enum of monitor types


### PR DESCRIPTION
TBD