### PR TITLE
Fix logger string interpolation

### DIFF
--- a/pkg/events/events_batch.go
+++ b/pkg/events/events_batch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -165,7 +166,7 @@ func (e *Events) batchWorker(ctx context.Context, id int) (err error) {
 				count = 0
 			}
 		case <-ctx.Done():
-			e.logger.Trace("batchWorker[", id, "]: exiting per context Done")
+			e.logger.Trace(fmt.Sprintf("batchWorker[%d]: exiting per context Done", id))
 			return ctx.Err()
 		}
 	}

--- a/pkg/logs/logs_batch.go
+++ b/pkg/logs/logs_batch.go
@@ -158,7 +158,7 @@ func (e *Logs) batchWorker(ctx context.Context, id int) (err error) {
 				count = 0
 			}
 		case <-ctx.Done():
-			e.logger.Trace("batchWorker[", id, "]: exiting per context Done")
+			e.logger.Trace(fmt.Sprintf("batchWorker[%d]: exiting per context Done", id))
 			return ctx.Err()
 		}
 	}


### PR DESCRIPTION
Code is raising a panic due to the logger string not being correctly interpolated.

Error I got:
```
panic: interface conversion: interface {} is int, not string

goroutine 31 [running]:
github.com/newrelic/newrelic-client-go/v2/pkg/logging.createFieldMap(...)
	/Users/mwu/go/pkg/mod/github.com/newrelic/newrelic-client-go/v2@v2.26.0/pkg/logging/logrus_logger.go:101
github.com/newrelic/newrelic-client-go/v2/pkg/logging.LogrusLogger.Trace({0x140002aee78?}, {0x104fe35d2, 0xc}, {0x1400039a7a0?, 0x1400026de01?, 0x1400026de40?})
	/Users/mwu/go/pkg/mod/github.com/newrelic/newrelic-client-go/v2@v2.26.0/pkg/logging/logrus_logger.go:92 +0x1d4
github.com/newrelic/newrelic-client-go/v2/pkg/logs.(*Logs).batchWorker(0x1400091b440, {0x1053d1d38, 0x14000926120}, 0x0)
	/Users/mwu/go/pkg/mod/github.com/newrelic/newrelic-client-go/v2@v2.26.0/pkg/logs/logs_batch.go:161 +0x2e8
github.com/newrelic/newrelic-client-go/v2/pkg/logs.(*Logs).BatchMode.func2(0x8?)
	/Users/mwu/go/pkg/mod/github.com/newrelic/newrelic-client-go/v2@v2.26.0/pkg/logs/logs_batch.go:45 +0x74
created by github.com/newrelic/newrelic-client-go/v2/pkg/logs.(*Logs).BatchMode
	/Users/mwu/go/pkg/mod/github.com/newrelic/newrelic-client-go/v2@v2.26.0/pkg/logs/logs_batch.go:43 +0x220
```