### PR TITLE
feat(entities): add entity search query helpers

### DIFF
--- a/pkg/entities/entities.go
+++ b/pkg/entities/entities.go
@@ -34,7 +34,7 @@ type EntitySearchParams struct {
 	Tags            []map[string]string
 }
 
-func BuildEntitySearchQuery(params EntitySearchParams) string {
+func BuildEntitySearchNrqlQuery(params EntitySearchParams) string {
 	paramsMap := map[string]string{
 		"name":   params.Name,
 		"domain": params.Domain,
@@ -77,16 +77,16 @@ func BuildEntitySearchQuery(params EntitySearchParams) string {
 
 	if len(params.Tags) > 0 {
 		if count > 0 {
-			query = fmt.Sprintf("%s AND %s", query, BuildTagsQueryFragment(params.Tags))
+			query = fmt.Sprintf("%s AND %s", query, BuildTagsNrqlQueryFragment(params.Tags))
 		} else {
-			query = BuildTagsQueryFragment(params.Tags)
+			query = BuildTagsNrqlQueryFragment(params.Tags)
 		}
 	}
 
 	return query
 }
 
-func BuildTagsQueryFragment(tags []map[string]string) string {
+func BuildTagsNrqlQueryFragment(tags []map[string]string) string {
 	var query string
 
 	for i, t := range tags {

--- a/pkg/entities/entities.go
+++ b/pkg/entities/entities.go
@@ -2,6 +2,8 @@
 package entities
 
 import (
+	"fmt"
+
 	"github.com/newrelic/newrelic-client-go/v2/internal/http"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/config"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/logging"
@@ -19,4 +21,50 @@ func New(config config.Config) Entities {
 		client: http.NewClient(config),
 		logger: config.GetLogger(),
 	}
+}
+
+func BuildEntitySearchQuery(name string, domain string, entityType string, tags []map[string]string) string {
+	params := map[string]string{
+		"name":   name,
+		"domain": domain,
+		"type":   entityType,
+	}
+
+	count := 0
+	query := ""
+	for k, v := range params {
+		if v == "" {
+			continue
+		}
+
+		if count == 0 {
+			query = fmt.Sprintf("%s = '%s'", k, v)
+		} else {
+			query = fmt.Sprintf("%s AND %s = '%s'", query, k, v)
+		}
+		count++
+	}
+
+	if len(tags) > 0 {
+		query = fmt.Sprintf("%s AND %s", query, BuildTagsQueryFragment(tags))
+	}
+
+	return query
+}
+
+func BuildTagsQueryFragment(tags []map[string]string) string {
+	var query string
+
+	for i, t := range tags {
+		var q string
+		if i > 0 {
+			q = fmt.Sprintf(" AND tags.`%s` = '%s'", t["key"], t["value"])
+		} else {
+			q = fmt.Sprintf("tags.`%s` = '%s'", t["key"], t["value"])
+		}
+
+		query = fmt.Sprintf("%s%s", query, q)
+	}
+
+	return query
 }

--- a/pkg/entities/entity_test.go
+++ b/pkg/entities/entity_test.go
@@ -35,3 +35,92 @@ func TestFindTagByKeyNotFound(t *testing.T) {
 	result := FindTagByKey(entityTags, "notFound")
 	require.Empty(t, result)
 }
+
+func TestBuildTagsQueryFragment_SingleTag(t *testing.T) {
+	t.Parallel()
+
+	expected := "tags.`tagKey` = 'tagValue'"
+
+	tags := []map[string]string{
+		map[string]string{
+			"key":   "tagKey",
+			"value": "tagValue",
+		},
+	}
+
+	result := BuildTagsQueryFragment(tags)
+
+	require.Equal(t, expected, result)
+}
+
+func TestBuildTagsQueryFragment_MultipleTags(t *testing.T) {
+	t.Parallel()
+
+	expected := "tags.`tagKey` = 'tagValue' AND tags.`tagKey2` = 'tagValue2' AND tags.`tagKey3` = 'tagValue3'"
+
+	tags := []map[string]string{
+		map[string]string{
+			"key":   "tagKey",
+			"value": "tagValue",
+		},
+		map[string]string{
+			"key":   "tagKey2",
+			"value": "tagValue2",
+		},
+		map[string]string{
+			"key":   "tagKey3",
+			"value": "tagValue3",
+		},
+	}
+
+	result := BuildTagsQueryFragment(tags)
+
+	require.Equal(t, expected, result)
+}
+
+func TestBuildTagsQueryFragment_EmptyTags(t *testing.T) {
+	t.Parallel()
+
+	expected := ""
+	tags := []map[string]string{}
+
+	result := BuildTagsQueryFragment(tags)
+
+	require.Equal(t, expected, result)
+}
+
+func TestBuildEntitySearchQuery(t *testing.T) {
+	t.Parallel()
+
+	tags := []map[string]string{}
+
+	// Name only
+	expected := "name = 'Dummy App'"
+	result := BuildEntitySearchQuery("Dummy App", "", "", tags)
+	require.Equal(t, expected, result)
+
+	// Name & Domain
+	expected = "name = 'Dummy App' AND domain = 'APM'"
+	result = BuildEntitySearchQuery("Dummy App", "APM", "", tags)
+	require.Equal(t, expected, result)
+
+	// Name, domain, and type
+	expected = "name = 'Dummy App' AND domain = 'APM' AND type = 'APPLICATION'"
+	result = BuildEntitySearchQuery("Dummy App", "APM", "APPLICATION", tags)
+	require.Equal(t, expected, result)
+
+	// Name, domain, type, and tags
+	expected = "name = 'Dummy App' AND domain = 'APM' AND type = 'APPLICATION' AND tags.`tagKey` = 'tagValue' AND tags.`tagKey2` = 'tagValue2'"
+	tags = []map[string]string{
+		map[string]string{
+			"key":   "tagKey",
+			"value": "tagValue",
+		},
+		map[string]string{
+			"key":   "tagKey2",
+			"value": "tagValue2",
+		},
+	}
+	result = BuildEntitySearchQuery("Dummy App", "APM", "APPLICATION", tags)
+	require.Equal(t, expected, result)
+}

--- a/pkg/entities/entity_test.go
+++ b/pkg/entities/entity_test.go
@@ -36,7 +36,7 @@ func TestFindTagByKeyNotFound(t *testing.T) {
 	require.Empty(t, result)
 }
 
-func TestBuildTagsQueryFragment_SingleTag(t *testing.T) {
+func TestBuildTagsNrqlQueryFragment_SingleTag(t *testing.T) {
 	t.Parallel()
 
 	expected := "tags.`tagKey` = 'tagValue'"
@@ -48,12 +48,12 @@ func TestBuildTagsQueryFragment_SingleTag(t *testing.T) {
 		},
 	}
 
-	result := BuildTagsQueryFragment(tags)
+	result := BuildTagsNrqlQueryFragment(tags)
 
 	require.Equal(t, expected, result)
 }
 
-func TestBuildTagsQueryFragment_MultipleTags(t *testing.T) {
+func TestBuildTagsNrqlQueryFragment_MultipleTags(t *testing.T) {
 	t.Parallel()
 
 	expected := "tags.`tagKey` = 'tagValue' AND tags.`tagKey2` = 'tagValue2' AND tags.`tagKey3` = 'tagValue3'"
@@ -73,23 +73,23 @@ func TestBuildTagsQueryFragment_MultipleTags(t *testing.T) {
 		},
 	}
 
-	result := BuildTagsQueryFragment(tags)
+	result := BuildTagsNrqlQueryFragment(tags)
 
 	require.Equal(t, expected, result)
 }
 
-func TestBuildTagsQueryFragment_EmptyTags(t *testing.T) {
+func TestBuildTagsNrqlQueryFragment_EmptyTags(t *testing.T) {
 	t.Parallel()
 
 	expected := ""
 	tags := []map[string]string{}
 
-	result := BuildTagsQueryFragment(tags)
+	result := BuildTagsNrqlQueryFragment(tags)
 
 	require.Equal(t, expected, result)
 }
 
-func TestBuildEntitySearchQuery(t *testing.T) {
+func TestBuildEntitySearchNrqlQuery(t *testing.T) {
 	t.Parallel()
 
 	// Name only
@@ -97,7 +97,7 @@ func TestBuildEntitySearchQuery(t *testing.T) {
 	searchParams := EntitySearchParams{
 		Name: "Dummy App",
 	}
-	result := BuildEntitySearchQuery(searchParams)
+	result := BuildEntitySearchNrqlQuery(searchParams)
 	require.Equal(t, expected, result)
 
 	// Case-sensitive search (applies to `name` only)
@@ -106,7 +106,7 @@ func TestBuildEntitySearchQuery(t *testing.T) {
 		Name:            "Dummy App",
 		IsCaseSensitive: true,
 	}
-	result = BuildEntitySearchQuery(searchParams)
+	result = BuildEntitySearchNrqlQuery(searchParams)
 	require.Equal(t, expected, result)
 
 	// Name & Domain
@@ -114,7 +114,7 @@ func TestBuildEntitySearchQuery(t *testing.T) {
 		Name:   "Dummy App",
 		Domain: "APM",
 	}
-	result = BuildEntitySearchQuery(searchParams)
+	result = BuildEntitySearchNrqlQuery(searchParams)
 	require.Contains(t, result, "name LIKE 'Dummy App'")
 	require.Contains(t, result, "domain = 'APM'")
 
@@ -124,7 +124,7 @@ func TestBuildEntitySearchQuery(t *testing.T) {
 		Domain: "APM",
 		Type:   "APPLICATION",
 	}
-	result = BuildEntitySearchQuery(searchParams)
+	result = BuildEntitySearchNrqlQuery(searchParams)
 	require.Contains(t, result, "name LIKE 'Dummy App'")
 	require.Contains(t, result, "domain = 'APM'")
 	require.Contains(t, result, "type = 'APPLICATION'")
@@ -145,7 +145,7 @@ func TestBuildEntitySearchQuery(t *testing.T) {
 			},
 		},
 	}
-	result = BuildEntitySearchQuery(searchParams)
+	result = BuildEntitySearchNrqlQuery(searchParams)
 	require.Contains(t, result, "name LIKE 'Dummy App'")
 	require.Contains(t, result, "domain = 'APM'")
 	require.Contains(t, result, "type = 'APPLICATION'")


### PR DESCRIPTION
This PR adds some exported helper functions to facilitate better entity search functionality in our downstream tools (newrelic-cli, terraform-provider-newrelic, etc).