### PR TITLE
feat(destinations): add custom header auth and secureUrl to destinations

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -1032,10 +1032,16 @@ packages:
       - name: AiNotificationsDestination
       - name: AiNotificationsCredentialsInput
         field_type_override: "*AiNotificationsCredentialsInput"
+      - name: AiNotificationsSecureURLInput
+        field_type_override: "*AiNotificationsSecureURLInput"
+      - name: AiNotificationsSecureURLUpdate
+        field_type_override: "*AiNotificationsSecureURLUpdate"
       - name: AiNotificationsAuth
         field_type_override: "ai.AiNotificationsAuth"
       - name: AiNotificationsError
         field_type_override: "ai.AiNotificationsError"
+      - name: AiNotificationsCustomHeadersAuthInput
+        field_type_override: "*AiNotificationsCustomHeadersAuthInput"
       - name: ID
         field_type_override: string
         skip_type_create: true

--- a/pkg/ai/types_ai.go
+++ b/pkg/ai/types_ai.go
@@ -215,6 +215,10 @@ type AiNotificationsTokenAuth struct {
 	Prefix string `json:"prefix"`
 }
 
+func (x AiNotificationsTokenAuth) GetCustomHeaders() []AiNotificationsCustomHeaders {
+	return nil
+}
+
 func (x AiNotificationsTokenAuth) GetAccessTokenURL() string {
 	return ""
 }
@@ -266,6 +270,10 @@ type AiNotificationsBasicAuth struct {
 	AuthType AiNotificationsAuthType `json:"authType"`
 	// Username
 	User string `json:"user"`
+}
+
+func (x AiNotificationsBasicAuth) GetCustomHeaders() []AiNotificationsCustomHeaders {
+	return nil
 }
 
 // GetAuthType returns a pointer to the value of AuthType from AiNotificationsBasicAuth
@@ -390,6 +398,8 @@ type AiNotificationsAuth struct {
 	Password SecureValue `json:"password,omitempty"`
 	// Basic auth user
 	User string `json:"user,omitempty"`
+	// Custom headers
+	CustomHeaders []AiNotificationsCustomHeaders `json:"customHeaders,omitempty"`
 }
 
 func (x *AiNotificationsAuth) ImplementsAiNotificationsAuth() {}
@@ -405,7 +415,63 @@ type AiNotificationsAuthInterface interface {
 	GetRefreshInterval() int
 	GetRefreshable() bool
 	GetScope() string
+	GetCustomHeaders() []AiNotificationsCustomHeaders
 }
+
+// AiNotificationsCustomHeaders - Custom headers
+type AiNotificationsCustomHeaders struct {
+	Key string `json:"key"`
+}
+
+// AiNotificationsCustomHeadersAuth - Custom headers based authentication
+type AiNotificationsCustomHeadersAuth struct {
+	// Authentication Type - CustomHeaders
+	AuthType AiNotificationsAuthType `json:"authType"`
+	// Custom headers
+	CustomHeaders []AiNotificationsCustomHeaders `json:"customHeaders"`
+}
+
+func (x AiNotificationsCustomHeadersAuth) GetUser() string {
+	return ""
+}
+
+func (x AiNotificationsCustomHeadersAuth) GetPrefix() string {
+	return ""
+}
+
+func (x AiNotificationsCustomHeadersAuth) GetAccessTokenURL() string {
+	return ""
+}
+
+func (x AiNotificationsCustomHeadersAuth) GetAuthorizationURL() string {
+	return ""
+}
+
+func (x AiNotificationsCustomHeadersAuth) GetClientId() string {
+	return ""
+}
+
+func (x AiNotificationsCustomHeadersAuth) GetRefreshInterval() int {
+	return 0
+}
+
+func (x AiNotificationsCustomHeadersAuth) GetRefreshable() bool {
+	return false
+}
+
+func (x AiNotificationsCustomHeadersAuth) GetScope() string {
+	return ""
+}
+
+func (x AiNotificationsCustomHeadersAuth) GetAuthType() AiNotificationsAuthType {
+	return x.AuthType
+}
+
+func (x AiNotificationsCustomHeadersAuth) GetCustomHeaders() []AiNotificationsCustomHeaders {
+	return x.CustomHeaders
+}
+
+func (x AiNotificationsCustomHeadersAuth) ImplementsAiNotificationsAuth() {}
 
 // UnmarshalAiNotificationsAuthInterface unmarshals the interface into the correct type
 // based on __typename provided by GraphQL
@@ -444,6 +510,16 @@ func UnmarshalAiNotificationsAuthInterface(b []byte) (*AiNotificationsAuthInterf
 			return &xxx, nil
 		case "AiNotificationsTokenAuth":
 			var interfaceType AiNotificationsTokenAuth
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AiNotificationsAuthInterface = &interfaceType
+
+			return &xxx, nil
+		case "AiNotificationsCustomHeadersAuth":
+			var interfaceType AiNotificationsCustomHeadersAuth
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err

--- a/pkg/notifications/notifications_api.go
+++ b/pkg/notifications/notifications_api.go
@@ -184,6 +184,12 @@ const AiNotificationsCreateDestinationMutation = `mutation(
 			  authType
 			  prefix
 			}
+			... on AiNotificationsCustomHeadersAuth {
+			  authType
+        	  customHeaders {
+          	    key
+			  }
+			}
 		}
 		createdAt
 		id
@@ -196,6 +202,9 @@ const AiNotificationsCreateDestinationMutation = `mutation(
 			key
 			label
 			value
+		}
+		secureUrl {
+			prefix
 		}
 		status
 		type
@@ -431,7 +440,7 @@ const AiNotificationsUpdateChannelMutation = `mutation(
 		updatedAt
 		updatedBy
 	}
-    error {
+	error {
       ... on AiNotificationsConstraintsError {
         constraints {
           dependencies
@@ -553,6 +562,12 @@ const AiNotificationsUpdateDestinationMutation = `mutation(
 			  authType
 			  prefix
 			}
+			... on AiNotificationsCustomHeadersAuth {
+			  authType
+        	  customHeaders {
+          	    key
+			  }
+			}
 		}
 		createdAt
 		id
@@ -565,6 +580,9 @@ const AiNotificationsUpdateDestinationMutation = `mutation(
 			key
 			label
 			value
+		}
+		secureUrl {
+			prefix
 		}
 		status
 		type
@@ -762,6 +780,12 @@ const getDestinationsQuery = `query(
 			  authType
 			  prefix
 			}
+			... on AiNotificationsCustomHeadersAuth {
+			  authType
+        	  customHeaders {
+          	    key
+			  }
+			}
 		}
 		createdAt
 		id
@@ -774,6 +798,9 @@ const getDestinationsQuery = `query(
 			key
 			label
 			value
+		}
+		secureUrl {
+			prefix
 		}
 		status
 		type

--- a/pkg/notifications/notifications_integration_test.go
+++ b/pkg/notifications/notifications_integration_test.go
@@ -148,6 +148,182 @@ func TestNotificationMutationDestination_FilterByName(t *testing.T) {
 	require.NotNil(t, deleteResult)
 }
 
+func TestNotificationMutationDestination_CustomHeaderAuth(t *testing.T) {
+	t.Parallel()
+
+	n := newIntegrationTestClient(t)
+
+	accountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	// Create a destination to work with in this test
+	testIntegrationDestinationNameRandStr := mock.RandSeq(5)
+	destination := AiNotificationsDestinationInput{}
+	destination.Type = AiNotificationsDestinationTypeTypes.WEBHOOK
+	destination.Properties = []AiNotificationsPropertyInput{
+		{
+			Key:          "url",
+			Value:        "https://webhook.site/94193c01-4a81-4782-8f1b-554d5230395b",
+			Label:        "",
+			DisplayValue: "",
+		},
+	}
+	destination.Auth = &AiNotificationsCredentialsInput{
+		Type: AiNotificationsAuthTypeTypes.CUSTOM_HEADERS,
+		CustomHeaders: &AiNotificationsCustomHeadersAuthInput{
+			[]AiNotificationsCustomHeaderInput{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+				{Key: "key3", Value: "value3"},
+			},
+		},
+	}
+	destination.Name = fmt.Sprintf("test-notifications-destination-%s", testIntegrationDestinationNameRandStr)
+
+	// Test: Create
+	createResult, err := n.AiNotificationsCreateDestination(accountID, destination)
+	require.NoError(t, err)
+	require.NotNil(t, createResult)
+	require.NotEmpty(t, createResult.Destination.Auth)
+	require.Equal(t, ai.AiNotificationsAuthType("CUSTOM_HEADERS"), createResult.Destination.Auth.AuthType)
+	require.Equal(t, 3, len(createResult.Destination.Auth.CustomHeaders))
+	require.Equal(t, "key1", createResult.Destination.Auth.CustomHeaders[0].Key)
+	require.Equal(t, "key2", createResult.Destination.Auth.CustomHeaders[1].Key)
+	require.Equal(t, "key3", createResult.Destination.Auth.CustomHeaders[2].Key)
+
+	// Test: Get Destination by id
+	filters := ai.AiNotificationsDestinationFilter{
+		ID: createResult.Destination.ID,
+	}
+	sorter := AiNotificationsDestinationSorter{}
+	getDestinationResult, err := n.GetDestinations(accountID, "", filters, sorter)
+	require.NoError(t, err)
+	require.NotNil(t, getDestinationResult)
+	assert.Equal(t, 1, getDestinationResult.TotalCount)
+	require.NotEmpty(t, getDestinationResult.Entities[0].GUID)
+	require.Equal(t, ai.AiNotificationsAuthType("CUSTOM_HEADERS"), getDestinationResult.Entities[0].Auth.AuthType)
+	require.Equal(t, 3, len(getDestinationResult.Entities[0].Auth.CustomHeaders))
+	require.Equal(t, "key1", getDestinationResult.Entities[0].Auth.CustomHeaders[0].Key)
+	require.Equal(t, "key2", getDestinationResult.Entities[0].Auth.CustomHeaders[1].Key)
+	require.Equal(t, "key3", getDestinationResult.Entities[0].Auth.CustomHeaders[2].Key)
+
+	// Test: Update Destination
+	updateDestination := AiNotificationsDestinationUpdate{}
+	updateDestination.Active = false
+	updateDestination.Properties = []AiNotificationsPropertyInput{
+		{
+			Key:          "url",
+			Value:        "https://webhook.site/94193c01-4a81-4782-8f1b-554d5230395b",
+			Label:        "",
+			DisplayValue: "",
+		},
+	}
+	updateDestination.Auth = &AiNotificationsCredentialsInput{
+		Type: AiNotificationsAuthTypeTypes.CUSTOM_HEADERS,
+		CustomHeaders: &AiNotificationsCustomHeadersAuthInput{
+			[]AiNotificationsCustomHeaderInput{
+				{Key: "key1", Value: "value1"},
+				{Key: "key4", Value: "value4"},
+			},
+		},
+	}
+	updateDestination.Name = fmt.Sprintf("test-notifications-update-destination-%s", testIntegrationDestinationNameRandStr)
+
+	updateDestinationResult, err := n.AiNotificationsUpdateDestination(accountID, updateDestination, createResult.Destination.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updateDestinationResult)
+	require.Equal(t, ai.AiNotificationsAuthType("CUSTOM_HEADERS"), updateDestinationResult.Destination.Auth.AuthType)
+	require.Equal(t, 2, len(updateDestinationResult.Destination.Auth.CustomHeaders))
+	require.Equal(t, "key1", updateDestinationResult.Destination.Auth.CustomHeaders[0].Key)
+	require.Equal(t, "key4", updateDestinationResult.Destination.Auth.CustomHeaders[1].Key)
+
+	// Test: Delete
+	deleteResult, err := n.AiNotificationsDeleteDestination(accountID, createResult.Destination.ID)
+	require.NoError(t, err)
+	require.NotNil(t, deleteResult)
+}
+
+func TestNotificationMutationDestination_secureUrl(t *testing.T) {
+	t.Parallel()
+
+	n := newIntegrationTestClient(t)
+
+	accountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	// Create a destination to work with in this test
+	testIntegrationDestinationNameRandStr := mock.RandSeq(5)
+	destination := AiNotificationsDestinationInput{}
+	destination.Type = AiNotificationsDestinationTypeTypes.WEBHOOK
+	destination.Properties = []AiNotificationsPropertyInput{}
+	destination.SecureURL = &AiNotificationsSecureURLInput{
+		Prefix:       "https://webhook.site",
+		SecureSuffix: "/94193c01-4a81-4782-8f1b-554d5230395b",
+	}
+	destination.Auth = &AiNotificationsCredentialsInput{
+		Type: AiNotificationsAuthTypeTypes.TOKEN,
+		Token: AiNotificationsTokenAuthInput{
+			Token:  "Token",
+			Prefix: "Bearer",
+		},
+	}
+	destination.Name = fmt.Sprintf("test-notifications-destination-%s", testIntegrationDestinationNameRandStr)
+
+	// Test: Create
+	createResult, err := n.AiNotificationsCreateDestination(accountID, destination)
+	require.NoError(t, err)
+	require.NotNil(t, createResult)
+	require.NotNil(t, createResult.Destination.SecureURL)
+	require.Equal(t, createResult.Destination.SecureURL.Prefix, "https://webhook.site")
+	require.NotEmpty(t, createResult.Destination.Auth)
+	require.Equal(t, ai.AiNotificationsAuthType("TOKEN"), createResult.Destination.Auth.AuthType)
+
+	// Test: Get Destination by id
+	filters := ai.AiNotificationsDestinationFilter{
+		ID: createResult.Destination.ID,
+	}
+	sorter := AiNotificationsDestinationSorter{}
+	getDestinationResult, err := n.GetDestinations(accountID, "", filters, sorter)
+	require.NoError(t, err)
+	require.NotNil(t, getDestinationResult)
+	assert.Equal(t, 1, getDestinationResult.TotalCount)
+	require.NotEmpty(t, getDestinationResult.Entities[0].GUID)
+	require.NotNil(t, getDestinationResult.Entities[0].SecureURL)
+	require.Equal(t, getDestinationResult.Entities[0].SecureURL.Prefix, "https://webhook.site")
+
+	// Test: Update Destination
+	updateDestination := AiNotificationsDestinationUpdate{}
+	updateDestination.Active = false
+	updateDestination.Properties = []AiNotificationsPropertyInput{}
+	updateDestination.SecureURL = &AiNotificationsSecureURLUpdate{
+		Prefix:       "https://webhook2.site",
+		SecureSuffix: "/59bb0d7a-1708-481a-a178-9161416f8ba6",
+	}
+	updateDestination.Auth = &AiNotificationsCredentialsInput{
+		Type: AiNotificationsAuthTypeTypes.TOKEN,
+		Token: AiNotificationsTokenAuthInput{
+			Token:  "TokenUpdate",
+			Prefix: "BearerUpdate",
+		},
+	}
+	updateDestination.Name = fmt.Sprintf("test-notifications-update-destination-%s", testIntegrationDestinationNameRandStr)
+
+	updateDestinationResult, err := n.AiNotificationsUpdateDestination(accountID, updateDestination, createResult.Destination.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updateDestinationResult)
+	require.NotNil(t, updateDestinationResult.Destination.SecureURL)
+	require.Equal(t, updateDestinationResult.Destination.SecureURL.Prefix, "https://webhook2.site")
+
+	// Test: Delete
+	deleteResult, err := n.AiNotificationsDeleteDestination(accountID, createResult.Destination.ID)
+	require.NoError(t, err)
+	require.NotNil(t, deleteResult)
+}
+
 func TestNotificationMutationChannel(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/notifications/types.go
+++ b/pkg/notifications/types.go
@@ -15,6 +15,8 @@ type AiNotificationsAuthType string
 var AiNotificationsAuthTypeTypes = struct {
 	// Basic user and password authentication
 	BASIC AiNotificationsAuthType
+	// Custom header based authentication
+	CUSTOM_HEADERS AiNotificationsAuthType
 	// OAuth based authentication
 	OAUTH2 AiNotificationsAuthType
 	// Token based authentication
@@ -22,6 +24,8 @@ var AiNotificationsAuthTypeTypes = struct {
 }{
 	// Basic user and password authentication
 	BASIC: "BASIC",
+	// Custom header based authentication
+	CUSTOM_HEADERS: "CUSTOM_HEADERS",
 	// OAuth based authentication
 	OAUTH2: "OAUTH2",
 	// Token based authentication
@@ -136,6 +140,8 @@ var AiNotificationsChannelTypeTypes = struct {
 	SERVICENOW_EVENTS AiNotificationsChannelType
 	// Servicenow incidents channel type
 	SERVICENOW_INCIDENTS AiNotificationsChannelType
+	// ServiceNow app channel type
+	SERVICE_NOW_APP AiNotificationsChannelType
 	// Slack channel type
 	SLACK AiNotificationsChannelType
 	// Slack Collaboration channel type
@@ -163,6 +169,8 @@ var AiNotificationsChannelTypeTypes = struct {
 	SERVICENOW_EVENTS: "SERVICENOW_EVENTS",
 	// Servicenow incidents channel type
 	SERVICENOW_INCIDENTS: "SERVICENOW_INCIDENTS",
+	// ServiceNow app channel type
+	SERVICE_NOW_APP: "SERVICE_NOW_APP",
 	// Slack channel type
 	SLACK: "SLACK",
 	// Slack Collaboration channel type
@@ -226,6 +234,8 @@ var AiNotificationsDestinationStatusTypes = struct {
 	AUTHORIZATION_ERROR AiNotificationsDestinationStatus
 	// Authorization Warning destination status
 	AUTHORIZATION_WARNING AiNotificationsDestinationStatus
+	// Auth Error destination status
+	AUTH_ERROR AiNotificationsDestinationStatus
 	// Configuration Error destination status
 	CONFIGURATION_ERROR AiNotificationsDestinationStatus
 	// Default destination status
@@ -234,6 +244,8 @@ var AiNotificationsDestinationStatusTypes = struct {
 	DRAFT AiNotificationsDestinationStatus
 	// Error channel status
 	ERROR AiNotificationsDestinationStatus
+	// External Server Error destination status
+	EXTERNAL_SERVER_ERROR AiNotificationsDestinationStatus
 	// Temporary Warning destination status
 	TEMPORARY_WARNING AiNotificationsDestinationStatus
 	// Tested channel status
@@ -242,6 +254,10 @@ var AiNotificationsDestinationStatusTypes = struct {
 	THROTTLED AiNotificationsDestinationStatus
 	// Throttling Warning destination status
 	THROTTLING_WARNING AiNotificationsDestinationStatus
+	// Timeout Error destination status
+	TIMEOUT_ERROR AiNotificationsDestinationStatus
+	// Uninstalled destination status
+	UNINSTALLED AiNotificationsDestinationStatus
 	// Unknown Error destination status
 	UNKNOWN_ERROR AiNotificationsDestinationStatus
 }{
@@ -251,6 +267,8 @@ var AiNotificationsDestinationStatusTypes = struct {
 	AUTHORIZATION_ERROR: "AUTHORIZATION_ERROR",
 	// Authorization Warning destination status
 	AUTHORIZATION_WARNING: "AUTHORIZATION_WARNING",
+	// Auth Error destination status
+	AUTH_ERROR: "AUTH_ERROR",
 	// Configuration Error destination status
 	CONFIGURATION_ERROR: "CONFIGURATION_ERROR",
 	// Default destination status
@@ -259,6 +277,8 @@ var AiNotificationsDestinationStatusTypes = struct {
 	DRAFT: "DRAFT",
 	// Error channel status
 	ERROR: "ERROR",
+	// External Server Error destination status
+	EXTERNAL_SERVER_ERROR: "EXTERNAL_SERVER_ERROR",
 	// Temporary Warning destination status
 	TEMPORARY_WARNING: "TEMPORARY_WARNING",
 	// Tested channel status
@@ -267,6 +287,10 @@ var AiNotificationsDestinationStatusTypes = struct {
 	THROTTLED: "THROTTLED",
 	// Throttling Warning destination status
 	THROTTLING_WARNING: "THROTTLING_WARNING",
+	// Timeout Error destination status
+	TIMEOUT_ERROR: "TIMEOUT_ERROR",
+	// Uninstalled destination status
+	UNINSTALLED: "UNINSTALLED",
 	// Unknown Error destination status
 	UNKNOWN_ERROR: "UNKNOWN_ERROR",
 }
@@ -289,6 +313,8 @@ var AiNotificationsDestinationTypeTypes = struct {
 	PAGERDUTY_SERVICE_INTEGRATION AiNotificationsDestinationType
 	// ServiceNow destination type
 	SERVICE_NOW AiNotificationsDestinationType
+	// ServiceNow app destination type
+	SERVICE_NOW_APP AiNotificationsDestinationType
 	// Slack destination type
 	SLACK AiNotificationsDestinationType
 	// Slack Collaboration destination type
@@ -312,6 +338,8 @@ var AiNotificationsDestinationTypeTypes = struct {
 	PAGERDUTY_SERVICE_INTEGRATION: "PAGERDUTY_SERVICE_INTEGRATION",
 	// ServiceNow destination type
 	SERVICE_NOW: "SERVICE_NOW",
+	// ServiceNow app destination type
+	SERVICE_NOW_APP: "SERVICE_NOW_APP",
 	// Slack destination type
 	SLACK: "SLACK",
 	// Slack Collaboration destination type
@@ -330,6 +358,12 @@ var AiNotificationsErrorTypeTypes = struct {
 	CONNECTION_ERROR AiNotificationsErrorType
 	// This operation could not be completed because the entity is in use
 	ENTITY_IN_USE AiNotificationsErrorType
+	// An external server error has occurred
+	EXTERNAL_SERVER_ERROR AiNotificationsErrorType
+	// Targeted account does not have access to this feature
+	FEATURE_FLAG_DISABLED AiNotificationsErrorType
+	// The channel name doesn't exist
+	INVALID_CHANNEL_NAME AiNotificationsErrorType
 	// The credentials provided were invalid, Please check them and try again
 	INVALID_CREDENTIALS AiNotificationsErrorType
 	// Could not provide suggestions for this key
@@ -356,6 +390,8 @@ var AiNotificationsErrorTypeTypes = struct {
 	UNAUTHORIZED_ACCOUNT AiNotificationsErrorType
 	// Received one or more unexpected parameters
 	UNEXPECTED_PARAMETER AiNotificationsErrorType
+	// The New Relic application was removed
+	UNINSTALLED_DESTINATION AiNotificationsErrorType
 	// An unknown error has occurred
 	UNKNOWN_ERROR AiNotificationsErrorType
 }{
@@ -363,6 +399,12 @@ var AiNotificationsErrorTypeTypes = struct {
 	CONNECTION_ERROR: "CONNECTION_ERROR",
 	// This operation could not be completed because the entity is in use
 	ENTITY_IN_USE: "ENTITY_IN_USE",
+	// An external server error has occurred
+	EXTERNAL_SERVER_ERROR: "EXTERNAL_SERVER_ERROR",
+	// Targeted account does not have access to this feature
+	FEATURE_FLAG_DISABLED: "FEATURE_FLAG_DISABLED",
+	// The channel name doesn't exist
+	INVALID_CHANNEL_NAME: "INVALID_CHANNEL_NAME",
 	// The credentials provided were invalid, Please check them and try again
 	INVALID_CREDENTIALS: "INVALID_CREDENTIALS",
 	// Could not provide suggestions for this key
@@ -389,6 +431,8 @@ var AiNotificationsErrorTypeTypes = struct {
 	UNAUTHORIZED_ACCOUNT: "UNAUTHORIZED_ACCOUNT",
 	// Received one or more unexpected parameters
 	UNEXPECTED_PARAMETER: "UNEXPECTED_PARAMETER",
+	// The New Relic application was removed
+	UNINSTALLED_DESTINATION: "UNINSTALLED_DESTINATION",
 	// An unknown error has occurred
 	UNKNOWN_ERROR: "UNKNOWN_ERROR",
 }
@@ -399,6 +443,12 @@ type AiNotificationsProduct string
 var AiNotificationsProductTypes = struct {
 	// Alerts product type
 	ALERTS AiNotificationsProduct
+	// APM product type
+	APM AiNotificationsProduct
+	// Change tracking product type
+	CHANGE_TRACKING AiNotificationsProduct
+	// CSSP (EOPs) product type
+	CSSP AiNotificationsProduct
 	// Discussions and comments product type
 	DISCUSSIONS AiNotificationsProduct
 	// Error Tracking product type
@@ -409,11 +459,19 @@ var AiNotificationsProductTypes = struct {
 	NTFC AiNotificationsProduct
 	// Proactive Detection product type
 	PD AiNotificationsProduct
+	// Security product type
+	SECURITY AiNotificationsProduct
 	// Sharing product type
 	SHARING AiNotificationsProduct
 }{
 	// Alerts product type
 	ALERTS: "ALERTS",
+	// APM product type
+	APM: "APM",
+	// Change tracking product type
+	CHANGE_TRACKING: "CHANGE_TRACKING",
+	// CSSP (EOPs) product type
+	CSSP: "CSSP",
 	// Discussions and comments product type
 	DISCUSSIONS: "DISCUSSIONS",
 	// Error Tracking product type
@@ -424,6 +482,8 @@ var AiNotificationsProductTypes = struct {
 	NTFC: "NTFC",
 	// Proactive Detection product type
 	PD: "PD",
+	// Security product type
+	SECURITY: "SECURITY",
 	// Sharing product type
 	SHARING: "SHARING",
 }
@@ -528,12 +588,9 @@ var AlertsWebhookCustomPayloadTypeTypes = struct {
 type Account struct {
 	// This field provides access to AiNotifications data.
 	AiNotifications AiNotificationsAccountStitchedFields `json:"aiNotifications,omitempty"`
-	//
-	ID int `json:"id,omitempty"`
-	//
-	LicenseKey string `json:"licenseKey,omitempty"`
-	//
-	Name string `json:"name,omitempty"`
+	ID              int                                  `json:"id,omitempty"`
+	LicenseKey      string                               `json:"licenseKey,omitempty"`
+	Name            string                               `json:"name,omitempty"`
 }
 
 // Actor - The `Actor` object contains fields that are scoped to the API user's access level.
@@ -594,12 +651,16 @@ type AiNotificationsChannelFilter struct {
 	DestinationId string `json:"destinationId,omitempty"`
 	// id
 	ID string `json:"id,omitempty"`
+	// ids
+	IDs []string `json:"ids"`
 	// name
 	Name string `json:"name,omitempty"`
 	// product
 	Product AiNotificationsProduct `json:"product,omitempty"`
 	// property
 	Property AiNotificationsPropertyFilter `json:"property,omitempty"`
+	// statuses
+	Statuses []AiNotificationsChannelStatus `json:"statuses"`
 	// type
 	Type AiNotificationsChannelType `json:"type,omitempty"`
 }
@@ -664,12 +725,28 @@ type AiNotificationsChannelsResponse struct {
 type AiNotificationsCredentialsInput struct {
 	// basic
 	Basic AiNotificationsBasicAuthInput `json:"basic,omitempty"`
+	// customHeaders
+	CustomHeaders *AiNotificationsCustomHeadersAuthInput `json:"customHeaders,omitempty"`
 	// oauth2
 	Oauth2 AiNotificationsOAuth2AuthInput `json:"oauth2,omitempty"`
 	// token
 	Token AiNotificationsTokenAuthInput `json:"token,omitempty"`
 	// type
 	Type AiNotificationsAuthType `json:"type"`
+}
+
+// AiNotificationsCustomHeaderInput - Custom header input object
+type AiNotificationsCustomHeaderInput struct {
+	// key
+	Key string `json:"key"`
+	// value
+	Value SecureValue `json:"value,omitempty"`
+}
+
+// AiNotificationsCustomHeadersAuthInput - Custom headers auth input object
+type AiNotificationsCustomHeadersAuthInput struct {
+	// customHeaders
+	CustomHeaders []AiNotificationsCustomHeaderInput `json:"customHeaders,omitempty"`
 }
 
 // AiNotificationsDeleteResponse - Delete response object
@@ -692,10 +769,10 @@ type AiNotificationsDestination struct {
 	Auth ai.AiNotificationsAuth `json:"auth,omitempty"`
 	// Destination created at
 	CreatedAt nrtime.DateTime `json:"createdAt"`
+	// Entity Id of the Destination
+	GUID EntityGUID `json:"guid"`
 	// Destination id
 	ID string `json:"id"`
-	// Entity Id of the destination
-	GUID EntityGUID `json:"guid"`
 	// Indicates whether the user is authenticated with the destination
 	IsUserAuthenticated bool `json:"isUserAuthenticated"`
 	// Last time a notification was sent
@@ -704,6 +781,8 @@ type AiNotificationsDestination struct {
 	Name string `json:"name"`
 	// List of destination property types
 	Properties []AiNotificationsProperty `json:"properties"`
+	// URL in secure format
+	SecureURL AiNotificationsSecureURL `json:"secureUrl,omitempty"`
 	// Destination status
 	Status AiNotificationsDestinationStatus `json:"status"`
 	// Destination type
@@ -714,9 +793,6 @@ type AiNotificationsDestination struct {
 	UpdatedBy int `json:"updatedBy"`
 }
 
-// EntityGUID - An encoded Entity GUID
-type EntityGUID string
-
 // AiNotificationsDestinationFilter - Filter destination object
 type AiNotificationsDestinationFilter struct {
 	// active
@@ -725,6 +801,8 @@ type AiNotificationsDestinationFilter struct {
 	AuthType AiNotificationsAuthType `json:"authType,omitempty"`
 	// id
 	ID string `json:"id,omitempty"`
+	// ids
+	IDs []string `json:"ids"`
 	// name
 	Name string `json:"name,omitempty"`
 	// property
@@ -742,7 +820,9 @@ type AiNotificationsDestinationInput struct {
 	// name
 	Name string `json:"name"`
 	// properties
-	Properties []AiNotificationsPropertyInput `json:"properties,omitempty"`
+	Properties []AiNotificationsPropertyInput `json:"properties"`
+	// secureUrl
+	SecureURL *AiNotificationsSecureURLInput `json:"secureUrl,omitempty"`
 	// type
 	Type AiNotificationsDestinationType `json:"type"`
 }
@@ -777,6 +857,8 @@ type AiNotificationsDestinationUpdate struct {
 	Name string `json:"name,omitempty"`
 	// properties
 	Properties []AiNotificationsPropertyInput `json:"properties,omitempty"`
+	// secureUrl
+	SecureURL *AiNotificationsSecureURLUpdate `json:"secureUrl,omitempty"`
 }
 
 // AiNotificationsDestinationsResponse - Destinations result object
@@ -857,6 +939,28 @@ type AiNotificationsResponseError struct {
 	Details string `json:"details"`
 	// Error type
 	Type AiNotificationsErrorType `json:"type"`
+}
+
+// AiNotificationsSecureURL - URL in secure format
+type AiNotificationsSecureURL struct {
+	// URL prefix
+	Prefix string `json:"prefix"`
+}
+
+// AiNotificationsSecureURLInput - Destination SecureUrlInput object
+type AiNotificationsSecureURLInput struct {
+	// prefix
+	Prefix string `json:"prefix"`
+	// secureSuffix
+	SecureSuffix SecureValue `json:"secureSuffix"`
+}
+
+// AiNotificationsSecureURLUpdate - Destination SecureUrlUpdate object
+type AiNotificationsSecureURLUpdate struct {
+	// prefix
+	Prefix string `json:"prefix,omitempty"`
+	// secureSuffix
+	SecureSuffix SecureValue `json:"secureSuffix,omitempty"`
 }
 
 // AiNotificationsTokenAuthInput - Token auth input object
@@ -1170,6 +1274,9 @@ type channelsResponse struct {
 type destinationsResponse struct {
 	Actor Actor `json:"actor"`
 }
+
+// EntityGUID - An encoded Entity GUID
+type EntityGUID string
 
 // SecureValue - The `SecureValue` scalar represents a secure value, ie a password, an API key, etc.
 type SecureValue string


### PR DESCRIPTION
### For Maintainers
⚠️ Kindly hold on merging this PR until 18 April, 2024.

This PR adds 2 new changes to destinations schema:
- new type of auth to destinations called custom headers
- new field secureUrl. This struct holds a SecureValue, so only the prefix part which is a non-SecureValue will be shown upon querying the API.

Required by https://github.com/newrelic/terraform-provider-newrelic/pull/2635/