### PR TITLE
fix(customeradministration): change auth_domain filter types in the package to use pointers

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -1599,6 +1599,15 @@ packages:
         field_type_override: "*OrganizationOrganizationCreateJobIdInput"
       - name: OrganizationOrganizationCreateJobStatusInput
         field_type_override: "*OrganizationOrganizationCreateJobStatusInput"
+        ######
+        # overrides associated with types starting with OrganizationAuthenticationDomainFilterInput
+        # which is used in the 'authenticationdomain' endpoint in customerAdministration
+      - name: OrganizationIdInput
+        field_type_override: "*OrganizationIdInput"
+      - name: OrganizationNameInput
+        field_type_override: "*OrganizationNameInput"
+      - name: OrganizationOrganizationIdInput
+        field_type_override: "*OrganizationOrganizationIdInput"
 
       - name: ID
         field_type_override: string

--- a/pkg/customeradministration/customeradministration_api.go
+++ b/pkg/customeradministration/customeradministration_api.go
@@ -107,8 +107,13 @@ const getAccountsQuery = `query(
 	sort: $sort,
 ) {
 	items {
+		createdAt
 		id
 		name
+		parentId
+		partnershipId
+		partnershipName
+		payMethod
 		regionCode
 		status
 	}

--- a/pkg/customeradministration/customeradministration_integration_test.go
+++ b/pkg/customeradministration/customeradministration_integration_test.go
@@ -70,8 +70,8 @@ func TestIntegrationCustomerAdministration_GetAuthenticationDomains(t *testing.T
 	client := newIntegrationTestClient(t)
 	_, err = client.GetAuthenticationDomains("",
 		OrganizationAuthenticationDomainFilterInput{
-			Name:           OrganizationNameInput{Eq: authenticationDomainName},
-			OrganizationId: OrganizationOrganizationIdInput{Eq: organizationId},
+			Name:           &OrganizationNameInput{Eq: authenticationDomainName},
+			OrganizationId: &OrganizationOrganizationIdInput{Eq: organizationId},
 		},
 		[]OrganizationAuthenticationDomainSortInput{},
 	)

--- a/pkg/customeradministration/types.go
+++ b/pkg/customeradministration/types.go
@@ -1228,10 +1228,20 @@ type MultiTenantIdentityUserType struct {
 
 // OrganizationAccount - The account type contains the properties of an account
 type OrganizationAccount struct {
+	// The creation time
+	CreatedAt nrtime.DateTime `json:"createdAt"`
 	// The account id
 	ID int `json:"id"`
 	// The account name
 	Name string `json:"name"`
+	// The parent ID
+	ParentId int `json:"parentId,omitempty"`
+	// The partnership ID
+	PartnershipId int `json:"partnershipId,omitempty"`
+	// The partnership Name
+	PartnershipName string `json:"partnershipName,omitempty"`
+	// The pay method
+	PayMethod string `json:"payMethod,omitempty"`
 	// The account region code
 	RegionCode string `json:"regionCode"`
 	// The status

--- a/pkg/customeradministration/types.go
+++ b/pkg/customeradministration/types.go
@@ -1391,11 +1391,11 @@ type OrganizationAuthenticationDomainCollection struct {
 // OrganizationAuthenticationDomainFilterInput - A filter for authentication domains
 type OrganizationAuthenticationDomainFilterInput struct {
 	// Filter authentication domains by id
-	ID OrganizationIdInput `json:"id,omitempty"`
+	ID *OrganizationIdInput `json:"id,omitempty"`
 	// Filter authentication domains by name
-	Name OrganizationNameInput `json:"name,omitempty"`
+	Name *OrganizationNameInput `json:"name,omitempty"`
 	// Filter authentication domains by organization
-	OrganizationId OrganizationOrganizationIdInput `json:"organizationId,omitempty"`
+	OrganizationId *OrganizationOrganizationIdInput `json:"organizationId,omitempty"`
 }
 
 // OrganizationAuthenticationDomainSortInput - Sort key and direction for authentication domains


### PR DESCRIPTION
Currently they're not which means they are sent in the query and as a result the query always return 0 items even if they're there.

Note: I only need the first commit in this PR, but still pushed the rest of the tutone update.