### PR TITLE
feat(organization): Add organizationUpdateSharedAccount mutation.

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -1455,8 +1455,8 @@ packages:
 #        max_query_field_depth: 2
 #      - name: organizationRevokeSharedAccount
 #        max_query_field_depth: 2
-#      - name: organizationUpdateSharedAccount
-#        max_query_field_depth: 2
+      - name: organizationUpdateSharedAccount
+        max_query_field_depth: 2
     types:
       - name: OrganizationNewManagedAccountInput
         field_type_override: "*OrganizationNewManagedAccountInput"

--- a/pkg/organization/organization_api.go
+++ b/pkg/organization/organization_api.go
@@ -121,3 +121,51 @@ const OrganizationUpdateMutation = `mutation(
 		name
 	}
 } }`
+
+// The shared account to update
+func (a *Organization) OrganizationUpdateSharedAccount(
+	sharedAccount OrganizationUpdateSharedAccountInput,
+) (*OrganizationUpdateSharedAccountResponse, error) {
+	return a.OrganizationUpdateSharedAccountWithContext(context.Background(),
+		sharedAccount,
+	)
+}
+
+// The shared account to update
+func (a *Organization) OrganizationUpdateSharedAccountWithContext(
+	ctx context.Context,
+	sharedAccount OrganizationUpdateSharedAccountInput,
+) (*OrganizationUpdateSharedAccountResponse, error) {
+
+	resp := OrganizationUpdateSharedAccountQueryResponse{}
+	vars := map[string]interface{}{
+		"sharedAccount": sharedAccount,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, OrganizationUpdateSharedAccountMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.OrganizationUpdateSharedAccountResponse, nil
+}
+
+type OrganizationUpdateSharedAccountQueryResponse struct {
+	OrganizationUpdateSharedAccountResponse OrganizationUpdateSharedAccountResponse `json:"OrganizationUpdateSharedAccount"`
+}
+
+const OrganizationUpdateSharedAccountMutation = `mutation(
+	$sharedAccount: OrganizationUpdateSharedAccountInput!,
+) { organizationUpdateSharedAccount(
+	sharedAccount: $sharedAccount,
+) {
+	sharedAccount {
+		accountId
+		id
+		limitingRoleId
+		name
+		sourceOrganizationId
+		sourceOrganizationName
+		targetOrganizationId
+		targetOrganizationName
+	}
+} }`

--- a/pkg/organization/organization_integration_test.go
+++ b/pkg/organization/organization_integration_test.go
@@ -5,8 +5,9 @@ import (
 	"regexp"
 	"testing"
 
-	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
+
+	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestIntegrationOrganizationCreate_CustomerIdNotFoundError(t *testing.T) {

--- a/pkg/organization/organization_test.go
+++ b/pkg/organization/organization_test.go
@@ -26,6 +26,9 @@ var (
 	unitTestMockOrganizationOneName     = "Mock Organization One"
 	unitTestMockOrganizationOneId       = "e1fe1ff8-0032-43d5-935f-caf47567a71d"
 
+	unitTestMockAccountOneId   = 123456
+	unitTestMockLimitingRoleId = 1000
+
 	organizationNameUpdated = "Virtuoso / OaC Organization"
 	organizationId          = os.Getenv("INTEGRATION_TESTING_NEW_RELIC_ORGANIZATION_ID")
 )

--- a/pkg/organization/organization_unit_test.go
+++ b/pkg/organization/organization_unit_test.go
@@ -1,6 +1,7 @@
 package organization
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -22,6 +23,21 @@ var (
 				"organizationInformation":  {
 					"id":  "` + unitTestMockOrganizationOneId + `",
 					"name":  "` + unitTestMockOrganizationOneName + `"
+				}
+			}
+		}
+	}`
+
+	testUpdateSharedAccountResponseJSON = `{
+		"data":  {
+			"organizationUpdateSharedAccount":  {
+				"sharedAccount":  {
+					"accountId":  ` + fmt.Sprint(unitTestMockAccountOneId) + `,
+					"id":  "` + unitTestMockOrganizationOneId + `",
+					"limitingRoleId":  ` + fmt.Sprint(unitTestMockLimitingRoleId) + `,
+					"name":  "` + unitTestMockOrganizationOneName + `",
+					"sourceOrganizationId":  "` + unitTestMockOrganizationOneId + `",
+					"sourceOrganizationName":  "` + unitTestMockOrganizationOneName + `"
 				}
 			}
 		}
@@ -70,6 +86,34 @@ func TestUnitUpdateOrganization(t *testing.T) {
 			Name: unitTestMockOrganizationOneName,
 		},
 		unitTestMockOrganizationOneId,
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestUnitOrganizationUpdateSharedAccount(t *testing.T) {
+	t.Parallel()
+
+	organization := newMockResponse(t, testUpdateSharedAccountResponseJSON, http.StatusOK)
+
+	expected := &OrganizationUpdateSharedAccountResponse{
+		SharedAccount: OrganizationSharedAccount{
+			AccountID:              unitTestMockAccountOneId,
+			ID:                     unitTestMockOrganizationOneId,
+			LimitingRoleId:         unitTestMockLimitingRoleId,
+			Name:                   unitTestMockOrganizationOneName,
+			SourceOrganizationId:   unitTestMockOrganizationOneId,
+			SourceOrganizationName: unitTestMockOrganizationOneName,
+		},
+	}
+
+	actual, err := organization.OrganizationUpdateSharedAccount(
+		OrganizationUpdateSharedAccountInput{
+			ID:             fmt.Sprint(unitTestMockAccountOneId),
+			LimitingRoleId: unitTestMockLimitingRoleId,
+		},
 	)
 
 	assert.NoError(t, err)


### PR DESCRIPTION
Hi!

We need this mutation for the project we're implementing this so adding it as PR.

Thanks!

_____

#### Maintainer's Note (for New Relic Internal Reviewers)
This change **does not** affect the New Relic Terraform Provider if consumed, since the `organization` package is not yet used there (as on 24 May, 2024).