### PR TITLE
fix(infra): Discard the infra test api call to prevent timeout issues

### DIFF
--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -128,7 +128,7 @@ func (nr *NewRelic) SetLogLevel(levelName string) {
 // TestEndpoints makes a few calls to determine if the NewRelic enpoints are reachable.
 func (nr *NewRelic) TestEndpoints() error {
 	endpoints := []string{
-		nr.config.Region().InfrastructureURL(),
+		//	nr.config.Region().InfrastructureURL(),
 		nr.config.Region().LogsURL(),
 		nr.config.Region().NerdGraphURL(),
 		nr.config.Region().RestURL(),


### PR DESCRIPTION
JIRA - https://new-relic.atlassian.net/browse/NR-270753

This PR aims to address the below timeout issue for few customers as it appears CLI is performing few [test calls ](https://github.com/newrelic/newrelic-cli/blob/53c2d81b257fe874d86c4a0b97b14489d9e7cd99/internal/install/command.go#L178)to verify if the New Relic endpoints are reachable and this infra-alert.service is being invoked during this specific [call](https://github.com/newrelic/newrelic-client-go/blob/0e073a6f00c54832713063f6e37222759337ff41/pkg/region/region_constants.go#L27).

FATAL Get "https://login.newrelic.com/login?return_to=https%3A%2F%2Finfrastructure-alert.service.newrelic.com%2Fv2": dial tcp 18.188.220.94:443: i/o timeout