### PR TITLE
chore(entities): add missing reference to `GetTags()` in `interface_methods` of `EntityOutline`

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -765,6 +765,7 @@ packages:
           - "GetDomain() string"
           - "GetGUID() common.EntityGUID"
           - "GetName() string"
+          - "GetTags() []EntityTag"
           - "GetType() string"
 
 


### PR DESCRIPTION
In #1146, a new method `GetTags()` was added to the interface `EntityOutlineInterface`. 

This was supposed to be a change automated via Tutone, via the addition of `GetTags()` to the attribute `interface_methods` under `EntityOutline` similar to #595, however, the relevant commit which included changes to `.tutone.yml` went missing.

This PR is an attempt to add this capability back to Tutone, to prevent diffs generated because of the absence of `GetTags()` in `interface_methods` of `EntityOutline`.