### PR TITLE
feat(alerts): add support for `ignoreOnExpectedTermination` in `expiration` to NRQL alert conditions

### DIFF
--- a/pkg/alerts/nrql_conditions.go
+++ b/pkg/alerts/nrql_conditions.go
@@ -16,6 +16,7 @@ type AlertsNrqlConditionExpiration struct {
 	ExpirationDuration          *int `json:"expirationDuration"`
 	CloseViolationsOnExpiration bool `json:"closeViolationsOnExpiration"`
 	OpenViolationOnExpiration   bool `json:"openViolationOnExpiration"`
+	IgnoreOnExpectedTermination bool `json:"ignoreOnExpectedTermination"`
 }
 
 // AlertsNrqlConditionSignal - Configuration that defines the signal that the NRQL condition will use to evaluate.
@@ -735,6 +736,7 @@ const (
       closeViolationsOnExpiration
       expirationDuration
       openViolationOnExpiration
+	  ignoreOnExpectedTermination
     }
     signal {
 	  aggregationWindow


### PR DESCRIPTION
### Summary
https://new-relic.atlassian.net/browse/NR-270141
This PR includes changes to support the usage of a new field with baseline/static NRQL alert conditions, `ignoreOnExpectedTermination`. This field is expected to be live on production soon, in queries and mutations which manage baseline/static NRQL alert conditions (the `expiration` field in these queries and mutations has been updated to contain `ignoreOnExpectedTermination`). Examples of some of these mutations and queries have been depicted below.

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/dec61392-3aec-4c8f-b1db-95b5e1abb56e">


### PR with Terraform Provider changes
https://github.com/newrelic/terraform-provider-newrelic/pull/2700