### PR TITLE
chore(entities): fix drift with browserapplication properties from entities package

### DIFF
--- a/pkg/entities/entities_api.go
+++ b/pkg/entities/entities_api.go
@@ -2105,7 +2105,21 @@ const getEntityQuery = `query(
 				apdexTarget
 			}
 			browserMonitoring {
+				ajax {
+					denyList
+				}
+				distributedTracing {
+					allowedOrigins
+					corsEnabled
+					corsUseNewrelicHeader
+					corsUseTracecontextHeaders
+					enabled
+					excludeNewrelicHeader
+				}
 				loader
+				privacy {
+					cookiesEnabled
+				}
 				pinnedVersion
 			}
 			sessionReplay {

--- a/pkg/entities/types.go
+++ b/pkg/entities/types.go
@@ -2728,6 +2728,8 @@ type AiWorkflowsDestinationConfiguration struct {
 	NotificationTriggers []AiWorkflowsNotificationTrigger `json:"notificationTriggers"`
 	// Type of the Destination Configuration
 	Type AiWorkflowsDestinationType `json:"type"`
+	// Update original notification message (Slack channels only)
+	UpdateOriginalMessage bool `json:"updateOriginalMessage,omitempty"`
 }
 
 // AiWorkflowsEnrichment - Makes it possible to augment the notification with additional data from the New Relic platform


### PR DESCRIPTION
#### Background

With #1171 merged, the `entities` package was cleaned up and the team has been running tests in the New Relic Terraform Provieder with the latest version comprising #1171 (v2.39.1 of the New Relic Go Client) to make sure nothing's broken and everything's running fine.

A tiny little glitch was found in one of these Terraform integration tests run on https://github.com/newrelic/terraform-provider-newrelic/pull/2708.

<img width="1242" alt="image" src="https://github.com/newrelic/newrelic-client-go/assets/127438038/7050fefb-c085-4f52-9407-784bb147513f">

Upon further investigation, the cause was found. [This block of code](https://github.com/newrelic/newrelic-client-go/commit/a785453d47562e1bc4747ca36f619f53a9835922#r143811903), which may have been manually added (owing to the issues we faced earlier with the entities package in Tutone) kinda got wiped away by our cleanup PR #1171, though we did change the depth of the `entity` query to 3 - it looks like we need greater depth to get these missing attributes.

However, to save time on the immediate release of the Terraform Provider we ought to do for an NRQL alert condition PR, I shall be adding this code change manually, and once the release is done, in the next few days, I shall create a PR to change the `entity` query to use depth 4.

You may see in the following screenshot that the failing tests's configuration now works fine after this manual addition.

<img width="1020" alt="image" src="https://github.com/newrelic/newrelic-client-go/assets/127438038/06756bb3-867b-493f-bfdb-df76cfabb252">

<img width="1161" alt="image" src="https://github.com/newrelic/newrelic-client-go/assets/127438038/efdbab47-431b-447b-a089-59a3acc022be">
