### PR TITLE
test(entity_tags): added test cases to test reserved key mutations on entity tags

### DIFF
--- a/pkg/entities/tags_integration_test.go
+++ b/pkg/entities/tags_integration_test.go
@@ -72,7 +72,7 @@ func TestIntegrationTaggingAddTagsToEntityAndGetTags(t *testing.T) {
 	result, err = client.TaggingAddTagsToEntity(testGUID, tags)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Greater(t, 0, len(result.Errors))
+	require.Greater(t, len(result.Errors), 0)
 	message := result.Errors[0].Message
 	match, er := regexp.MatchString("reversed", message)
 	require.NoError(t, er)
@@ -110,7 +110,7 @@ func TestIntegrationTaggingReplaceTagsOnEntity(t *testing.T) {
 	result, err = client.TaggingReplaceTagsOnEntity(testGUID, tags)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Greater(t, 0, len(result.Errors))
+	require.Greater(t, len(result.Errors), 0)
 	message := result.Errors[0].Message
 	match, er := regexp.MatchString("reversed", message)
 	require.NoError(t, er)

--- a/pkg/entities/tags_integration_test.go
+++ b/pkg/entities/tags_integration_test.go
@@ -74,8 +74,8 @@ func TestIntegrationTaggingAddTagsToEntityAndGetTags(t *testing.T) {
 	require.NotNil(t, result)
 	require.Greater(t, 0, len(result.Errors))
 	message := result.Errors[0].Message
-	match, err = regexp.MatchString("reversed", message)
-	require.NoError(t, err)
+	match, er := regexp.MatchString("reversed", message)
+	require.NoError(t, er)
 	require.True(t, match)
 }
 
@@ -112,8 +112,8 @@ func TestIntegrationTaggingReplaceTagsOnEntity(t *testing.T) {
 	require.NotNil(t, result)
 	require.Greater(t, 0, len(result.Errors))
 	message := result.Errors[0].Message
-	match, err = regexp.MatchString("reversed", message)
-	require.NoError(t, err)
+	match, er := regexp.MatchString("reversed", message)
+	require.NoError(t, er)
 	require.True(t, match)
 }
 

--- a/pkg/entities/tags_integration_test.go
+++ b/pkg/entities/tags_integration_test.go
@@ -4,9 +4,9 @@
 package entities
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/require"
+	"regexp"
+	"testing"
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
@@ -61,6 +61,22 @@ func TestIntegrationTaggingAddTagsToEntityAndGetTags(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Greater(t, len(actual), 0)
+
+	//Test: To add a reversed key(immutable keys)
+	tags = []TaggingTagInput{
+		{
+			Key:    "account",
+			Values: []string{"Random-name"},
+		},
+	}
+	result, err = client.TaggingAddTagsToEntity(testGUID, tags)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Greater(t, 0, len(result.Errors))
+	message := result.Errors[0].Message
+	match, err = regexp.MatchString("reversed", message)
+	require.NoError(t, err)
+	require.True(t, match)
 }
 
 func TestIntegrationTaggingReplaceTagsOnEntity(t *testing.T) {
@@ -83,6 +99,22 @@ func TestIntegrationTaggingReplaceTagsOnEntity(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, 0, len(result.Errors))
+
+	//Test: To update a reversed key(immutable keys)
+	tags = []TaggingTagInput{
+		{
+			Key:    "account",
+			Values: []string{"Random-name"},
+		},
+	}
+	result, err = client.TaggingReplaceTagsOnEntity(testGUID, tags)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Greater(t, 0, len(result.Errors))
+	message := result.Errors[0].Message
+	match, err = regexp.MatchString("reversed", message)
+	require.NoError(t, err)
+	require.True(t, match)
 }
 
 func TestIntegrationDeleteTags(t *testing.T) {

--- a/pkg/entities/tags_integration_test.go
+++ b/pkg/entities/tags_integration_test.go
@@ -62,21 +62,6 @@ func TestIntegrationTaggingAddTagsToEntityAndGetTags(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, len(actual), 0)
 
-	//Test: To add a reversed key(immutable keys)
-	tags = []TaggingTagInput{
-		{
-			Key:    "account",
-			Values: []string{"Random-name"},
-		},
-	}
-	result, err = client.TaggingAddTagsToEntity(testGUID, tags)
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Greater(t, len(result.Errors), 0)
-	message := result.Errors[0].Message
-	match, er := regexp.MatchString("reserved", message)
-	require.NoError(t, er)
-	require.True(t, match)
 }
 
 func TestIntegrationTaggingReplaceTagsOnEntity(t *testing.T) {
@@ -100,21 +85,6 @@ func TestIntegrationTaggingReplaceTagsOnEntity(t *testing.T) {
 	require.NotNil(t, result)
 	require.Equal(t, 0, len(result.Errors))
 
-	//Test: To update a reversed key(immutable keys)
-	tags = []TaggingTagInput{
-		{
-			Key:    "account",
-			Values: []string{"Random-name"},
-		},
-	}
-	result, err = client.TaggingReplaceTagsOnEntity(testGUID, tags)
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Greater(t, len(result.Errors), 0)
-	message := result.Errors[0].Message
-	match, er := regexp.MatchString("reserved", message)
-	require.NoError(t, er)
-	require.True(t, match)
 }
 
 func TestIntegrationDeleteTags(t *testing.T) {
@@ -154,4 +124,40 @@ func TestIntegrationDeleteTagValues(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, 0, len(result.Errors))
+}
+
+func TestIntegrationEntityTagsReservedKeysMutation(t *testing.T) {
+	t.Parallel()
+
+	var (
+		testGUID = common.EntityGUID(testhelpers.IntegrationTestApplicationEntityGUID)
+	)
+
+	client := newIntegrationTestClient(t)
+
+	// Test: To add a reserved key(immutable key)
+	tags := []TaggingTagInput{
+		{
+			Key:    "account",
+			Values: []string{"Random-name"},
+		},
+	}
+	result, err := client.TaggingAddTagsToEntity(testGUID, tags)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Greater(t, len(result.Errors), 0)
+	message := result.Errors[0].Message
+	match, er := regexp.MatchString("reserved", message)
+	require.NoError(t, er)
+	require.True(t, match)
+
+	// Test: To update a reserved key(immutable key)
+	result, err = client.TaggingReplaceTagsOnEntity(testGUID, tags)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Greater(t, len(result.Errors), 0)
+	message = result.Errors[0].Message
+	match, er = regexp.MatchString("reserved", message)
+	require.NoError(t, er)
+	require.True(t, match)
 }

--- a/pkg/entities/tags_integration_test.go
+++ b/pkg/entities/tags_integration_test.go
@@ -74,7 +74,7 @@ func TestIntegrationTaggingAddTagsToEntityAndGetTags(t *testing.T) {
 	require.NotNil(t, result)
 	require.Greater(t, len(result.Errors), 0)
 	message := result.Errors[0].Message
-	match, er := regexp.MatchString("reversed", message)
+	match, er := regexp.MatchString("reserved", message)
 	require.NoError(t, er)
 	require.True(t, match)
 }
@@ -112,7 +112,7 @@ func TestIntegrationTaggingReplaceTagsOnEntity(t *testing.T) {
 	require.NotNil(t, result)
 	require.Greater(t, len(result.Errors), 0)
 	message := result.Errors[0].Message
-	match, er := regexp.MatchString("reversed", message)
+	match, er := regexp.MatchString("reserved", message)
 	require.NoError(t, er)
 	require.True(t, match)
 }


### PR DESCRIPTION
This PR has changes related to adding test cases to test reversed key mutations on entity tags. The main purpose of these test cases is to check whether NerdGraph is returning correct error messages or not when a user tries to mutate reserved keys (immutable keys), e.g., "account" and "accountId".

- This PR is part of part of this ticket: https://new-relic.atlassian.net/browse/NR-273648

- The terraform changes are part of this PR: https://github.com/newrelic/terraform-provider-newrelic/pull/2710