### PR TITLE
fix(dashboard): update line and table widget threshold `to` and `from` fields datatype from `int` to `float64`

### DIFF
--- a/pkg/dashboards/type_overrides.go
+++ b/pkg/dashboards/type_overrides.go
@@ -16,15 +16,15 @@ type DashboardLineWidgetThresholdInput struct {
 }
 
 type DashboardLineWidgetThresholdThresholdInput struct {
-	From     *int                                   `json:"from,omitempty"`
-	To       *int                                   `json:"to,omitempty"`
+	From     *float64                               `json:"from,omitempty"`
+	To       *float64                               `json:"to,omitempty"`
 	Name     string                                 `json:"name,omitempty"`
 	Severity DashboardLineTableWidgetsAlertSeverity `json:"severity,omitempty"`
 }
 
 type DashboardTableWidgetThresholdInput struct {
-	From       *int                                   `json:"from,omitempty"`
-	To         *int                                   `json:"to,omitempty"`
+	From       *float64                               `json:"from,omitempty"`
+	To         *float64                               `json:"to,omitempty"`
 	ColumnName string                                 `json:"columnName,omitempty"`
 	Severity   DashboardLineTableWidgetsAlertSeverity `json:"severity,omitempty"`
 }


### PR DESCRIPTION
This PR include fix for updating the datatype for "to" and "from" fields in threshold attribute for Table and Line widget in newrelic_one_dashboard.
This is done as a part to fix this [#2703](https://github.com/newrelic/terraform-provider-newrelic/issues/2703) GitHub issue, fixed in PR [#2713](https://github.com/newrelic/terraform-provider-newrelic/issues/2713) in the Terraform Provider's repository.
[Jira Story](https://new-relic.atlassian.net/browse/NR-288587)
