### PR TITLE
feat(synthetics): Added support for Synthetics Multi Browser, Multi Devices attributes in few synthetics APIs

### DIFF
--- a/pkg/synthetics/synthetics_api.go
+++ b/pkg/synthetics/synthetics_api.go
@@ -582,7 +582,9 @@ const SyntheticsCreateScriptBrowserMonitorMutation = `mutation(
 		advancedOptions {
 			enableScreenshotOnFailureAndScript
 		}
+		browsers
 		createdAt
+		devices
 		guid
 		id
 		locations {
@@ -724,7 +726,9 @@ const SyntheticsCreateSimpleBrowserMonitorMutation = `mutation(
 			responseValidationText
 			useTlsValidation
 		}
+		browsers
 		createdAt
+		devices
 		guid
 		id
 		locations {
@@ -796,7 +800,9 @@ const SyntheticsCreateSimpleMonitorMutation = `mutation(
 			responseValidationText
 			useTlsValidation
 		}
+		browsers
 		createdAt
+		devices
 		guid
 		id
 		locations {
@@ -866,7 +872,9 @@ const SyntheticsCreateStepMonitorMutation = `mutation(
 		advancedOptions {
 			enableScreenshotOnFailureAndScript
 		}
+		browsers
 		createdAt
+		devices
 		guid
 		id
 		locations {
@@ -1647,7 +1655,9 @@ const SyntheticsUpdateScriptBrowserMonitorMutation = `mutation(
 		advancedOptions {
 			enableScreenshotOnFailureAndScript
 		}
+		browsers
 		createdAt
+		devices
 		guid
 		id
 		locations {
@@ -1789,7 +1799,9 @@ const SyntheticsUpdateSimpleBrowserMonitorMutation = `mutation(
 			responseValidationText
 			useTlsValidation
 		}
+		browsers
 		createdAt
+		devices
 		guid
 		id
 		locations {
@@ -1927,7 +1939,9 @@ const SyntheticsUpdateStepMonitorMutation = `mutation(
 		advancedOptions {
 			enableScreenshotOnFailureAndScript
 		}
+		browsers
 		createdAt
+		devices
 		guid
 		id
 		locations {

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -119,6 +119,60 @@ var SyntheticsAutomatedTestStatusTypes = struct {
 	TIMEOUT: "TIMEOUT",
 }
 
+// SyntheticsBrowser - Enum of browser types
+type SyntheticsBrowser string
+
+var SyntheticsBrowserTypes = struct {
+	// Chrome browser
+	CHROME SyntheticsBrowser
+	// Edge browser
+	EDGE SyntheticsBrowser
+	// Firefox browser
+	FIREFOX SyntheticsBrowser
+	// No Browser/Legacy
+	NONE SyntheticsBrowser
+}{
+	// Chrome browser
+	CHROME: "CHROME",
+	// Edge browser
+	EDGE: "EDGE",
+	// Firefox browser
+	FIREFOX: "FIREFOX",
+	// No Browser/Legacy
+	NONE: "NONE",
+}
+
+// SyntheticsDevice - enum for DeviceEmulation
+type SyntheticsDevice string
+
+var SyntheticsDeviceTypes = struct {
+	// deviceType: DESKTOP, deviceOrientation: NONE
+	DESKTOP SyntheticsDevice
+	// deviceType: MOBILE, deviceOrientation: LANDSCAPE
+	MOBILE_LANDSCAPE SyntheticsDevice
+	// deviceType: MOBILE, deviceOrientation: PORTRAIT
+	MOBILE_PORTRAIT SyntheticsDevice
+	// No Device Settings
+	NONE SyntheticsDevice
+	// deviceType: TABLET, deviceOrientation: LANDSCAPE
+	TABLET_LANDSCAPE SyntheticsDevice
+	// deviceType: TABLET, deviceOrientation: PORTRAIT
+	TABLET_PORTRAIT SyntheticsDevice
+}{
+	// deviceType: DESKTOP, deviceOrientation: NONE
+	DESKTOP: "DESKTOP",
+	// deviceType: MOBILE, deviceOrientation: LANDSCAPE
+	MOBILE_LANDSCAPE: "MOBILE_LANDSCAPE",
+	// deviceType: MOBILE, deviceOrientation: PORTRAIT
+	MOBILE_PORTRAIT: "MOBILE_PORTRAIT",
+	// No Device Settings
+	NONE: "NONE",
+	// deviceType: TABLET, deviceOrientation: LANDSCAPE
+	TABLET_LANDSCAPE: "TABLET_LANDSCAPE",
+	// deviceType: TABLET, deviceOrientation: PORTRAIT
+	TABLET_PORTRAIT: "TABLET_PORTRAIT",
+}
+
 // SyntheticsDeviceOrientation - enum of Orientations that the user can select for their emulated device
 type SyntheticsDeviceOrientation string
 
@@ -935,6 +989,10 @@ type SyntheticsCreateScriptBrowserMonitorInput struct {
 	AdvancedOptions SyntheticsScriptBrowserMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
 	// The monitor's Apdex target used to populate SLA reports
 	ApdexTarget float64 `json:"apdexTarget,omitempty"`
+	// The browser(s) that the monitor will use to run jobs
+	Browsers []SyntheticsBrowser `json:"browsers,omitempty"`
+	// The devices that the monitor will use to run jobs
+	Devices []SyntheticsDevice `json:"devices,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsScriptedMonitorLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -957,6 +1015,10 @@ type SyntheticsCreateSimpleBrowserMonitorInput struct {
 	AdvancedOptions SyntheticsSimpleBrowserMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
 	// The monitor's Apdex target used to populate SLA reports
 	ApdexTarget float64 `json:"apdexTarget,omitempty"`
+	// The browser(s) that the monitor will use to run jobs
+	Browsers []SyntheticsBrowser `json:"browsers,omitempty"`
+	// The devices that the monitor will use to run jobs
+	Devices []SyntheticsDevice `json:"devices,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -999,6 +1061,10 @@ type SyntheticsCreateStepMonitorInput struct {
 	AdvancedOptions SyntheticsStepMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
 	// The monitor's Apdex target used to populate SLA reports
 	ApdexTarget float64 `json:"apdexTarget,omitempty"`
+	// The browser(s) that the monitor will use to run jobs
+	Browsers []SyntheticsBrowser `json:"browsers,omitempty"`
+	// The devices that the monitor will use to run jobs
+	Devices []SyntheticsDevice `json:"devices,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsScriptedMonitorLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -1083,7 +1149,7 @@ type SyntheticsDaysOfWeekOutput struct {
 	WeekDay SyntheticsMonitorDowntimeWeekDays `json:"weekDay,omitempty"`
 }
 
-// SyntheticsDeviceEmulation - Information related to device emulation
+// SyntheticsDeviceEmulation - Information related to device emulation - will be deprecated soon
 type SyntheticsDeviceEmulation struct {
 	// The device orientation the user would like to represent
 	DeviceOrientation SyntheticsDeviceOrientation `json:"deviceOrientation"`
@@ -1415,8 +1481,12 @@ type SyntheticsScriptAPIMonitorUpdateMutationResult struct {
 type SyntheticsScriptBrowserMonitor struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsScriptBrowserMonitorAdvancedOptions `json:"advancedOptions,omitempty"`
+	// The browser(s) that the monitor will use to run jobs
+	Browsers []SyntheticsBrowser `json:"browsers,omitempty"`
 	// The creation time of the monitor in millis
 	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	// The devices that the monitor will use to run jobs
+	Devices []SyntheticsDevice `json:"devices,omitempty"`
 	// The unique client identifier for the Synthetics Monitor in New Relic
 	GUID EntityGUID `json:"guid,omitempty"`
 	// The unique identifier of the monitor within the Synthetics domain
@@ -1525,8 +1595,12 @@ type SyntheticsSecureCredentialOverrideInput struct {
 type SyntheticsSimpleBrowserMonitor struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsSimpleBrowserMonitorAdvancedOptions `json:"advancedOptions,omitempty"`
+	// The browser(s) that the monitor will use to run jobs
+	Browsers []SyntheticsBrowser `json:"browsers,omitempty"`
 	// The creation time of the monitor in millis
 	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	// The devices that the monitor will use to run jobs
+	Devices []SyntheticsDevice `json:"devices,omitempty"`
 	// The unique client identifier for the Synthetics Monitor in New Relic
 	GUID EntityGUID `json:"guid,omitempty"`
 	// The unique identifier of the monitor within the Synthetics domain
@@ -1675,8 +1749,12 @@ type SyntheticsStepInput struct {
 type SyntheticsStepMonitor struct {
 	// The monitor advanced options
 	AdvancedOptions SyntheticsStepMonitorAdvancedOptions `json:"advancedOptions,omitempty"`
+	// The browser(s) that the monitor will use to run jobs
+	Browsers []SyntheticsBrowser `json:"browsers,omitempty"`
 	// The creation time of the monitor in millis
 	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	// The devices that the monitor will use to run jobs
+	Devices []SyntheticsDevice `json:"devices,omitempty"`
 	// The unique client identifier for the Synthetics Monitor in New Relic
 	GUID EntityGUID `json:"guid,omitempty"`
 	// The unique identifier of the monitor within the Synthetics domain
@@ -1801,6 +1879,10 @@ type SyntheticsUpdateScriptBrowserMonitorInput struct {
 	AdvancedOptions SyntheticsScriptBrowserMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
 	// The monitor's Apdex target used to populate SLA reports
 	ApdexTarget float64 `json:"apdexTarget,omitempty"`
+	// The browser(s) that the monitor will use to run jobs
+	Browsers []SyntheticsBrowser `json:"browsers,omitempty"`
+	// The device(s) that the monitor will use to run jobs
+	Devices []SyntheticsDevice `json:"devices,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsScriptedMonitorLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -1823,6 +1905,10 @@ type SyntheticsUpdateSimpleBrowserMonitorInput struct {
 	AdvancedOptions SyntheticsSimpleBrowserMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
 	// The monitor's Apdex target used to populate SLA reports
 	ApdexTarget float64 `json:"apdexTarget,omitempty"`
+	// The browser(s) that the monitor will use to run jobs
+	Browsers []SyntheticsBrowser `json:"browsers,omitempty"`
+	// The devices that the monitor will use to run jobs
+	Devices []SyntheticsDevice `json:"devices,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor
@@ -1865,6 +1951,10 @@ type SyntheticsUpdateStepMonitorInput struct {
 	AdvancedOptions SyntheticsStepMonitorAdvancedOptionsInput `json:"advancedOptions,omitempty"`
 	// The monitor's Apdex target used to populate SLA reports
 	ApdexTarget float64 `json:"apdexTarget,omitempty"`
+	// The browser(s) that the monitor will use to run jobs
+	Browsers []SyntheticsBrowser `json:"browsers,omitempty"`
+	// The devices that the monitor will use to run jobs
+	Devices []SyntheticsDevice `json:"devices,omitempty"`
 	// The locations the monitor will run from
 	Locations SyntheticsScriptedMonitorLocationsInput `json:"locations,omitempty"`
 	// The human readable identifier for the monitor


### PR DESCRIPTION
### Background
Recently, Synthetics added a new feature for scripted, step, and simple browser monitors to support multiple browsers and devices, allowing users to choose from various options when running monitors. Until now, we only had the option of choosing one device combination. As per customer requests and Synthetics' requirements to support the same multi-browser/devices functionality in Terraform, So, support terraform changes we need changes in client-go as well. So, made below changes to support this.

### Changes
1: Ran tutone and generated synthetics package, which brought browsers, devices fileds.
2: Added integration test cases to validate browsers, devices fields.
3: Sross checked the changes tutone brought in and tested the changes related to these fields along with integration test cases as well.