### PR TITLE
fix: changing the default value for 'to' and 'from' in Table and line widget for newrelic_one_dashboard resource

### DIFF
--- a/pkg/dashboards/type_overrides.go
+++ b/pkg/dashboards/type_overrides.go
@@ -16,15 +16,15 @@ type DashboardLineWidgetThresholdInput struct {
 }
 
 type DashboardLineWidgetThresholdThresholdInput struct {
-	From     *float64                               `json:"from,omitempty"`
-	To       *float64                               `json:"to,omitempty"`
+	From     string                                 `json:"from,omitempty"`
+	To       string                                 `json:"to,omitempty"`
 	Name     string                                 `json:"name,omitempty"`
 	Severity DashboardLineTableWidgetsAlertSeverity `json:"severity,omitempty"`
 }
 
 type DashboardTableWidgetThresholdInput struct {
-	From       *float64                               `json:"from,omitempty"`
-	To         *float64                               `json:"to,omitempty"`
+	From       string                                 `json:"from,omitempty"`
+	To         string                                 `json:"to,omitempty"`
 	ColumnName string                                 `json:"columnName,omitempty"`
 	Severity   DashboardLineTableWidgetsAlertSeverity `json:"severity,omitempty"`
 }


### PR DESCRIPTION
changed the default values for 'to' and 'from' fields in threshold for table and line widget in dashboard.
This PR include update for these field type from float64 to string to omit these fields in nerdgraph request if these fields are not specified in the terraform configuration file. 