### PR TITLE
fix(synthetics): alter []SyntheticsCustomHeaderInput to allow empty custom headers in the request

### DIFF
--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -89,7 +89,7 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 		AdvancedOptions: SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &tv,
 			ResponseValidationText:             "SUCCESS",
-			CustomHeaders: []SyntheticsCustomHeaderInput{
+			CustomHeaders: &[]SyntheticsCustomHeaderInput{
 				{
 					Name:  "Monitor",
 					Value: "synthetics",
@@ -110,7 +110,7 @@ func TestSyntheticsSimpleBrowserMonitor_Basic(t *testing.T) {
 
 	simpleBrowserMonitorInputUpdated := SyntheticsUpdateSimpleBrowserMonitorInput{
 		AdvancedOptions: SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{
-			CustomHeaders: []SyntheticsCustomHeaderInput{
+			CustomHeaders: &[]SyntheticsCustomHeaderInput{
 				{
 					Name:  "Monitor",
 					Value: "Synthetics",
@@ -171,7 +171,7 @@ func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
 
 	simpleMonitorInput := SyntheticsCreateSimpleMonitorInput{
 		AdvancedOptions: SyntheticsSimpleMonitorAdvancedOptionsInput{
-			CustomHeaders: []SyntheticsCustomHeaderInput{
+			CustomHeaders: &[]SyntheticsCustomHeaderInput{
 				{
 					Name:  "Monitor",
 					Value: "Synthetics",
@@ -209,7 +209,7 @@ func TestSyntheticsSimpleMonitor_Basic(t *testing.T) {
 
 	simpleMonitorInputUpdated := SyntheticsUpdateSimpleMonitorInput{
 		AdvancedOptions: SyntheticsSimpleMonitorAdvancedOptionsInput{
-			CustomHeaders: []SyntheticsCustomHeaderInput{
+			CustomHeaders: &[]SyntheticsCustomHeaderInput{
 				{
 					Name:  "Monitors",
 					Value: "Synthetics",
@@ -1090,7 +1090,7 @@ func TestSyntheticsStartAutomatedTest_Basic(t *testing.T) {
 		AdvancedOptions: SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &tv,
 			ResponseValidationText:             "SUCCESS",
-			CustomHeaders: []SyntheticsCustomHeaderInput{
+			CustomHeaders: &[]SyntheticsCustomHeaderInput{
 				{
 					Name:  "Monitor",
 					Value: "synthetics",
@@ -1104,7 +1104,7 @@ func TestSyntheticsStartAutomatedTest_Basic(t *testing.T) {
 	monitorThreeName := fmt.Sprintf("%s-syntheticsStartAutomatedTest", generateSyntheticsEntityNameForIntegrationTest("MONITOR", false))
 	monitorThreeInput := SyntheticsCreateSimpleMonitorInput{
 		AdvancedOptions: SyntheticsSimpleMonitorAdvancedOptionsInput{
-			CustomHeaders: []SyntheticsCustomHeaderInput{
+			CustomHeaders: &[]SyntheticsCustomHeaderInput{
 				{
 					Name:  monitorThreeName,
 					Value: "Synthetics",

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -1564,7 +1564,7 @@ type SyntheticsSimpleBrowserMonitorAdvancedOptions struct {
 // SyntheticsSimpleBrowserMonitorAdvancedOptionsInput - The advanced options inputs available for a Simple Browser monitor
 type SyntheticsSimpleBrowserMonitorAdvancedOptionsInput struct {
 	// Custom headers to use in monitor job
-	CustomHeaders []SyntheticsCustomHeaderInput `json:"customHeaders,omitempty"`
+	CustomHeaders *[]SyntheticsCustomHeaderInput `json:"customHeaders,omitempty"`
 	// Emulate a device
 	DeviceEmulation *SyntheticsDeviceEmulationInput `json:"deviceEmulation,omitempty"`
 	// Capture a screenshot during job execution
@@ -1632,7 +1632,7 @@ type SyntheticsSimpleMonitorAdvancedOptions struct {
 // SyntheticsSimpleMonitorAdvancedOptionsInput - The advanced options inputs available for a Simple (ping) monitor
 type SyntheticsSimpleMonitorAdvancedOptionsInput struct {
 	// Custom headers to use in monitor job
-	CustomHeaders []SyntheticsCustomHeaderInput `json:"customHeaders,omitempty"`
+	CustomHeaders *[]SyntheticsCustomHeaderInput `json:"customHeaders,omitempty"`
 	// Categorize redirects during a monitor job as a failure
 	RedirectIsFailure *bool `json:"redirectIsFailure,omitempty"`
 	// Validation text for monitor to search for at given URI


### PR DESCRIPTION
Added the capability to delete all custom headers for simple/browser synthetic monitors.
changes as of this PR:
- updated the type of []SyntheticsCustomHeaderInput type to pointer.
- relevant changes to support this has been done in terraform provider PR [2725](https://github.com/newrelic/terraform-provider-newrelic/pull/2725)

Jira:  [NR-296277](https://new-relic.atlassian.net/browse/NR-296277)
 
 

[NR-296277]: https://new-relic.atlassian.net/browse/NR-296277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ