### PR TITLE
fix(browseragent): changing cookiesEnabled field to pointer type

### DIFF
--- a/pkg/agentapplications/agentapplications_integration_test.go
+++ b/pkg/agentapplications/agentapplications_integration_test.go
@@ -56,8 +56,9 @@ func TestIntegrationAgentApplicationBrowser_WithSettings(t *testing.T) {
 
 	client := newAgentApplicationIntegrationTestClient(t)
 	appName := testhelpers.GenerateRandomName(10)
+	cookiesEnabled := true
 	settings := AgentApplicationBrowserSettingsInput{
-		CookiesEnabled:            true,
+		CookiesEnabled:            &cookiesEnabled,
 		DistributedTracingEnabled: true,
 		LoaderType:                AgentApplicationBrowserLoaderTypes.LITE,
 	}
@@ -68,6 +69,7 @@ func TestIntegrationAgentApplicationBrowser_WithSettings(t *testing.T) {
 	require.NotNil(t, createResult)
 	require.Equal(t, appName, createResult.Name)
 
+	cookiesEnabled = false
 	// Update
 	updateSettings := AgentApplicationSettingsUpdateInput{
 		BrowserMonitoring: &AgentApplicationSettingsBrowserMonitoringInput{
@@ -76,7 +78,7 @@ func TestIntegrationAgentApplicationBrowser_WithSettings(t *testing.T) {
 				Enabled: false,
 			},
 			Privacy: &AgentApplicationSettingsBrowserPrivacyInput{
-				CookiesEnabled: false,
+				CookiesEnabled: &cookiesEnabled,
 			},
 		},
 	}
@@ -101,8 +103,9 @@ func TestIntegrationAgentApplicationBrowser_InvalidLoaderTypeInput(t *testing.T)
 
 	client := newAgentApplicationIntegrationTestClient(t)
 	appName := testhelpers.GenerateRandomName(10)
+	cookiesEnabled := true
 	settings := AgentApplicationBrowserSettingsInput{
-		CookiesEnabled:            true,
+		CookiesEnabled:            &cookiesEnabled,
 		DistributedTracingEnabled: true,
 		LoaderType:                AgentApplicationBrowserLoader("INVALID"),
 	}
@@ -128,9 +131,10 @@ func TestIntegrationAgentApplicationEnableAPMBrowser_Basic(t *testing.T) {
 func TestIntegrationAgentApplicationEnableAPMBrowser_WithSettings(t *testing.T) {
 	t.Parallel()
 
+	cookiesEnabled := true
 	client := newAgentApplicationIntegrationTestClient(t)
 	settings := AgentApplicationBrowserSettingsInput{
-		CookiesEnabled:            true,
+		CookiesEnabled:            &cookiesEnabled,
 		DistributedTracingEnabled: true,
 		LoaderType:                AgentApplicationBrowserLoaderTypes.PRO,
 	}

--- a/pkg/agentapplications/types.go
+++ b/pkg/agentapplications/types.go
@@ -229,7 +229,7 @@ type AgentApplicationBrowserSettings struct {
 // AgentApplicationBrowserSettingsInput - Configure additional browser settings here.
 type AgentApplicationBrowserSettingsInput struct {
 	// Configure cookies. The default is enabled: true.
-	CookiesEnabled bool `json:"cookiesEnabled,omitempty"`
+	CookiesEnabled *bool `json:"cookiesEnabled,omitempty"`
 	// Configure distributed tracing in browser apps. The default is enabled: true.
 	DistributedTracingEnabled bool `json:"distributedTracingEnabled,omitempty"`
 	// Determines which browser loader is configured. The default is "SPA".
@@ -395,7 +395,7 @@ type AgentApplicationSettingsBrowserPrivacy struct {
 // AgentApplicationSettingsBrowserPrivacyInput - Browser monitoring's page load timing feature can track sessions by using cookies that contain a simple session identifier.
 type AgentApplicationSettingsBrowserPrivacyInput struct {
 	// If enabled, enables cookies.
-	CookiesEnabled bool `json:"cookiesEnabled,omitempty"`
+	CookiesEnabled *bool `json:"cookiesEnabled,omitempty"`
 }
 
 // AgentApplicationSettingsBrowserProperties - General Properties related to browser applications.


### PR DESCRIPTION
Currently, if user send the value for `cookiesEnabled` as false for browser agent, that is currently being ignored, and the default value of true is being used. Fixed it by changing the boolean field to a pointer. 