### PR TITLE
fix(dashboard):  changing legend_enabled/legend field to pointer type

### DIFF
--- a/pkg/dashboards/dashboards_types.go
+++ b/pkg/dashboards/dashboards_types.go
@@ -323,7 +323,7 @@ type RawConfigurationPlatformOptions struct {
 }
 
 type DashboardWidgetLegend struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 type DashboardWidgetYAxisLeft struct {


### PR DESCRIPTION
Currently, if user send the value for legend_enabled as false while creating dashboards, that is currently being ignored, and the default value of true is being used. Fixed it by changing the boolean field to a pointer.

Fixes https://github.com/newrelic/terraform-provider-newrelic/issues/2736