### PR TITLE
fix(azure_link_account): add update capability for all fields in azure cloud link account 

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -475,6 +475,12 @@ packages:
         argument_type_overrides:
           accountId: "Int!"
           accounts: "[CloudUnlinkAccountsInput!]!"
+      - name: cloudUpdateAccount
+        max_query_field_depth: 3
+        exclude_fields:
+          - "integration"
+          - "integrations"
+          - "provider"
     types:
       #
       # Types that we should auto-detect are in another package someday

--- a/pkg/cloud/cloud_api.go
+++ b/pkg/cloud/cloud_api.go
@@ -1808,6 +1808,61 @@ const CloudUnlinkAccountMutation = `mutation(
 	}
 } }`
 
+// Update one or more Cloud Provider accounts to a NewRelic account. Updates each Linked account with the passed parameters.
+func (a *Cloud) CloudUpdateAccount(
+	accountID int,
+	accounts CloudUpdateCloudAccountsInput,
+) (*CloudUpdateAccountPayload, error) {
+	return a.CloudUpdateAccountWithContext(context.Background(),
+		accountID,
+		accounts,
+	)
+}
+
+// Update one or more Cloud Provider accounts to a NewRelic account. Updates each Linked account with the passed parameters.
+func (a *Cloud) CloudUpdateAccountWithContext(
+	ctx context.Context,
+	accountID int,
+	accounts CloudUpdateCloudAccountsInput,
+) (*CloudUpdateAccountPayload, error) {
+
+	resp := CloudUpdateAccountQueryResponse{}
+	vars := map[string]interface{}{
+		"accountId": accountID,
+		"accounts":  accounts,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, CloudUpdateAccountMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.CloudUpdateAccountPayload, nil
+}
+
+type CloudUpdateAccountQueryResponse struct {
+	CloudUpdateAccountPayload CloudUpdateAccountPayload `json:"CloudUpdateAccount"`
+}
+
+const CloudUpdateAccountMutation = `mutation(
+	$accountId: Int!,
+	$accounts: CloudUpdateCloudAccountsInput!,
+) { cloudUpdateAccount(
+	accountId: $accountId,
+	accounts: $accounts,
+) {
+	linkedAccounts {
+		authLabel
+		createdAt
+		disabled
+		externalId
+		id
+		metricCollectionMode
+		name
+		nrAccountId
+		updatedAt
+	}
+} }`
+
 // Get one linked provider account.
 func (a *Cloud) GetLinkedAccount(
 	accountID int,

--- a/pkg/cloud/cloud_api_integration_test.go
+++ b/pkg/cloud/cloud_api_integration_test.go
@@ -329,6 +329,22 @@ func TestCloudAccount_AzureMonitorIntegration(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, linkResponse)
+	//integration-test to test Azure link account update mutation
+	updateResponse, err := client.CloudUpdateAccount(testAccountID, CloudUpdateCloudAccountsInput{
+		Azure: []CloudAzureUpdateAccountInput{
+			{
+				Name:            "TEST_AZURE_ACCOUNT_UPDATED",
+				ApplicationID:   azureCredentials["INTEGRATION_TESTING_AZURE_APPLICATION_ID"],
+				ClientSecret:    SecureValue(azureCredentials["INTEGRATION_TESTING_AZURE_CLIENT_SECRET_ID"]),
+				SubscriptionId:  azureCredentials["INTEGRATION_TESTING_AZURE_SUBSCRIPTION_ID"],
+				TenantId:        azureCredentials["INTEGRATION_TESTING_AZURE_TENANT_ID"],
+				LinkedAccountId: linkResponse.LinkedAccounts[0].ID,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updateResponse)
+	require.Equal(t, "TEST_AZURE_ACCOUNT_UPDATED", updateResponse.LinkedAccounts[0].Name)
 
 	// Get the linked account
 	getResponse, err = client.GetLinkedAccounts("azure")

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -683,6 +683,22 @@ type CloudAwsGovCloudProvider struct {
 
 func (x *CloudAwsGovCloudProvider) ImplementsCloudProvider() {}
 
+// CloudAwsGovCloudUpdateAccountInput - Information required to update an AWS GovCloud account to a NewRelic account.
+type CloudAwsGovCloudUpdateAccountInput struct {
+	// The key used to make requests to AWS service APIs
+	AccessKeyId string `json:"accessKeyId,omitempty"`
+	// The AWS account id
+	AwsAccountId string `json:"awsAccountId,omitempty"`
+	// Disable the linked account.
+	Disabled bool `json:"disabled,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The linked account new name.
+	Name string `json:"name,omitempty"`
+	// The secret key used to make requests to AWS service APIs
+	SecretAccessKey SecureValue `json:"secretAccessKey,omitempty"`
+}
+
 // CloudAwsGovcloudDisableIntegrationsInput - List of integrations
 type CloudAwsGovcloudDisableIntegrationsInput struct {
 	// API Gateway integration
@@ -1403,6 +1419,18 @@ type CloudAwsTransitgatewayIntegrationInput struct {
 	LinkedAccountId int `json:"linkedAccountId"`
 	// The data polling interval in seconds.
 	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudAwsUpdateAccountInput - Information required to update a AWS account to a NewRelic account.
+type CloudAwsUpdateAccountInput struct {
+	// The AWS role ARN (used to fetch data).
+	Arn string `json:"arn,omitempty"`
+	// Disable the linked account.
+	Disabled bool `json:"disabled,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The linked account new name.
+	Name string `json:"name,omitempty"`
 }
 
 // CloudAwsWafIntegration - WAF Integration
@@ -2749,6 +2777,24 @@ type CloudAzureStorageIntegrationInput struct {
 	ResourceGroups []string `json:"resourceGroups,omitempty"`
 }
 
+// CloudAzureUpdateAccountInput - Information required to update a Azure account to a NewRelic account.
+type CloudAzureUpdateAccountInput struct {
+	// The Azure account application identifier (used to fetch data).
+	ApplicationID string `json:"applicationId,omitempty"`
+	// The Azure account application secret key.
+	ClientSecret SecureValue `json:"clientSecret,omitempty"`
+	// Disable the linked account.
+	Disabled *bool `json:"disabled,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The linked account new name.
+	Name string `json:"name,omitempty"`
+	// The Azure account subscription identifier.
+	SubscriptionId string `json:"subscriptionId,omitempty"`
+	// The Azure account tenant identifier.
+	TenantId string `json:"tenantId,omitempty"`
+}
+
 // CloudAzureVirtualmachineIntegration - Virtual machine scale sets Integration
 type CloudAzureVirtualmachineIntegration struct {
 	// The object creation date, in epoch (Unix) time
@@ -3118,6 +3164,22 @@ func (x *CloudConfigureIntegrationPayload) UnmarshalJSON(b []byte) error {
 	}
 
 	return nil
+}
+
+// CloudConfluentUpdateAccountInput - Information required to update a Confluent Cloud account to a NewRelic account.
+type CloudConfluentUpdateAccountInput struct {
+	// The Confluent account API key.
+	APIKey SecureValue `json:"apiKey"`
+	// The Confluent Cloud account API Secret key.
+	APISecret SecureValue `json:"apiSecret"`
+	// Disable the linked account.
+	Disabled bool `json:"disabled,omitempty"`
+	// The Confluent Cloud account identifier.
+	ExternalId string `json:"externalId,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The linked account new name.
+	Name string `json:"name,omitempty"`
 }
 
 // CloudDashboardTemplate - A cloud service dashboard template.
@@ -3711,6 +3773,20 @@ type CloudEmrIntegrationInput struct {
 	TagKey string `json:"tagKey,omitempty"`
 	// Specify a Tag value associated with the resources that you want to monitor. Filter values are case-sensitive.
 	TagValue string `json:"tagValue,omitempty"`
+}
+
+// CloudFossaUpdateAccountInput - Information required to update a Fossa account to a NewRelic account.
+type CloudFossaUpdateAccountInput struct {
+	// The Fossa account application api key(bearer token).
+	APIKey SecureValue `json:"apiKey"`
+	// Disable the linked account.
+	Disabled bool `json:"disabled,omitempty"`
+	// The Fossa account identifier.
+	ExternalId string `json:"externalId,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The linked account new name.
+	Name string `json:"name,omitempty"`
 }
 
 // CloudGcpAiplatformIntegration - Vertex AI Integration
@@ -4731,6 +4807,18 @@ type CloudGcpStorageIntegrationInput struct {
 	LinkedAccountId int `json:"linkedAccountId"`
 	// The data polling interval in seconds.
 	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudGcpUpdateAccountInput - Information required to update a GCP account to a NewRelic account.
+type CloudGcpUpdateAccountInput struct {
+	// Disable the linked account.
+	Disabled bool `json:"disabled,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The linked account new name.
+	Name string `json:"name,omitempty"`
+	// The GCP project identifier.
+	ProjectId string `json:"projectId,omitempty"`
 }
 
 // CloudGcpVmsIntegration - Compute Engine Integration
@@ -5778,6 +5866,28 @@ type CloudUnlinkAccountPayload struct {
 type CloudUnlinkAccountsInput struct {
 	// The linked account identifier.
 	LinkedAccountId int `json:"linkedAccountId"`
+}
+
+// CloudUpdateAccountPayload - Autogenerated return type of UpdateAccount
+type CloudUpdateAccountPayload struct {
+	// The updated Linked accounts.
+	LinkedAccounts []CloudLinkedAccount `json:"linkedAccounts"`
+}
+
+// CloudUpdateCloudAccountsInput - Specific Cloud provider information required to update the Cloud provider account to a NewRelic account.
+type CloudUpdateCloudAccountsInput struct {
+	// Aws provider
+	Aws []CloudAwsUpdateAccountInput `json:"aws,omitempty"`
+	// AwsGovCloud provider
+	AwsGovcloud []CloudAwsGovCloudUpdateAccountInput `json:"awsGovcloud,omitempty"`
+	// Azure provider
+	Azure []CloudAzureUpdateAccountInput `json:"azure,omitempty"`
+	// Confluent Cloud provider
+	Confluent []CloudConfluentUpdateAccountInput `json:"confluent,omitempty"`
+	// Fossa provider
+	Fossa []CloudFossaUpdateAccountInput `json:"fossa,omitempty"`
+	// Gcp provider
+	Gcp []CloudGcpUpdateAccountInput `json:"gcp,omitempty"`
 }
 
 // CloudVpcIntegration - VPC Integration


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed (if relevant).

earlier newrelic_azure_link_account resource was providing only renaming of the link account feature. This PR include changes which will allow users to update all the fields for the resource.
These changes are done as a part of this[ help request.](https://newrelic.slack.com/archives/CP9Q30JDC/p1725499613506239)

jira ticket: https://new-relic.atlassian.net/browse/NR-323227

Fixes # (issue)

Type of change
Please delete options that are not relevant.

 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 This change requires a documentation update
Checklist:
Please delete options that are not relevant.

 My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
 My code is formatted to [Go standards](https://go.dev/blog/gofmt)
 I have performed a self-review of my own code
 I have made corresponding changes to the documentation
 I have added tests that prove my fix is effective or that my feature works
 New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.