### PR TITLE
feat(alert_muting_rule): Add `action_on_muting_rule_window_ended` attribute in `newrelic_alert_muting_rule` Terraform Resource

### DIFF
--- a/pkg/alerts/muting_rules.go
+++ b/pkg/alerts/muting_rules.go
@@ -9,17 +9,18 @@ import (
 
 // MutingRule represents the alert suppression mechanism in the Alerts API.
 type MutingRule struct {
-	ID            int                      `json:"id,string,omitempty"`
-	AccountID     int                      `json:"accountId,omitempty"`
-	Condition     MutingRuleConditionGroup `json:"condition,omitempty"`
-	CreatedAt     string                   `json:"createdAt,omitempty"`
-	CreatedByUser ByUser                   `json:"createdByUser,omitempty"`
-	Description   string                   `json:"description,omitempty"`
-	Enabled       bool                     `json:"enabled"`
-	Name          string                   `json:"name,omitempty"`
-	UpdatedAt     string                   `json:"updatedAt,omitempty"`
-	UpdatedByUser ByUser                   `json:"updatedByUser,omitempty"`
-	Schedule      *MutingRuleSchedule      `json:"schedule,omitempty"`
+	ID                            int                                 `json:"id,string,omitempty"`
+	AccountID                     int                                 `json:"accountId,omitempty"`
+	Condition                     MutingRuleConditionGroup            `json:"condition,omitempty"`
+	CreatedAt                     string                              `json:"createdAt,omitempty"`
+	CreatedByUser                 ByUser                              `json:"createdByUser,omitempty"`
+	Description                   string                              `json:"description,omitempty"`
+	Enabled                       bool                                `json:"enabled"`
+	Name                          string                              `json:"name,omitempty"`
+	UpdatedAt                     string                              `json:"updatedAt,omitempty"`
+	UpdatedByUser                 ByUser                              `json:"updatedByUser,omitempty"`
+	Schedule                      *MutingRuleSchedule                 `json:"schedule,omitempty"`
+	ActionOnMutingRuleWindowEnded AlertsActionOnMutingRuleWindowEnded `json:"actionOnMutingRuleWindowEnded,omitempty"`
 }
 
 // ByUser is a collection of the user information that created or updated the muting rule.
@@ -133,11 +134,12 @@ type MutingRuleScheduleUpdateInput struct {
 
 // MutingRuleCreateInput is the input for creating muting rules.
 type MutingRuleCreateInput struct {
-	Condition   MutingRuleConditionGroup       `json:"condition"`
-	Description string                         `json:"description"`
-	Enabled     bool                           `json:"enabled"`
-	Name        string                         `json:"name"`
-	Schedule    *MutingRuleScheduleCreateInput `json:"schedule,omitempty"`
+	Condition                     MutingRuleConditionGroup            `json:"condition"`
+	Description                   string                              `json:"description"`
+	Enabled                       bool                                `json:"enabled"`
+	Name                          string                              `json:"name"`
+	Schedule                      *MutingRuleScheduleCreateInput      `json:"schedule,omitempty"`
+	ActionOnMutingRuleWindowEnded AlertsActionOnMutingRuleWindowEnded `json:"actionOnMutingRuleWindowEnded,omitempty"`
 }
 
 // MutingRuleUpdateInput is the input for updating a rule.
@@ -145,11 +147,12 @@ type MutingRuleUpdateInput struct {
 	// Condition is is available from the API, but the json needs to be handled
 	// properly.
 
-	Condition   *MutingRuleConditionGroup      `json:"condition,omitempty"`
-	Description string                         `json:"description,omitempty"`
-	Enabled     bool                           `json:"enabled"`
-	Name        string                         `json:"name,omitempty"`
-	Schedule    *MutingRuleScheduleUpdateInput `json:"schedule"`
+	Condition                     *MutingRuleConditionGroup           `json:"condition,omitempty"`
+	Description                   string                              `json:"description,omitempty"`
+	Enabled                       bool                                `json:"enabled"`
+	Name                          string                              `json:"name,omitempty"`
+	Schedule                      *MutingRuleScheduleUpdateInput      `json:"schedule"`
+	ActionOnMutingRuleWindowEnded AlertsActionOnMutingRuleWindowEnded `json:"actionOnMutingRuleWindowEnded,omitempty"`
 }
 
 // ListMutingRules queries for all muting rules in a given account.
@@ -356,12 +359,12 @@ const (
 			repeatCount
 			weeklyRepeatDays
 		}
+		actionOnMutingRuleWindowEnded
 	`
 
 	alertsMutingRulesCreate = `mutation CreateRule($accountID: Int!, $rule: AlertsMutingRuleInput!) {
 		alertsMutingRuleCreate(accountId: $accountID, rule: $rule) {` +
 		alertsMutingRuleFields +
-
 		`}
 	}`
 

--- a/pkg/alerts/muting_rules.go
+++ b/pkg/alerts/muting_rules.go
@@ -11,6 +11,7 @@ import (
 type MutingRule struct {
 	ID                            int                                 `json:"id,string,omitempty"`
 	AccountID                     int                                 `json:"accountId,omitempty"`
+	ActionOnMutingRuleWindowEnded AlertsActionOnMutingRuleWindowEnded `json:"actionOnMutingRuleWindowEnded,omitempty"`
 	Condition                     MutingRuleConditionGroup            `json:"condition,omitempty"`
 	CreatedAt                     string                              `json:"createdAt,omitempty"`
 	CreatedByUser                 ByUser                              `json:"createdByUser,omitempty"`
@@ -20,7 +21,6 @@ type MutingRule struct {
 	UpdatedAt                     string                              `json:"updatedAt,omitempty"`
 	UpdatedByUser                 ByUser                              `json:"updatedByUser,omitempty"`
 	Schedule                      *MutingRuleSchedule                 `json:"schedule,omitempty"`
-	ActionOnMutingRuleWindowEnded AlertsActionOnMutingRuleWindowEnded `json:"actionOnMutingRuleWindowEnded,omitempty"`
 }
 
 // ByUser is a collection of the user information that created or updated the muting rule.
@@ -134,25 +134,24 @@ type MutingRuleScheduleUpdateInput struct {
 
 // MutingRuleCreateInput is the input for creating muting rules.
 type MutingRuleCreateInput struct {
+	ActionOnMutingRuleWindowEnded AlertsActionOnMutingRuleWindowEnded `json:"actionOnMutingRuleWindowEnded,omitempty"`
 	Condition                     MutingRuleConditionGroup            `json:"condition"`
 	Description                   string                              `json:"description"`
 	Enabled                       bool                                `json:"enabled"`
 	Name                          string                              `json:"name"`
 	Schedule                      *MutingRuleScheduleCreateInput      `json:"schedule,omitempty"`
-	ActionOnMutingRuleWindowEnded AlertsActionOnMutingRuleWindowEnded `json:"actionOnMutingRuleWindowEnded,omitempty"`
 }
 
 // MutingRuleUpdateInput is the input for updating a rule.
 type MutingRuleUpdateInput struct {
 	// Condition is is available from the API, but the json needs to be handled
 	// properly.
-
+	ActionOnMutingRuleWindowEnded AlertsActionOnMutingRuleWindowEnded `json:"actionOnMutingRuleWindowEnded,omitempty"`
 	Condition                     *MutingRuleConditionGroup           `json:"condition,omitempty"`
 	Description                   string                              `json:"description,omitempty"`
 	Enabled                       bool                                `json:"enabled"`
 	Name                          string                              `json:"name,omitempty"`
 	Schedule                      *MutingRuleScheduleUpdateInput      `json:"schedule"`
-	ActionOnMutingRuleWindowEnded AlertsActionOnMutingRuleWindowEnded `json:"actionOnMutingRuleWindowEnded,omitempty"`
 }
 
 // ListMutingRules queries for all muting rules in a given account.
@@ -324,6 +323,7 @@ const (
 
 	alertsMutingRuleFields = `
 		accountId
+		actionOnMutingRuleWindowEnded
 		condition {
 			conditions {
 				attribute
@@ -359,7 +359,6 @@ const (
 			repeatCount
 			weeklyRepeatDays
 		}
-		actionOnMutingRuleWindowEnded
 	`
 
 	alertsMutingRulesCreate = `mutation CreateRule($accountID: Int!, $rule: AlertsMutingRuleInput!) {

--- a/pkg/alerts/muting_rules_test.go
+++ b/pkg/alerts/muting_rules_test.go
@@ -55,6 +55,7 @@ var (
 								"timeZone": "America/Los_Angeles",
 								"weeklyRepeatDays": null
 							},
+							"actionOnMutingRuleWindowEnded": "CLOSE_ISSUES_ON_INACTIVE",
 							"status": "INACTIVE",
 							"updatedAt": "2021-01-12T00:50:39.533Z",
 							"updatedByUser": {
@@ -117,7 +118,8 @@ var (
 							"gravatar": "https://secure.gravatar.com/avatar/692dc9742bd717014494f5093faff304",
 							"id": 1,
 							"name": "Test User"
-						}
+						},
+						"actionOnMutingRuleWindowEnded": "CLOSE_ISSUES_ON_INACTIVE"
 					}
 				}
 			}
@@ -168,7 +170,8 @@ var (
 				"gravatar": "https://secure.gravatar.com/avatar/692dc9742bd717014494f5093faff304",
 				"id": 1,
 				"name": "Test User"
-			}
+			},
+			"actionOnMutingRuleWindowEnded": "CLOSE_ISSUES_ON_INACTIVE"
 		}
 	}`
 
@@ -182,7 +185,8 @@ var (
 				"repeat": null,
 				"repeatCount": null,
 				"weeklyRepeatDays": null
-			}
+			},
+			"actionOnMutingRuleWindowEnded": "DO_NOTHING"
 		}
 	}`
 
@@ -248,6 +252,7 @@ func TestListMutingRules(t *testing.T) {
 				ID:       1,
 				Name:     "Test User",
 			},
+			ActionOnMutingRuleWindowEnded: "CLOSE_ISSUES_ON_INACTIVE",
 		},
 	}
 
@@ -313,6 +318,7 @@ func TestGetMutingRule(t *testing.T) {
 			ID:       1,
 			Name:     "Test User",
 		},
+		ActionOnMutingRuleWindowEnded: "CLOSE_ISSUES_ON_INACTIVE",
 	}
 
 	actual, err := alerts.GetMutingRule(accountID, ruleID)
@@ -376,6 +382,7 @@ func TestCreateMutingRule(t *testing.T) {
 			ID:       1,
 			Name:     "Test User",
 		},
+		ActionOnMutingRuleWindowEnded: "CLOSE_ISSUES_ON_INACTIVE",
 	}
 
 	actual, err := alerts.CreateMutingRule(accountID, MutingRuleCreateInput{})
@@ -407,6 +414,7 @@ func TestUpdateMutingRule(t *testing.T) {
 			EndRepeat: &endRepeat,
 			StartTime: &startTime,
 		},
+		ActionOnMutingRuleWindowEnded: "DO_NOTHING",
 	}
 
 	actual, err := alerts.UpdateMutingRule(accountID, ruleID, MutingRuleUpdateInput{})

--- a/pkg/alerts/types.go
+++ b/pkg/alerts/types.go
@@ -3,6 +3,21 @@ package alerts
 
 import "github.com/newrelic/newrelic-client-go/v2/pkg/nrtime"
 
+// AlertsActionOnMutingRuleWindowEnded - Configuration on the action when the muting rule window is ended or disabled
+type AlertsActionOnMutingRuleWindowEnded string
+
+var AlertsActionOnMutingRuleWindowEndedTypes = struct {
+	// Muting Rule closes issues when the muting rule window is ended or disabled to notify users.
+	CLOSE_ISSUES_ON_INACTIVE AlertsActionOnMutingRuleWindowEnded
+	// The currently opened issues will not be notified even if the muting rule window is ended or disabled.
+	DO_NOTHING AlertsActionOnMutingRuleWindowEnded
+}{
+	// Muting Rule closes issues when the muting rule window is ended or disabled to notify users.
+	CLOSE_ISSUES_ON_INACTIVE: "CLOSE_ISSUES_ON_INACTIVE",
+	// The currently opened issues will not be notified even if the muting rule window is ended or disabled.
+	DO_NOTHING: "DO_NOTHING",
+}
+
 // AlertsDayOfWeek - The day of the week used to configure a WEEKLY scheduled MutingRule
 type AlertsDayOfWeek string
 
@@ -221,6 +236,8 @@ type AlertsMutingRuleConditionInput struct {
 
 // AlertsMutingRuleInput - Input for creating MutingRules for New Relic Alerts Violations.
 type AlertsMutingRuleInput struct {
+	// The action when the muting rule window is ended or disabled.
+	ActionOnMutingRuleWindowEnded AlertsActionOnMutingRuleWindowEnded `json:"actionOnMutingRuleWindowEnded,omitempty"`
 	// The condition that defines which violations to target.
 	Condition AlertsMutingRuleConditionGroupInput `json:"condition,omitempty"`
 	// The description of the MutingRule.


### PR DESCRIPTION
## Description

- The addition of the `action_on_muting_rule_window_ended ` attribute in the `newrelic_alert_muting_rule` Terraform resource aims to enhance the functionality of muting rules within New Relic's alerting system using terraform.
- The attribute `actionOnMutingRuleWindowEnded` is added to MutingRule, MutingRuleCreateInput, and MutingRuleUpdateInput structs.
- Link to GitHub Issue: [https://github.com/newrelic/terraform-provider-newrelic/issues/2774](url)