### PR TITLE
feat(dashboard): add multiple account support for dashboard widgets n…

### DIFF
--- a/pkg/dashboards/dashboards_api_integration_test.go
+++ b/pkg/dashboards/dashboards_api_integration_test.go
@@ -187,7 +187,7 @@ func TestIntegrationDashboard_LinkedEntities(t *testing.T) {
 							Bar: &DashboardBarWidgetConfigurationInput{
 								NRQLQueries: []DashboardWidgetNRQLQueryInput{
 									{
-										AccountID: testAccountID,
+										AccountIDS: [testAccountID],
 										Query:     "FROM Transaction SELECT average(duration) FACET appName",
 									},
 								},
@@ -245,7 +245,7 @@ func TestIntegrationDashboard_InvalidInput(t *testing.T) {
 							Bar: &DashboardBarWidgetConfigurationInput{
 								NRQLQueries: []DashboardWidgetNRQLQueryInput{
 									{
-										AccountID: testAccountID,
+										AccountIDS: [testAccountID],
 										Query:     "This is bad NRQL input",
 									},
 								},

--- a/pkg/dashboards/dashboards_widgets_integration_test.go
+++ b/pkg/dashboards/dashboards_widgets_integration_test.go
@@ -40,7 +40,7 @@ func TestIntegrationDashboard_Billboard(t *testing.T) {
 							Billboard: &DashboardBillboardWidgetConfigurationInput{
 								NRQLQueries: []DashboardWidgetNRQLQueryInput{
 									{
-										AccountID: testAccountID,
+										AccountIDS: [testAccountID],
 										Query:     "FROM Metric SELECT 1",
 									},
 								},
@@ -99,7 +99,7 @@ func TestIntegrationDashboard_Billboard(t *testing.T) {
 							Billboard: &DashboardBillboardWidgetConfigurationInput{
 								NRQLQueries: []DashboardWidgetNRQLQueryInput{
 									{
-										AccountID: testAccountID,
+										AccountIDS: [testAccountID],
 										Query:     "FROM Metric SELECT 1",
 									},
 								},
@@ -206,7 +206,7 @@ func TestIntegrationDashboard_EmptyPage(t *testing.T) {
 							Billboard: &DashboardBillboardWidgetConfigurationInput{
 								NRQLQueries: []DashboardWidgetNRQLQueryInput{
 									{
-										AccountID: testAccountID,
+										AccountIDS: [testAccountID],
 										Query:     "FROM Metric SELECT 1",
 									},
 								},

--- a/pkg/dashboards/types.go
+++ b/pkg/dashboards/types.go
@@ -572,7 +572,7 @@ type DashboardWidgetLayoutInput struct {
 // DashboardWidgetNRQLQueryInput - NRQL query used by a widget.
 type DashboardWidgetNRQLQueryInput struct {
 	// New Relic account ID to issue the query against.
-	AccountID int `json:"accountId"`
+	AccountIDS []int `json:"accountIds"`
 	// NRQL formatted query.
 	Query nrdb.NRQL `json:"query"`
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed (if relevant).
Added multiple account_ids field instead of account_id field to support for multiple account id selection for dashboard nrql block in widget.
Jira story: https://new-relic.atlassian.net/browse/NR-343906

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

-Add a list of multiple accountIds in the account_ids field for nrql block of dashboard widget.
- perform a terraform apply
- in UI the multi-account should be selected with multiple account selected.