### PR TITLE
feat: Add SignalSeasonality support

### DIFF
--- a/pkg/alerts/nrql_conditions.go
+++ b/pkg/alerts/nrql_conditions.go
@@ -203,6 +203,23 @@ var (
 	}
 )
 
+type NrqlSignalSeasonality string
+
+var (
+	// NrqlSignalSeasonalities enumerates the possible signal seasonality values for a baseline NRQL alert condition.
+	NrqlSignalSeasonalities = struct {
+		Hourly NrqlSignalSeasonality
+		Daily  NrqlSignalSeasonality
+		Weekly NrqlSignalSeasonality
+		None   NrqlSignalSeasonality
+	}{
+		Hourly: "HOURLY",
+		Daily:  "DAILY",
+		Weekly: "WEEKLY",
+		None:   "NONE",
+	}
+)
+
 type NrqlConditionThresholdPrediction struct {
 	PredictBy                 int  `json:"predictBy,omitempty"`
 	PreferPredictionViolation bool `json:"preferPredictionViolation"`
@@ -294,6 +311,8 @@ type NrqlConditionCreateInput struct {
 
 	// BaselineDirection ONLY applies to NRQL conditions of type BASELINE.
 	BaselineDirection *NrqlBaselineDirection `json:"baselineDirection,omitempty"`
+	// SignalSeasonality ONLY applies to NRQL conditions of type BASELINE.
+	SignalSeasonality *NrqlSignalSeasonality `json:"signalSeasonality"`
 }
 
 // NrqlConditionUpdateInput represents the input options for updating a Nrql Condition.
@@ -302,6 +321,8 @@ type NrqlConditionUpdateInput struct {
 
 	// BaselineDirection ONLY applies to NRQL conditions of type BASELINE.
 	BaselineDirection *NrqlBaselineDirection `json:"baselineDirection,omitempty"`
+	// SignalSeasonality ONLY applies to NRQL conditions of type BASELINE.
+	SignalSeasonality *NrqlSignalSeasonality `json:"signalSeasonality"`
 }
 
 type NrqlConditionsSearchCriteria struct {
@@ -322,6 +343,7 @@ type NrqlAlertCondition struct {
 
 	// BaselineDirection exists ONLY for NRQL conditions of type BASELINE.
 	BaselineDirection *NrqlBaselineDirection `json:"baselineDirection,omitempty"`
+	SignalSeasonality *NrqlSignalSeasonality `json:"signalSeasonality"`
 }
 
 // NrqlCondition represents a New Relic NRQL Alert condition.
@@ -765,6 +787,7 @@ const (
 	graphqlFragmentNrqlBaselineConditionFields = `
 		... on AlertsNrqlBaselineCondition {
 			baselineDirection
+			signalSeasonality
 		}
 	`
 
@@ -807,17 +830,17 @@ const (
 	// Baseline
 	createNrqlConditionBaselineMutation = `
 		mutation($accountId: Int!, $policyId: ID!, $condition: AlertsNrqlConditionBaselineInput!) {
-			alertsNrqlConditionBaselineCreate(accountId: $accountId, policyId: $policyId, condition: $condition) {
-				baselineDirection` +
+			alertsNrqlConditionBaselineCreate(accountId: $accountId, policyId: $policyId, condition: $condition) {` +
 		graphqlNrqlConditionStructFields +
+		graphqlFragmentNrqlBaselineConditionFields +
 		` } }`
 
 	// Baseline
 	updateNrqlConditionBaselineMutation = `
 		mutation($accountId: Int!, $id: ID!, $condition: AlertsNrqlConditionUpdateBaselineInput!) {
-			alertsNrqlConditionBaselineUpdate(accountId: $accountId, id: $id, condition: $condition) {
-				baselineDirection` +
+			alertsNrqlConditionBaselineUpdate(accountId: $accountId, id: $id, condition: $condition) { ` +
 		graphqlNrqlConditionStructFields +
+		graphqlFragmentNrqlBaselineConditionFields +
 		` } }`
 
 	// Static

--- a/pkg/alerts/nrql_conditions_integration_test.go
+++ b/pkg/alerts/nrql_conditions_integration_test.go
@@ -28,7 +28,8 @@ var (
 	nrqlConditionBaseSlideBy            = 30                                          // needed for setting pointer
 	nrqlConditionEvaluationDelay        = 60                                          // needed for setting pointer
 	nrqlConditionTitleTemplate          = "Title {{ createdAt }}"                     // needed for setting pointer
-	nrqlConditionPredictBy              = 7200																				// needed for setting pointer
+	nrqlConditionPredictBy              = 7200                                        // needed for setting pointer
+	nrqlConditionSignalSeasonality      = NrqlSignalSeasonalities.Weekly              // needed for setting pointer
 	nrqlConditionCreateBase             = NrqlConditionCreateBase{
 		Description: "test description",
 		Enabled:     true,
@@ -937,8 +938,8 @@ func TestIntegrationNrqlConditions_Prediction(t *testing.T) {
 	}
 
 	var (
-		randStr                  = mock.RandSeq(5)
-		createPredictionInput    = NrqlConditionCreateInput{
+		randStr               = mock.RandSeq(5)
+		createPredictionInput = NrqlConditionCreateInput{
 			NrqlConditionCreateBase: nrqlConditionCreateWithPrediction,
 		}
 	)
@@ -966,6 +967,113 @@ func TestIntegrationNrqlConditions_Prediction(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, readResult)
 	require.Equal(t, nrqlConditionPredictBy, readResult.Terms[0].Prediction.PredictBy)
+
+	// Deferred teardown
+	defer func() {
+		_, err := client.DeletePolicyMutation(testAccountID, policy.ID)
+		if err != nil {
+			t.Logf("error cleaning up alert policy %s (%s): %s", policy.ID, policy.Name, err)
+		}
+	}()
+}
+
+func TestIntegrationNrqlConditions_SignalSeasonality(t *testing.T) {
+	t.Parallel()
+
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	var (
+		randStr        = mock.RandSeq(5)
+		conditionName  = fmt.Sprintf("test-nrql-condition-%s", randStr)
+		conditionInput = NrqlConditionCreateInput{
+			NrqlConditionCreateBase: NrqlConditionCreateBase{
+				Enabled: true,
+				Name:    conditionName,
+				Nrql: NrqlConditionCreateQuery{
+					Query: "SELECT average(duration) From Transaction",
+				},
+				Terms: []NrqlConditionTerm{
+					{
+						Threshold:            &nrqlConditionBaseThreshold,
+						ThresholdOccurrences: ThresholdOccurrences.AtLeastOnce,
+						ThresholdDuration:    300,
+						Operator:             AlertsNRQLConditionTermsOperatorTypes.ABOVE,
+						Priority:             NrqlConditionPriorities.Critical,
+					},
+				},
+				Signal: &AlertsNrqlConditionCreateSignal{
+					AggregationWindow: &nrqlConditionBaseAggWindow,
+					FillOption:        &AlertsFillOptionTypes.STATIC,
+					FillValue:         &nrqlConditionBaseSignalFillValue,
+					EvaluationDelay:   &nrqlConditionEvaluationDelay,
+					AggregationMethod: &nrqlConditionBaseAggMethod,
+					AggregationDelay:  &nrqlConditionBaseAggDelay,
+				},
+				ViolationTimeLimitSeconds: 3600,
+			},
+			BaselineDirection: &NrqlBaselineDirections.LowerOnly,
+			SignalSeasonality: &nrqlConditionSignalSeasonality,
+		}
+
+		updateInput = NrqlConditionUpdateInput{
+			NrqlConditionUpdateBase: NrqlConditionUpdateBase{
+				Enabled: true,
+				Name:    conditionName,
+				Nrql: NrqlConditionUpdateQuery{
+					Query: "SELECT average(duration) From Transaction",
+				},
+				Terms: []NrqlConditionTerm{
+					{
+						Threshold:            &nrqlConditionBaseThreshold,
+						ThresholdOccurrences: ThresholdOccurrences.AtLeastOnce,
+						ThresholdDuration:    300,
+						Operator:             AlertsNRQLConditionTermsOperatorTypes.ABOVE,
+						Priority:             NrqlConditionPriorities.Critical,
+					},
+				},
+				Signal: &AlertsNrqlConditionUpdateSignal{
+					AggregationWindow: &nrqlConditionBaseAggWindow,
+					FillOption:        &AlertsFillOptionTypes.STATIC,
+					FillValue:         &nrqlConditionBaseSignalFillValue,
+					EvaluationDelay:   &nrqlConditionEvaluationDelay,
+					AggregationMethod: &nrqlConditionBaseAggMethod,
+					AggregationDelay:  &nrqlConditionBaseAggDelay,
+				},
+				ViolationTimeLimitSeconds: 3600,
+			},
+			BaselineDirection: &NrqlBaselineDirections.LowerOnly,
+			SignalSeasonality: &nrqlConditionSignalSeasonality,
+		}
+	)
+
+	// Setup
+	client := newIntegrationTestClient(t)
+	testPolicy := AlertsPolicyInput{
+		IncidentPreference: AlertsIncidentPreferenceTypes.PER_POLICY,
+		Name:               fmt.Sprintf("test-alert-policy-%s", randStr),
+	}
+	policy, err := client.CreatePolicyMutation(testAccountID, testPolicy)
+	require.NoError(t, err)
+
+	// Test: Create (baseline condition with signal seasonality field)
+	createdCondition, err := client.CreateNrqlConditionBaselineMutation(testAccountID, policy.ID, conditionInput)
+	require.NoError(t, err)
+	require.NotNil(t, createdCondition)
+	require.NotNil(t, createdCondition.ID)
+	require.NotNil(t, createdCondition.PolicyID)
+	require.NotNil(t, createdCondition.SignalSeasonality)
+	require.Equal(t, &nrqlConditionSignalSeasonality, createdCondition.SignalSeasonality)
+
+	// Test: Update (baseline condition with signal seasonality modified)
+	nrqlConditionSignalSeasonalityUpdated := NrqlSignalSeasonalities.None // needed for setting pointer
+	updateInput.SignalSeasonality = &nrqlConditionSignalSeasonalityUpdated
+
+	updatedCondition, err := client.UpdateNrqlConditionBaselineMutation(testAccountID, createdCondition.ID, updateInput)
+	require.NoError(t, err)
+	require.Equal(t, &nrqlConditionSignalSeasonalityUpdated, updatedCondition.SignalSeasonality)
 
 	// Deferred teardown
 	defer func() {


### PR DESCRIPTION
https://new-relic.atlassian.net/browse/NR-368786

Adds support for `SignalSeasonality` to NRQL baseline conditions.

Related to [TF Provider PR](https://github.com/newrelic/terraform-provider-newrelic/pull/2844)