### PR TITLE
fix(alerts): add already available name/nameLike fields to policy search struct

### DIFF
--- a/pkg/alerts/types.go
+++ b/pkg/alerts/types.go
@@ -297,6 +297,10 @@ type AlertsMutingRuleScheduleInput struct {
 type AlertsPoliciesSearchCriteriaInput struct {
 	// The list of policy ids to return.
 	IDs []string `json:"ids"`
+	//Exact name of the policy.
+	Name string `json:"name,omitempty"`
+	//String to partially match a policy name.
+	NameLike string `json:"nameLike,omitempty"`
 }
 
 // AlertsPoliciesSearchResultSet - Collection of policies with pagination information.


### PR DESCRIPTION
`name` and `nameLike` fields are available in the GraphQL schema. They should be consistent in this client as well.