### PR TITLE
fix(synthetics): Remove `omitempty` from `ResponseValidationText` to allow unsetting

### DIFF
--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -1710,7 +1710,7 @@ type SyntheticsSimpleMonitorAdvancedOptionsInput struct {
 	// Categorize redirects during a monitor job as a failure
 	RedirectIsFailure *bool `json:"redirectIsFailure,omitempty"`
 	// Validation text for monitor to search for at given URI
-	ResponseValidationText string `json:"responseValidationText,omitempty"`
+	ResponseValidationText *string `json:"responseValidationText"`
 	// Monitor should skip default HEAD request and instead use GET verb in check
 	ShouldBypassHeadRequest *bool `json:"shouldBypassHeadRequest,omitempty"`
 	// Monitor should validate SSL certificate chain

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -1644,7 +1644,7 @@ type SyntheticsSimpleBrowserMonitorAdvancedOptionsInput struct {
 	// Capture a screenshot during job execution
 	EnableScreenshotOnFailureAndScript *bool `json:"enableScreenshotOnFailureAndScript,omitempty"`
 	// Validation text for monitor to search for at given URI
-	ResponseValidationText string `json:"responseValidationText,omitempty"`
+	ResponseValidationText string `json:"responseValidationText"`
 	// Monitor should validate SSL certificate chain
 	UseTlsValidation *bool `json:"useTlsValidation,omitempty"`
 }

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -1710,7 +1710,7 @@ type SyntheticsSimpleMonitorAdvancedOptionsInput struct {
 	// Categorize redirects during a monitor job as a failure
 	RedirectIsFailure *bool `json:"redirectIsFailure,omitempty"`
 	// Validation text for monitor to search for at given URI
-	ResponseValidationText *string `json:"responseValidationText"`
+	ResponseValidationText string `json:"responseValidationText"`
 	// Monitor should skip default HEAD request and instead use GET verb in check
 	ShouldBypassHeadRequest *bool `json:"shouldBypassHeadRequest,omitempty"`
 	// Monitor should validate SSL certificate chain


### PR DESCRIPTION
Issue mentioned in the [Jira Ticket](https://new-relic.atlassian.net/browse/NR-382532)

**Fix:-** 

**Changes:**
- Removed `omitempty` from the `ResponseValidationText` field in `SyntheticsSimpleMonitorAdvancedOptionsInput`.

**Context:**
This change resolves an issue where the `validation_string` parameter could not be unset in Terraform. After applying this fix, Terraform will correctly unset the `validation_string` when it is removed from the configuration.
