### PR TITLE
feat: Added auto-discovery slug to cloud configure integration api

### DIFF
--- a/pkg/cloud/cloud_api.go
+++ b/pkg/cloud/cloud_api.go
@@ -236,6 +236,12 @@ const CloudConfigureIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+        ... on CloudAwsAutoDiscoveryIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
 		... on CloudAzureApimanagementIntegration {
 			__typename
 			inventoryPollingInterval
@@ -1022,6 +1028,12 @@ const CloudDisableIntegrationMutation = `mutation(
 			metricsPollingInterval
 		}
 		... on CloudAwsXrayIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+        ... on CloudAwsAutoDiscoveryIntegration {
 			__typename
 			awsRegions
 			inventoryPollingInterval
@@ -2100,6 +2112,12 @@ const getLinkedAccountQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+        ... on CloudAwsAutoDiscoveryIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
 		... on CloudAzureApimanagementIntegration {
 			__typename
 			inventoryPollingInterval
@@ -2944,6 +2962,12 @@ const getLinkedAccountsQuery = `query(
 			metricsPollingInterval
 		}
 		... on CloudAwsXrayIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+        ... on CloudAwsAutoDiscoveryIntegration {
 			__typename
 			awsRegions
 			inventoryPollingInterval

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -471,6 +471,8 @@ type CloudAwsDisableIntegrationsInput struct {
 	AwsWafv2 []CloudDisableAccountIntegrationInput `json:"awsWafv2,omitempty"`
 	// X-Ray integration
 	AwsXray []CloudDisableAccountIntegrationInput `json:"awsXray,omitempty"`
+	// Auto Discovery integration
+	AwsAutoDiscovery []CloudDisableAccountIntegrationInput `json:"awsAutoDiscovery,omitempty"`
 	// Billing integration
 	Billing []CloudDisableAccountIntegrationInput `json:"billing,omitempty"`
 	// CloudFront integration
@@ -843,6 +845,8 @@ type CloudAwsIntegrationsInput struct {
 	AwsWafv2 []CloudAwsWafv2IntegrationInput `json:"awsWafv2,omitempty"`
 	// X-Ray integration
 	AwsXray []CloudAwsXrayIntegrationInput `json:"awsXray,omitempty"`
+	// Aws Auto Discovery Integration
+	AwsAutoDiscovery []CloudAwsAutoDiscoveryIntegrationInput `json:"awsAutoDiscovery,omitempty"`
 	// Billing integration
 	Billing []CloudBillingIntegrationInput `json:"billing,omitempty"`
 	// CloudFront integration
@@ -1537,6 +1541,44 @@ func (x *CloudAwsXrayIntegration) ImplementsCloudIntegration() {}
 
 // CloudAwsXrayIntegrationInput - X-Ray
 type CloudAwsXrayIntegrationInput struct {
+	// Specify each AWS region that includes the resources that you want to monitor.
+	AwsRegions []string `json:"awsRegions,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudAwsAutoDiscoveryIntegration - Aws Auto Discovery Integration
+type CloudAwsAutoDiscoveryIntegration struct {
+	// Specify each AWS region that includes the resources that you want to monitor.
+	AwsRegions []string `json:"awsRegions,omitempty"`
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudAwsAutoDiscoveryIntegration) ImplementsCloudIntegration() {}
+
+// CloudAwsAutoDiscoveryIntegrationInput - AWS Auto Discovery Integration
+type CloudAwsAutoDiscoveryIntegrationInput struct {
 	// Specify each AWS region that includes the resources that you want to monitor.
 	AwsRegions []string `json:"awsRegions,omitempty"`
 	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
@@ -6254,6 +6296,14 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 
 			var xxx CloudIntegrationInterface = &interfaceType
 
+			return &xxx, nil
+		case "CloudAwsAutoDiscoveryIntegration":
+			var interfaceType CloudAwsAutoDiscoveryIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+			var xxx CloudIntegrationInterface = &interfaceType
 			return &xxx, nil
 		case "CloudAzureApimanagementIntegration":
 			var interfaceType CloudAzureAPImanagementIntegration


### PR DESCRIPTION
### What was done ?
- Client changes wrt new slug introduced in the configure-integration API for cloud monitoring.
- New Slug Name - aws_auto_discovery

### Testing Done
- Client changes done and tested via terraform provider to confirm working.