### PR TITLE
feat(dashboard): support multiple account id's when creating dashboards

### DIFF
--- a/pkg/dashboards/types.go
+++ b/pkg/dashboards/types.go
@@ -572,7 +572,9 @@ type DashboardWidgetLayoutInput struct {
 // DashboardWidgetNRQLQueryInput - NRQL query used by a widget.
 type DashboardWidgetNRQLQueryInput struct {
 	// New Relic account ID to issue the query against.
-	AccountID int `json:"accountId"`
+	AccountID int `json:"accountId,omitempty"`
+	// New Relic account IDs to issue the query against.
+	AccountIDS []int `json:"accountIds,omitempty"`
 	// NRQL formatted query.
 	Query nrdb.NRQL `json:"query"`
 }


### PR DESCRIPTION
https://new-relic.atlassian.net/browse/NR-436500

problem context:
After the multiple account query was launched, the backend system in New Relic platform got be able to respond the JSON file supporting the multiple account data. Once, however, newrelic-cli makes a Terraform formatted file, its output doesn't contain the information on the part of multiple account (losing or trimmed this kind of information). It resulted in different output of dashboards or sometimes the series of provisioning doesn't work as expected.

As tentative solution for this, the customer needs to manually create the dashboard. This is very laborious to do the flow and can potentially include some kind of human error.