### PR TITLE
feat: add FederatedLogSetup, AwsConnection, and FederatedLogPartition entity support to pipelinecontrol

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -1812,6 +1812,16 @@ packages:
         max_query_field_depth: 3
       - name: entityManagementDelete
         max_query_field_depth: 3
+      - name: entityManagementCreateFederatedLogSetup
+        max_query_field_depth: 4
+      - name: entityManagementCreateAwsConnection
+        max_query_field_depth: 3  
+      - name: entityManagementCreateFederatedLogPartition
+        max_query_field_depth: 4
+      - name: entityManagementUpdateFederatedLogPartition
+        max_query_field_depth: 4
+      - name: entityManagementUpdateFederatedLogSetup
+        max_query_field_depth: 4  
     types:
       - name: EntityManagementEntity
         include_implementations:

--- a/pkg/cloud/cloud_api_unit_test.go
+++ b/pkg/cloud/cloud_api_unit_test.go
@@ -64,8 +64,8 @@ var (
 		}
 	}
   }`
-	linkedAccountID = fmt.Sprintf("%06d", rand.Int63n(1e6))
-	nrAccountID     = fmt.Sprintf("%06d", rand.Int63n(1e6))
+	linkedAccountID = fmt.Sprintf("%d", rand.Int63n(1e6-1e5)+1e5)
+	nrAccountID     = fmt.Sprintf("%d", rand.Int63n(1e6-1e5)+1e5)
 
 	testUpdateAzureLinkAccount = `
 {

--- a/pkg/pipelinecontrol/pipelinecontrol_api.go
+++ b/pkg/pipelinecontrol/pipelinecontrol_api.go
@@ -245,6 +245,7 @@ const getEntityQuery = `query(
 ) { actor { entityManagement { entity(
 	id: $id,
 ) {
+	__typename
 	id
 	metadata {
 		createdAt
@@ -314,6 +315,128 @@ const getEntityQuery = `query(
 			id
 			type
 		}
+		tags {
+			key
+			values
+		}
+	}
+	... on EntityManagementFederatedLogSetupEntity {
+		__typename
+		cloudProvider
+		cloudProviderRegion
+		dataLocationBucket
+		dataProcessingComponent {
+			__typename
+			id
+			name
+			type
+		}
+		dataProcessingConnection {
+			__typename
+			id
+			name
+			type
+		}
+		description
+		metadata {
+			createdAt
+			createdBy {
+				__typename
+				id
+			}
+			updatedAt
+			updatedBy {
+				__typename
+				id
+			}
+			version
+		}
+		nrAccountId
+		nrRegion
+		queryConnection {
+			__typename
+			id
+			name
+			type
+		}
+		scope {
+			id
+			type
+		}
+		setupStatus: status
+		tags {
+			key
+			values
+		}
+	}
+	... on EntityManagementAwsConnectionEntity {
+		__typename
+		credential {
+			assumeRole {
+				externalId
+				roleArn
+			}
+		}
+		description
+		enabled
+		externalId
+		metadata {
+			createdAt
+			createdBy {
+				__typename
+				id
+			}
+			updatedAt
+			updatedBy {
+				__typename
+				id
+			}
+			version
+		}
+		region
+		scope {
+			id
+			type
+		}
+		settings {
+			key
+			value
+		}
+		tags {
+			key
+			values
+		}
+	}
+	... on EntityManagementFederatedLogPartitionEntity {
+		__typename
+		dataLocationURI
+		description
+		isDefault
+		metadata {
+			createdAt
+			createdBy {
+				__typename
+				id
+			}
+			updatedAt
+			updatedBy {
+				__typename
+				id
+			}
+			version
+		}
+		nrAccountId
+		partitionDatabase
+		partitionTable
+		retentionPolicy {
+			duration
+			unit
+		}
+		scope {
+			id
+			type
+		}
+		partitionStatus: status
 		tags {
 			key
 			values
@@ -433,6 +556,636 @@ const getEntitySearchQuery = `query(
 				values
 			}
 		}
+		... on EntityManagementFederatedLogSetupEntity {
+			__typename
+			cloudProvider
+			cloudProviderRegion
+			dataLocationBucket
+			dataProcessingComponent {
+				__typename
+				id
+				name
+				type
+			}
+			dataProcessingConnection {
+				__typename
+				id
+				name
+				type
+			}
+			description
+			metadata {
+				createdAt
+				createdBy {
+					__typename
+					id
+				}
+				updatedAt
+				updatedBy {
+					__typename
+					id
+				}
+				version
+			}
+			nrAccountId
+			nrRegion
+			queryConnection {
+				__typename
+				id
+				name
+				type
+			}
+			scope {
+				id
+				type
+			}
+			setupStatus: status
+			tags {
+				key
+				values
+			}
+		}
+		... on EntityManagementAwsConnectionEntity {
+			__typename
+			credential {
+				assumeRole {
+					externalId
+					roleArn
+				}
+			}
+			description
+			enabled
+			externalId
+			metadata {
+				createdAt
+				createdBy {
+					__typename
+					id
+				}
+				updatedAt
+				updatedBy {
+					__typename
+					id
+				}
+				version
+			}
+			region
+			scope {
+				id
+				type
+			}
+			settings {
+				key
+				value
+			}
+			tags {
+				key
+				values
+			}
+		}
+		... on EntityManagementFederatedLogPartitionEntity {
+			__typename
+			dataLocationURI
+			description
+			isDefault
+			metadata {
+				createdAt
+				createdBy {
+					__typename
+					id
+				}
+				updatedAt
+				updatedBy {
+					__typename
+					id
+				}
+				version
+			}
+			nrAccountId
+			partitionDatabase
+			partitionTable
+			retentionPolicy {
+				duration
+				unit
+			}
+			scope {
+				id
+				type
+			}
+			partitionStatus: status
+			tags {
+				key
+				values
+			}
+		}
 	}
 	nextCursor
 } } } }`
+
+// Creates an entity of type FederatedLogSetupEntity.
+func (a *Pipelinecontrol) EntityManagementCreateFederatedLogSetup(
+	federatedLogSetupEntity EntityManagementFederatedLogSetupEntityCreateInput,
+) (*EntityManagementFederatedLogSetupEntityCreateResult, error) {
+	return a.EntityManagementCreateFederatedLogSetupWithContext(context.Background(),
+		federatedLogSetupEntity,
+	)
+}
+
+// Creates an entity of type FederatedLogSetupEntity.
+func (a *Pipelinecontrol) EntityManagementCreateFederatedLogSetupWithContext(
+	ctx context.Context,
+	federatedLogSetupEntity EntityManagementFederatedLogSetupEntityCreateInput,
+) (*EntityManagementFederatedLogSetupEntityCreateResult, error) {
+
+	resp := EntityManagementCreateFederatedLogSetupQueryResponse{}
+	vars := map[string]interface{}{
+		"federatedLogSetupEntity": federatedLogSetupEntity,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, EntityManagementCreateFederatedLogSetupMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.EntityManagementFederatedLogSetupEntityCreateResult, nil
+}
+
+type EntityManagementCreateFederatedLogSetupQueryResponse struct {
+	EntityManagementFederatedLogSetupEntityCreateResult EntityManagementFederatedLogSetupEntityCreateResult `json:"entityManagementCreateFederatedLogSetup"`
+}
+
+// NOTE: This mutation has been simplified to avoid exceeding the GraphQL API's 15,000 grammar token limit.
+// The original auto-generated mutation (~14,490 lines) included inline fragments for all entity types,
+// which was unnecessary for FederatedLogSetupEntity and caused the error:
+// "More than 15,000 'grammar' tokens have been presented. To prevent Denial Of Service attacks, parsing has been cancelled."
+//
+// This simplified version only queries fields specific to FederatedLogSetupEntity.
+const EntityManagementCreateFederatedLogSetupMutation = `mutation(
+	$federatedLogSetupEntity: EntityManagementFederatedLogSetupEntityCreateInput!,
+) { entityManagementCreateFederatedLogSetup(
+	federatedLogSetupEntity: $federatedLogSetupEntity,
+) {
+	entity {
+		__typename
+		id
+		name
+		type
+		cloudProvider
+		cloudProviderRegion
+		dataLocationBucket
+		description
+		nrAccountId
+		nrRegion
+		status
+		dataProcessingComponent {
+			__typename
+			id
+			name
+			type
+		}
+		dataProcessingConnection {
+			__typename
+			id
+			name
+			type
+		}
+		queryConnection {
+			__typename
+			id
+			name
+			type
+		}
+		metadata {
+			createdAt
+			createdBy {
+				__typename
+				id
+			}
+			updatedAt
+			updatedBy {
+				__typename
+				id
+			}
+			version
+		}
+		scope {
+			id
+			type
+		}
+		tags {
+			key
+			values
+		}
+	}
+} }`
+
+// Creates an entity of type AwsConnectionEntity.
+func (a *Pipelinecontrol) EntityManagementCreateAwsConnection(
+	awsConnectionEntity EntityManagementAwsConnectionEntityCreateInput,
+) (*EntityManagementAwsConnectionEntityCreateResult, error) {
+	return a.EntityManagementCreateAwsConnectionWithContext(context.Background(),
+		awsConnectionEntity,
+	)
+}
+
+// Creates an entity of type AwsConnectionEntity.
+func (a *Pipelinecontrol) EntityManagementCreateAwsConnectionWithContext(
+	ctx context.Context,
+	awsConnectionEntity EntityManagementAwsConnectionEntityCreateInput,
+) (*EntityManagementAwsConnectionEntityCreateResult, error) {
+
+	resp := EntityManagementCreateAwsConnectionQueryResponse{}
+	vars := map[string]interface{}{
+		"awsConnectionEntity": awsConnectionEntity,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, EntityManagementCreateAwsConnectionMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.EntityManagementAwsConnectionEntityCreateResult, nil
+}
+
+type EntityManagementCreateAwsConnectionQueryResponse struct {
+	EntityManagementAwsConnectionEntityCreateResult EntityManagementAwsConnectionEntityCreateResult `json:"EntityManagementCreateAwsConnection"`
+}
+
+const EntityManagementCreateAwsConnectionMutation = `mutation(
+    $awsConnectionEntity: EntityManagementAwsConnectionEntityCreateInput!,
+) { entityManagementCreateAwsConnection(
+    awsConnectionEntity: $awsConnectionEntity,
+) {
+    entity {
+        credential {
+            assumeRole {
+                externalId
+                roleArn
+            }
+        }
+        description
+        enabled
+        externalId
+        id
+        metadata {
+            createdAt
+            createdBy {
+                __typename
+                id
+                ... on EntityManagementSystemActor {
+                    __typename
+                }
+                ... on EntityManagementUserActor {
+                    __typename
+                }
+            }
+            updatedAt
+            updatedBy {
+                __typename
+                id
+                ... on EntityManagementSystemActor {
+                    __typename
+                }
+                ... on EntityManagementUserActor {
+                    __typename
+                }
+            }
+            version
+        }
+        name
+        region
+        scope {
+            id
+            type
+        }
+        settings {
+            key
+            value
+        }
+        tags {
+            key
+            values
+        }
+        type
+    }
+} }`
+
+// Creates an entity of type FederatedLogPartitionEntity.
+func (a *Pipelinecontrol) EntityManagementCreateFederatedLogPartition(
+	federatedLogPartitionEntity EntityManagementFederatedLogPartitionEntityCreateInput,
+) (*EntityManagementFederatedLogPartitionEntityCreateResult, error) {
+	return a.EntityManagementCreateFederatedLogPartitionWithContext(context.Background(),
+		federatedLogPartitionEntity,
+	)
+}
+
+// Creates an entity of type FederatedLogPartitionEntity.
+func (a *Pipelinecontrol) EntityManagementCreateFederatedLogPartitionWithContext(
+	ctx context.Context,
+	federatedLogPartitionEntity EntityManagementFederatedLogPartitionEntityCreateInput,
+) (*EntityManagementFederatedLogPartitionEntityCreateResult, error) {
+
+	resp := EntityManagementCreateFederatedLogPartitionQueryResponse{}
+	vars := map[string]interface{}{
+		"federatedLogPartitionEntity": federatedLogPartitionEntity,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, EntityManagementCreateFederatedLogPartitionMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.EntityManagementFederatedLogPartitionEntityCreateResult, nil
+}
+
+type EntityManagementCreateFederatedLogPartitionQueryResponse struct {
+	EntityManagementFederatedLogPartitionEntityCreateResult EntityManagementFederatedLogPartitionEntityCreateResult `json:"EntityManagementCreateFederatedLogPartition"`
+}
+
+// NOTE: This mutation has been simplified to avoid exceeding the GraphQL API's grammar token limit
+// and to avoid FieldsConflict errors from inline fragments with conflicting nullability shapes.
+// This simplified version only queries fields specific to FederatedLogPartitionEntity.
+const EntityManagementCreateFederatedLogPartitionMutation = `mutation(
+    $federatedLogPartitionEntity: EntityManagementFederatedLogPartitionEntityCreateInput!,
+) { entityManagementCreateFederatedLogPartition(
+    federatedLogPartitionEntity: $federatedLogPartitionEntity,
+) {
+    entity {
+        dataLocationURI
+        description
+        id
+        isDefault
+        metadata {
+            createdAt
+            createdBy {
+                __typename
+                id
+            }
+            updatedAt
+            updatedBy {
+                __typename
+                id
+            }
+            version
+        }
+        name
+        nrAccountId
+        partitionDatabase
+        partitionTable
+        retentionPolicy {
+            duration
+            unit
+        }
+        scope {
+            id
+            type
+        }
+        status
+        tags {
+            key
+            values
+        }
+        type
+    }
+} }`
+
+// Updates an entity of type FederatedLogPartitionEntity.
+func (a *Pipelinecontrol) EntityManagementUpdateFederatedLogPartition(
+	federatedLogPartitionEntity EntityManagementFederatedLogPartitionEntityUpdateInput,
+	iD string,
+	version int,
+) (*EntityManagementFederatedLogPartitionEntityUpdateResult, error) {
+	return a.EntityManagementUpdateFederatedLogPartitionWithContext(context.Background(),
+		federatedLogPartitionEntity,
+		iD,
+		version,
+	)
+}
+
+// Updates an entity of type FederatedLogPartitionEntity.
+func (a *Pipelinecontrol) EntityManagementUpdateFederatedLogPartitionWithContext(
+	ctx context.Context,
+	federatedLogPartitionEntity EntityManagementFederatedLogPartitionEntityUpdateInput,
+	iD string,
+	version int,
+) (*EntityManagementFederatedLogPartitionEntityUpdateResult, error) {
+
+	resp := EntityManagementUpdateFederatedLogPartitionQueryResponse{}
+	vars := map[string]interface{}{
+		"federatedLogPartitionEntity": federatedLogPartitionEntity,
+		"id":                          iD,
+		"version":                     version,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, EntityManagementUpdateFederatedLogPartitionMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.EntityManagementFederatedLogPartitionEntityUpdateResult, nil
+}
+
+type EntityManagementUpdateFederatedLogPartitionQueryResponse struct {
+	EntityManagementFederatedLogPartitionEntityUpdateResult EntityManagementFederatedLogPartitionEntityUpdateResult `json:"EntityManagementUpdateFederatedLogPartition"`
+}
+
+const EntityManagementUpdateFederatedLogPartitionMutation = `mutation(
+    $federatedLogPartitionEntity: EntityManagementFederatedLogPartitionEntityUpdateInput!,
+    $id: ID!,
+    $version: Int,
+) { entityManagementUpdateFederatedLogPartition(
+    federatedLogPartitionEntity: $federatedLogPartitionEntity,
+    id: $id,
+    version: $version,
+) {
+    entity {
+
+    description
+        id
+        isDefault
+        metadata {
+            createdAt
+            createdBy {
+                __typename
+                id
+                ... on EntityManagementSystemActor {
+                    __typename
+                }
+                ... on EntityManagementUserActor {
+                    __typename
+                }
+            }
+            updatedAt
+            updatedBy {
+                __typename
+                id
+                ... on EntityManagementSystemActor {
+                    __typename
+                }
+                ... on EntityManagementUserActor {
+                    __typename
+                }
+            }
+            version
+        }
+        name
+        nrAccountId
+        partitionDatabase
+        partitionTable
+        retentionPolicy {
+            duration
+            unit
+        }
+        scope {
+            id
+            type
+        }
+        setup {
+            cloudProvider
+            cloudProviderRegion
+            dataLocationBucket
+            dataProcessingComponent {
+                __typename
+                id
+                name
+                type
+            }
+            dataProcessingConnection {
+                __typename
+                id
+                name
+                type
+            }
+            description
+            id
+            metadata {
+                createdAt
+                updatedAt
+                version
+            }
+            name
+            nrAccountId
+            nrRegion
+            queryConnection {
+                __typename
+                id
+                name
+                type
+            }
+            scope {
+                id
+                type
+            }
+            status
+            tags {
+                key
+                values
+            }
+            type
+        }
+        status
+        tags {
+            key
+            values
+        }
+        type
+    }
+} }`
+
+// Updates an entity of type FederatedLogSetupEntity.
+func (a *Pipelinecontrol) EntityManagementUpdateFederatedLogSetup(
+	federatedLogSetupEntity EntityManagementFederatedLogSetupEntityUpdateInput,
+	iD string,
+	version int,
+) (*EntityManagementFederatedLogSetupEntityUpdateResult, error) {
+	return a.EntityManagementUpdateFederatedLogSetupWithContext(context.Background(),
+		federatedLogSetupEntity,
+		iD,
+		version,
+	)
+}
+
+// Updates an entity of type FederatedLogSetupEntity.
+func (a *Pipelinecontrol) EntityManagementUpdateFederatedLogSetupWithContext(
+	ctx context.Context,
+	federatedLogSetupEntity EntityManagementFederatedLogSetupEntityUpdateInput,
+	iD string,
+	version int,
+) (*EntityManagementFederatedLogSetupEntityUpdateResult, error) {
+
+	resp := EntityManagementUpdateFederatedLogSetupQueryResponse{}
+	vars := map[string]interface{}{
+		"federatedLogSetupEntity": federatedLogSetupEntity,
+		"id":                      iD,
+		"version":                 version,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, EntityManagementUpdateFederatedLogSetupMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.EntityManagementFederatedLogSetupEntityUpdateResult, nil
+}
+
+type EntityManagementUpdateFederatedLogSetupQueryResponse struct {
+	EntityManagementFederatedLogSetupEntityUpdateResult EntityManagementFederatedLogSetupEntityUpdateResult `json:"EntityManagementUpdateFederatedLogSetup"`
+}
+
+const EntityManagementUpdateFederatedLogSetupMutation = `mutation(
+	$federatedLogSetupEntity: EntityManagementFederatedLogSetupEntityUpdateInput!,
+	$id: ID!,
+	$version: Int,
+) { entityManagementUpdateFederatedLogSetup(
+	federatedLogSetupEntity: $federatedLogSetupEntity,
+	id: $id,
+	version: $version,
+) {
+	entity {
+		__typename
+		id
+		name
+		type
+		cloudProvider
+		cloudProviderRegion
+		dataLocationBucket
+		description
+		nrAccountId
+		nrRegion
+		status
+		dataProcessingComponent {
+			__typename
+			id
+			name
+			type
+		}
+		dataProcessingConnection {
+			__typename
+			id
+			name
+			type
+		}
+		queryConnection {
+			__typename
+			id
+			name
+			type
+		}
+		metadata {
+			createdAt
+			createdBy {
+				__typename
+				id
+			}
+			updatedAt
+			updatedBy {
+				__typename
+				id
+			}
+			version
+		}
+		scope {
+			id
+			type
+		}
+		tags {
+			key
+			values
+		}
+	}
+} }`

--- a/pkg/pipelinecontrol/pipelinecontrol_integration_test.go
+++ b/pkg/pipelinecontrol/pipelinecontrol_integration_test.go
@@ -5,6 +5,7 @@ package pipelinecontrol
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -89,4 +90,177 @@ func TestIntegrationEntityManagement_PipelineCloudRule_CRUD(t *testing.T) {
 
 	// 5. Delete the entity (this is handled by the deferred function)
 	// The test will complete, and the deferred function will execute for cleanup.
+}
+
+// TestIntegrationEntityManagement_FederatedLogSetup_CRUD tests full CRUD for FederatedLogSetupEntity.
+// Set the environment variable RUN_FEDERATED_LOG_SETUP_TEST=true to run this test.
+func TestIntegrationEntityManagement_FederatedLogSetup_CRUD(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("RUN_FEDERATED_LOG_SETUP_TEST") != "true" {
+		t.Skip("Skipping FederatedLogSetup integration test. Set RUN_FEDERATED_LOG_SETUP_TEST=true to run.")
+	}
+
+	client := newIntegrationTestClient(t)
+	accountID, _ := testhelpers.GetTestAccountID()
+
+	dataProcessingConnectionId := os.Getenv("TEST_DATA_PROCESSING_CONNECTION_ID")
+	queryConnectionId := os.Getenv("TEST_QUERY_CONNECTION_ID")
+	dataLocationBucket := os.Getenv("TEST_DATA_LOCATION_BUCKET")
+
+	if dataProcessingConnectionId == "" || queryConnectionId == "" || dataLocationBucket == "" {
+		t.Skip("Required env vars not set: TEST_DATA_PROCESSING_CONNECTION_ID, TEST_QUERY_CONNECTION_ID, TEST_DATA_LOCATION_BUCKET")
+	}
+
+	setupName := fmt.Sprintf("test-federated-log-setup-%s", testhelpers.RandSeq(5))
+
+	createInput := EntityManagementFederatedLogSetupEntityCreateInput{
+		Name:                       setupName,
+		Description:                "A test federated log setup from integration testing.",
+		CloudProvider:              EntityManagementCloudProviderTypes.AWS,
+		CloudProviderRegion:        "us-east-1",
+		DataLocationBucket:         dataLocationBucket,
+		DataProcessingConnectionId: dataProcessingConnectionId,
+		NrAccountId:                fmt.Sprintf("%d", accountID),
+		NrRegion:                   EntityManagementNrRegionTypes.US,
+		QueryConnectionId:          queryConnectionId,
+		Status:                     EntityManagementFederatedLogSetupStatusTypes.CREATING,
+		Scope: EntityManagementScopedReferenceInput{
+			Type: EntityManagementEntityScopeTypes.ACCOUNT,
+			ID:   fmt.Sprintf("%d", accountID),
+		},
+	}
+
+	// 1. Create
+	createResult, err := client.EntityManagementCreateFederatedLogSetup(createInput)
+	require.NoError(t, err)
+	require.NotNil(t, createResult)
+	require.NotEmpty(t, createResult.Entity.ID)
+	require.Equal(t, setupName, createResult.Entity.Name)
+	require.Equal(t, EntityManagementCloudProviderTypes.AWS, createResult.Entity.CloudProvider)
+
+	defer func() {
+		_, deleteErr := client.EntityManagementDelete(createResult.Entity.ID)
+		require.NoError(t, deleteErr, "Failed to clean up FederatedLogSetup entity %s", createResult.Entity.ID)
+	}()
+
+	// 2. Read
+	getResult, err := client.GetEntity(createResult.Entity.ID)
+	require.NoError(t, err)
+	require.NotNil(t, getResult)
+
+	setupEntity, ok := (*getResult).(*EntityManagementFederatedLogSetupEntity)
+	require.True(t, ok, "Fetched entity was not of the expected FederatedLogSetupEntity type")
+	require.Equal(t, createResult.Entity.ID, setupEntity.ID)
+	require.Equal(t, createInput.Name, setupEntity.Name)
+	require.Equal(t, createInput.Description, setupEntity.Description)
+	require.Equal(t, createInput.CloudProvider, setupEntity.CloudProvider)
+	require.Equal(t, createInput.CloudProviderRegion, setupEntity.CloudProviderRegion)
+
+	// 3. Update
+	updateInput := EntityManagementFederatedLogSetupEntityUpdateInput{
+		Name:                       setupName + "-updated",
+		Description:                "Updated federated log setup from integration testing.",
+		CloudProvider:              EntityManagementCloudProviderTypes.AWS,
+		CloudProviderRegion:        "us-east-1",
+		DataLocationBucket:         dataLocationBucket,
+		DataProcessingConnectionId: dataProcessingConnectionId,
+		NrAccountId:                fmt.Sprintf("%d", accountID),
+		NrRegion:                   EntityManagementNrRegionTypes.US,
+		QueryConnectionId:          queryConnectionId,
+		Status:                     EntityManagementFederatedLogSetupStatusTypes.CREATING,
+	}
+
+	updateResult, err := client.EntityManagementUpdateFederatedLogSetup(updateInput, createResult.Entity.ID, setupEntity.Metadata.Version)
+	require.NoError(t, err)
+	require.NotNil(t, updateResult)
+	require.Equal(t, setupName+"-updated", updateResult.Entity.Name)
+	require.Equal(t, "Updated federated log setup from integration testing.", updateResult.Entity.Description)
+	require.Equal(t, setupEntity.Metadata.Version+1, updateResult.Entity.Metadata.Version)
+
+	// 4. Read after update
+	getResultAfterUpdate, err := client.GetEntity(createResult.Entity.ID)
+	require.NoError(t, err)
+	require.NotNil(t, getResultAfterUpdate)
+
+	setupEntityUpdated, ok := (*getResultAfterUpdate).(*EntityManagementFederatedLogSetupEntity)
+	require.True(t, ok, "Fetched entity was not of the expected FederatedLogSetupEntity type")
+	require.Equal(t, updateResult.Entity.Name, setupEntityUpdated.Name)
+	require.Equal(t, updateInput.Description, setupEntityUpdated.Description)
+
+	// 5. Delete (handled by deferred function)
+}
+
+// TestIntegrationEntityManagement_FederatedLogSetup_Create tests the creation of a FederatedLogSetupEntity.
+// This test is skipped by default as it requires specific cloud infrastructure setup.
+// Set the environment variable RUN_FEDERATED_LOG_SETUP_TEST=true to run this test.
+func TestIntegrationEntityManagement_FederatedLogSetup_Create(t *testing.T) {
+	t.Parallel()
+
+	// Skip this test unless explicitly enabled
+	if os.Getenv("RUN_FEDERATED_LOG_SETUP_TEST") != "true" {
+		t.Skip("Skipping FederatedLogSetup integration test. Set RUN_FEDERATED_LOG_SETUP_TEST=true to run.")
+	}
+
+	client := newIntegrationTestClient(t)
+	accountID, _ := testhelpers.GetTestAccountID()
+
+	// Generate a unique name for the test
+	setupName := fmt.Sprintf("test-federated-log-setup-%s", testhelpers.RandSeq(5))
+
+	// Note: This test requires valid connection IDs for DataProcessingConnection and QueryConnection
+	// These would need to be created separately or provided via environment variables
+	dataProcessingConnectionId := os.Getenv("TEST_DATA_PROCESSING_CONNECTION_ID")
+	queryConnectionId := os.Getenv("TEST_QUERY_CONNECTION_ID")
+	dataLocationBucket := os.Getenv("TEST_DATA_LOCATION_BUCKET")
+
+	if dataProcessingConnectionId == "" || queryConnectionId == "" || dataLocationBucket == "" {
+		t.Skip("Skipping FederatedLogSetup integration test. Required environment variables not set: TEST_DATA_PROCESSING_CONNECTION_ID, TEST_QUERY_CONNECTION_ID, TEST_DATA_LOCATION_BUCKET")
+	}
+
+	createInput := EntityManagementFederatedLogSetupEntityCreateInput{
+		Name:                       setupName,
+		Description:                "A test federated log setup from integration testing.",
+		CloudProvider:              EntityManagementCloudProviderTypes.AWS,
+		CloudProviderRegion:        "us-east-1",
+		DataLocationBucket:         dataLocationBucket,
+		DataProcessingConnectionId: dataProcessingConnectionId,
+		NrAccountId:                fmt.Sprintf("%d", accountID),
+		NrRegion:                   EntityManagementNrRegionTypes.US,
+		QueryConnectionId:          queryConnectionId,
+		Status:                     EntityManagementFederatedLogSetupStatusTypes.CREATING,
+		Scope: EntityManagementScopedReferenceInput{
+			Type: EntityManagementEntityScopeTypes.ACCOUNT,
+			ID:   fmt.Sprintf("%d", accountID),
+		},
+	}
+
+	// 1. Create the entity
+	createResult, err := client.EntityManagementCreateFederatedLogSetup(createInput)
+	require.NotNil(t, createResult)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, createResult.Entity.ID)
+	require.Equal(t, setupName, createResult.Entity.Name)
+	require.Equal(t, EntityManagementCloudProviderTypes.AWS, createResult.Entity.CloudProvider)
+
+	// Defer the deletion to ensure cleanup even if assertions fail
+	defer func() {
+		_, deleteErr := client.EntityManagementDelete(createResult.Entity.ID)
+		require.NoError(t, deleteErr, "Failed to clean up FederatedLogSetup entity %s", createResult.Entity.ID)
+	}()
+
+	// 2. Read the entity to verify creation
+	getResult, err := client.GetEntity(createResult.Entity.ID)
+	require.NoError(t, err)
+	require.NotNil(t, getResult)
+
+	// Type assert the result to access specific fields
+	setupEntity, ok := (*getResult).(*EntityManagementFederatedLogSetupEntity)
+	require.True(t, ok, "Fetched entity was not of the expected type")
+	require.Equal(t, createResult.Entity.ID, setupEntity.ID)
+	require.Equal(t, createInput.Name, setupEntity.Name)
+	require.Equal(t, createInput.Description, setupEntity.Description)
+	require.Equal(t, createInput.CloudProvider, setupEntity.CloudProvider)
+	require.Equal(t, createInput.CloudProviderRegion, setupEntity.CloudProviderRegion)
 }

--- a/pkg/pipelinecontrol/pipelinecontrol_unit_test.go
+++ b/pkg/pipelinecontrol/pipelinecontrol_unit_test.go
@@ -181,3 +181,749 @@ func TestUnitEntityManagement_GetEntity_Error(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, result)
 }
+
+var (
+	testFederatedLogSetupID = "MXxYY0YYxYYYYYYYYY6YY0YYY1YYY1YYYYY9YYY6YYYxY3YxYyyyYY04YYY3YYy0YYYyYYYyYyYyYYYyYYYy"
+
+	testCreateFederatedLogSetupResponseJSON = `
+	{
+		"data": {
+			"entityManagementCreateFederatedLogSetup": {
+				"entity": {
+					"id": "MXxYY0YYxYYYYYYYYY6YY0YYY1YYY1YYYYY9YYY6YYYxY3YxYyyyYY04YYY3YYy0YYYyYYYyYyYyYYYyYYYy",
+					"metadata": {
+						"version": 1
+					},
+					"name": "Test Federated Log Setup",
+					"description": "Test Federated Log Setup - New Relic Go Client",
+					"cloudProvider": "AWS",
+					"cloudProviderRegion": "us-east-1",
+					"dataLocationBucket": "my-test-bucket",
+					"nrAccountId": "12345",
+					"nrRegion": "US",
+					"status": "ACTIVE"
+				}
+			}
+		}
+	}`
+
+	testCreateFederatedLogSetupErrorResponseJSON = `
+	{
+		"errors": [
+			{
+				"message": "Invalid input: missing required field"
+			}
+		]
+	}`
+)
+
+func TestUnitEntityManagement_CreateFederatedLogSetup(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testCreateFederatedLogSetupResponseJSON, http.StatusOK)
+
+	createInput := EntityManagementFederatedLogSetupEntityCreateInput{
+		Name:                       "Test Federated Log Setup",
+		Description:                "Test Federated Log Setup - New Relic Go Client",
+		CloudProvider:              EntityManagementCloudProviderTypes.AWS,
+		CloudProviderRegion:        "us-east-1",
+		DataLocationBucket:         "my-test-bucket",
+		DataProcessingConnectionId: "connection-123",
+		NrAccountId:                "12345",
+		NrRegion:                   EntityManagementNrRegionTypes.US,
+		QueryConnectionId:          "query-connection-456",
+		Status:                     EntityManagementFederatedLogSetupStatusTypes.ACTIVE,
+		Scope: EntityManagementScopedReferenceInput{
+			Type: EntityManagementEntityScopeTypes.ACCOUNT,
+			ID:   testAccountID,
+		},
+	}
+
+	result, err := client.EntityManagementCreateFederatedLogSetup(createInput)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, testFederatedLogSetupID, result.Entity.ID)
+	require.Equal(t, "Test Federated Log Setup", result.Entity.Name)
+	require.Equal(t, EntityManagementCloudProviderTypes.AWS, result.Entity.CloudProvider)
+	require.Equal(t, "us-east-1", result.Entity.CloudProviderRegion)
+	require.Equal(t, EntityManagementNrRegionTypes.US, result.Entity.NrRegion)
+	require.Equal(t, EntityManagementFederatedLogSetupStatusTypes.ACTIVE, result.Entity.Status)
+}
+
+func TestUnitEntityManagement_CreateFederatedLogSetupWithContext(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testCreateFederatedLogSetupResponseJSON, http.StatusOK)
+
+	createInput := EntityManagementFederatedLogSetupEntityCreateInput{
+		Name:                       "Test Federated Log Setup",
+		Description:                "Test Federated Log Setup - New Relic Go Client",
+		CloudProvider:              EntityManagementCloudProviderTypes.AWS,
+		CloudProviderRegion:        "us-east-1",
+		DataLocationBucket:         "my-test-bucket",
+		DataProcessingConnectionId: "connection-123",
+		NrAccountId:                "12345",
+		NrRegion:                   EntityManagementNrRegionTypes.US,
+		QueryConnectionId:          "query-connection-456",
+		Status:                     EntityManagementFederatedLogSetupStatusTypes.ACTIVE,
+		Scope: EntityManagementScopedReferenceInput{
+			Type: EntityManagementEntityScopeTypes.ACCOUNT,
+			ID:   testAccountID,
+		},
+	}
+
+	result, err := client.EntityManagementCreateFederatedLogSetupWithContext(context.Background(), createInput)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, testFederatedLogSetupID, result.Entity.ID)
+	require.Equal(t, "Test Federated Log Setup", result.Entity.Name)
+}
+
+func TestUnitEntityManagement_CreateFederatedLogSetup_Error(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testCreateFederatedLogSetupErrorResponseJSON, http.StatusBadRequest)
+
+	createInput := EntityManagementFederatedLogSetupEntityCreateInput{
+		Name:          "Test Federated Log Setup",
+		CloudProvider: EntityManagementCloudProviderTypes.AWS,
+	}
+
+	result, err := client.EntityManagementCreateFederatedLogSetup(createInput)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+var (
+	testAwsConnectionID = "MXxZZ0ZZxZZZZZZZZZ7ZZ0ZZZ1ZZZ1ZZZZZ0ZZZ7ZZZxZ4ZxZzzzZZ05ZZZ4ZZz0ZZZzZZZzZzZzZZZzZZZz"
+
+	testCreateAwsConnectionResponseJSON = `
+	{
+		"data": {
+			"EntityManagementCreateAwsConnection": {
+				"entity": {
+					"id": "MXxZZ0ZZxZZZZZZZZZ7ZZ0ZZZ1ZZZ1ZZZZZ0ZZZ7ZZZxZ4ZxZzzzZZ05ZZZ4ZZz0ZZZzZZZzZzZzZZZzZZZz",
+					"metadata": {
+						"version": 1
+					},
+					"name": "Test AWS Connection",
+					"description": "Test AWS Connection - New Relic Go Client",
+					"enabled": true,
+					"region": "us-east-1",
+					"externalId": "ext-123",
+					"credential": {
+						"assumeRole": {
+							"roleArn": "arn:aws:iam::123456789012:role/test-role",
+							"externalId": "ext-456"
+						}
+					},
+					"scope": {
+						"id": "12345",
+						"type": "ACCOUNT"
+					},
+					"settings": [
+						{
+							"key": "setting1",
+							"value": "value1"
+						}
+					],
+					"tags": [],
+					"type": "AWS_CONNECTION"
+				}
+			}
+		}
+	}`
+
+	testCreateAwsConnectionErrorResponseJSON = `
+	{
+		"errors": [
+			{
+				"message": "Invalid input: missing required field"
+			}
+		]
+	}`
+
+	testGetEntitySearchResponseJSON = `
+	{
+		"data": {
+			"actor": {
+				"entityManagement": {
+					"entitySearch": {
+						"entities": [
+							{
+								"__typename": "EntityManagementPipelineCloudRuleEntity",
+								"id": "MXxXX0XXxXXXXXXXXX5XX0XXX1XXX1XXXXX8XXX5XXXxX2XxXxxxXX03XXX2XXx0XXXxXXXxXxXxXXXxXXXx",
+								"metadata": {
+									"version": 1
+								},
+								"name": "Test Rule",
+								"description": "Test Pipeline Cloud Rule",
+								"nrql": "DELETE FROM Log WHERE (container_name = 'mario')",
+								"scope": {
+									"id": "12345",
+									"type": "ACCOUNT"
+								},
+								"tags": []
+							}
+						],
+						"nextCursor": ""
+					}
+				}
+			}
+		}
+	}`
+
+	testGetEntitySearchEmptyResponseJSON = `
+	{
+		"data": {
+			"actor": {
+				"entityManagement": {
+					"entitySearch": {
+						"entities": [],
+						"nextCursor": ""
+					}
+				}
+			}
+		}
+	}`
+
+	testGetEntityFederatedLogSetupResponseJSON = `
+	{
+		"data": {
+			"actor": {
+				"entityManagement": {
+					"entity": {
+						"__typename": "EntityManagementFederatedLogSetupEntity",
+						"id": "MXxYY0YYxYYYYYYYYY6YY0YYY1YYY1YYYYY9YYY6YYYxY3YxYyyyYY04YYY3YYy0YYYyYYYyYyYyYYYyYYYy",
+						"metadata": {
+							"version": 1
+						},
+						"name": "Test Federated Log Setup",
+						"description": "Test Federated Log Setup",
+						"cloudProvider": "AWS",
+						"cloudProviderRegion": "us-east-1",
+						"dataLocationBucket": "my-test-bucket",
+						"nrAccountId": "12345",
+						"nrRegion": "US",
+						"status": "ACTIVE",
+						"scope": {
+							"id": "12345",
+							"type": "ACCOUNT"
+						},
+						"tags": []
+					}
+				}
+			}
+		}
+	}`
+
+	testGetEntityAwsConnectionResponseJSON = `
+	{
+		"data": {
+			"actor": {
+				"entityManagement": {
+					"entity": {
+						"__typename": "EntityManagementAwsConnectionEntity",
+						"id": "MXxZZ0ZZxZZZZZZZZZ7ZZ0ZZZ1ZZZ1ZZZZZ0ZZZ7ZZZxZ4ZxZzzzZZ05ZZZ4ZZz0ZZZzZZZzZzZzZZZzZZZz",
+						"metadata": {
+							"version": 1
+						},
+						"name": "Test AWS Connection",
+						"description": "Test AWS Connection",
+						"enabled": true,
+						"region": "us-east-1",
+						"scope": {
+							"id": "12345",
+							"type": "ACCOUNT"
+						},
+						"tags": []
+					}
+				}
+			}
+		}
+	}`
+)
+
+func TestUnitEntityManagement_CreateAwsConnection(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testCreateAwsConnectionResponseJSON, http.StatusOK)
+
+	createInput := EntityManagementAwsConnectionEntityCreateInput{
+		Name:        "Test AWS Connection",
+		Description: "Test AWS Connection - New Relic Go Client",
+		Enabled:     true,
+		Region:      "us-east-1",
+		ExternalId:  "ext-123",
+		Credential: EntityManagementAwsCredentialsCreateInput{
+			AssumeRole: EntityManagementAwsAssumeRoleConfigCreateInput{
+				RoleArn: "arn:aws:iam::123456789012:role/test-role",
+			},
+		},
+		Scope: EntityManagementScopedReferenceInput{
+			Type: EntityManagementEntityScopeTypes.ACCOUNT,
+			ID:   testAccountID,
+		},
+	}
+
+	result, err := client.EntityManagementCreateAwsConnection(createInput)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, testAwsConnectionID, result.Entity.ID)
+	require.Equal(t, "Test AWS Connection", result.Entity.Name)
+	require.Equal(t, "Test AWS Connection - New Relic Go Client", result.Entity.Description)
+	require.True(t, result.Entity.Enabled)
+	require.Equal(t, "us-east-1", result.Entity.Region)
+}
+
+func TestUnitEntityManagement_CreateAwsConnectionWithContext(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testCreateAwsConnectionResponseJSON, http.StatusOK)
+
+	createInput := EntityManagementAwsConnectionEntityCreateInput{
+		Name:        "Test AWS Connection",
+		Description: "Test AWS Connection - New Relic Go Client",
+		Enabled:     true,
+		Region:      "us-east-1",
+		Credential: EntityManagementAwsCredentialsCreateInput{
+			AssumeRole: EntityManagementAwsAssumeRoleConfigCreateInput{
+				RoleArn: "arn:aws:iam::123456789012:role/test-role",
+			},
+		},
+		Scope: EntityManagementScopedReferenceInput{
+			Type: EntityManagementEntityScopeTypes.ACCOUNT,
+			ID:   testAccountID,
+		},
+	}
+
+	result, err := client.EntityManagementCreateAwsConnectionWithContext(context.Background(), createInput)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, testAwsConnectionID, result.Entity.ID)
+	require.Equal(t, "Test AWS Connection", result.Entity.Name)
+}
+
+func TestUnitEntityManagement_CreateAwsConnection_Error(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testCreateAwsConnectionErrorResponseJSON, http.StatusBadRequest)
+
+	createInput := EntityManagementAwsConnectionEntityCreateInput{
+		Name: "Test AWS Connection",
+	}
+
+	result, err := client.EntityManagementCreateAwsConnection(createInput)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+func TestUnitEntityManagement_GetEntitySearch(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testGetEntitySearchResponseJSON, http.StatusOK)
+
+	result, err := client.GetEntitySearch("", "type = 'PIPELINE_CLOUD_RULE'")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Entities, 1)
+
+	ruleEntity, ok := result.Entities[0].(*EntityManagementPipelineCloudRuleEntity)
+	require.True(t, ok)
+	require.Equal(t, testRuleID, ruleEntity.ID)
+}
+
+func TestUnitEntityManagement_GetEntitySearchWithContext(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testGetEntitySearchResponseJSON, http.StatusOK)
+
+	result, err := client.GetEntitySearchWithContext(context.Background(), "", "type = 'PIPELINE_CLOUD_RULE'")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Entities, 1)
+}
+
+func TestUnitEntityManagement_GetEntitySearch_Empty(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testGetEntitySearchEmptyResponseJSON, http.StatusOK)
+
+	result, err := client.GetEntitySearch("", "type = 'NONEXISTENT'")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Entities, 0)
+}
+
+func TestUnitEntityManagement_GetEntitySearch_Error(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, `{"errors": [{"message": "Invalid query"}]}`, http.StatusBadRequest)
+
+	result, err := client.GetEntitySearch("", "invalid query")
+
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+func TestUnitEntityManagement_GetEntity_FederatedLogSetup(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testGetEntityFederatedLogSetupResponseJSON, http.StatusOK)
+
+	result, err := client.GetEntity(testFederatedLogSetupID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	setupEntity, ok := (*result).(*EntityManagementFederatedLogSetupEntity)
+	require.True(t, ok, "Fetched entity was not of the expected FederatedLogSetupEntity type")
+	require.Equal(t, testFederatedLogSetupID, setupEntity.ID)
+	require.Equal(t, "Test Federated Log Setup", setupEntity.Name)
+	require.Equal(t, EntityManagementCloudProviderTypes.AWS, setupEntity.CloudProvider)
+}
+
+func TestUnitEntityManagement_GetEntity_AwsConnection(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testGetEntityAwsConnectionResponseJSON, http.StatusOK)
+
+	result, err := client.GetEntity(testAwsConnectionID)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	connEntity, ok := (*result).(*EntityManagementAwsConnectionEntity)
+	require.True(t, ok, "Fetched entity was not of the expected AwsConnectionEntity type")
+	require.Equal(t, testAwsConnectionID, connEntity.ID)
+	require.Equal(t, "Test AWS Connection", connEntity.Name)
+	require.True(t, connEntity.Enabled)
+}
+
+var (
+	testFederatedLogPartitionID = "MXxWW0WWxWWWWWWWWW8WW0WWW1WWW1WWWWW2WWW8WWWxW5WxWwwwWW06WWW5WWw0WWWwWWWwWwWwWWWwWWWw"
+
+	testCreateFederatedLogPartitionResponseJSON = `
+	{
+		"data": {
+			"EntityManagementCreateFederatedLogPartition": {
+				"entity": {
+					"id": "MXxWW0WWxWWWWWWWWW8WW0WWW1WWW1WWWWW2WWW8WWWxW5WxWwwwWW06WWW5WWw0WWWwWWWwWwWwWWWwWWWw",
+					"metadata": {
+						"version": 1
+					},
+					"name": "Test Partition",
+					"description": "Test Federated Log Partition - New Relic Go Client",
+					"dataLocationUri": "s3://my-bucket/logs/partition1",
+					"isDefault": false,
+					"nrAccountId": "12345",
+					"partitionDatabase": "my_database",
+					"partitionTable": "my_table",
+					"status": "ACTIVE",
+					"retentionPolicy": {
+						"duration": 30,
+						"unit": "DAYS"
+					},
+					"scope": {
+						"id": "12345",
+						"type": "ACCOUNT"
+					},
+					"tags": [],
+					"type": "FEDERATED_LOG_PARTITION"
+				}
+			}
+		}
+	}`
+
+	testCreateFederatedLogPartitionErrorResponseJSON = `
+	{
+		"errors": [
+			{
+				"message": "Invalid input: missing required field"
+			}
+		]
+	}`
+)
+
+func TestUnitEntityManagement_CreateFederatedLogPartition(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testCreateFederatedLogPartitionResponseJSON, http.StatusOK)
+
+	createInput := EntityManagementFederatedLogPartitionEntityCreateInput{
+		Name:              "Test Partition",
+		Description:       "Test Federated Log Partition - New Relic Go Client",
+		DataLocationUri:   "s3://my-bucket/logs/partition1",
+		IsDefault:         false,
+		NrAccountId:       "12345",
+		PartitionDatabase: "my_database",
+		PartitionTable:    "my_table",
+		SetupId:           "setup-789",
+		Status:            EntityManagementLogPartitionStatusTypes.ACTIVE,
+		RetentionPolicy: &EntityManagementRetentionPolicyCreateInput{
+			Duration: 30,
+			Unit:     EntityManagementRetentionUnitTypes.DAYS,
+		},
+		Scope: EntityManagementScopedReferenceInput{
+			Type: EntityManagementEntityScopeTypes.ACCOUNT,
+			ID:   testAccountID,
+		},
+	}
+
+	result, err := client.EntityManagementCreateFederatedLogPartition(createInput)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, testFederatedLogPartitionID, result.Entity.ID)
+	require.Equal(t, "Test Partition", result.Entity.Name)
+	require.Equal(t, "s3://my-bucket/logs/partition1", result.Entity.DataLocationUri)
+	require.False(t, result.Entity.IsDefault)
+	require.Equal(t, "12345", result.Entity.NrAccountId)
+	require.Equal(t, "my_database", result.Entity.PartitionDatabase)
+	require.Equal(t, "my_table", result.Entity.PartitionTable)
+	require.Equal(t, EntityManagementLogPartitionStatusTypes.ACTIVE, result.Entity.Status)
+	require.Equal(t, 30, result.Entity.RetentionPolicy.Duration)
+	require.Equal(t, EntityManagementRetentionUnitTypes.DAYS, result.Entity.RetentionPolicy.Unit)
+}
+
+func TestUnitEntityManagement_CreateFederatedLogPartitionWithContext(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testCreateFederatedLogPartitionResponseJSON, http.StatusOK)
+
+	createInput := EntityManagementFederatedLogPartitionEntityCreateInput{
+		Name:              "Test Partition",
+		Description:       "Test Federated Log Partition - New Relic Go Client",
+		DataLocationUri:   "s3://my-bucket/logs/partition1",
+		IsDefault:         false,
+		NrAccountId:       "12345",
+		PartitionDatabase: "my_database",
+		PartitionTable:    "my_table",
+		SetupId:           "setup-789",
+		Status:            EntityManagementLogPartitionStatusTypes.ACTIVE,
+		Scope: EntityManagementScopedReferenceInput{
+			Type: EntityManagementEntityScopeTypes.ACCOUNT,
+			ID:   testAccountID,
+		},
+	}
+
+	result, err := client.EntityManagementCreateFederatedLogPartitionWithContext(context.Background(), createInput)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, testFederatedLogPartitionID, result.Entity.ID)
+	require.Equal(t, "Test Partition", result.Entity.Name)
+}
+
+func TestUnitEntityManagement_CreateFederatedLogPartition_Error(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testCreateFederatedLogPartitionErrorResponseJSON, http.StatusBadRequest)
+
+	createInput := EntityManagementFederatedLogPartitionEntityCreateInput{
+		Name: "Test Partition",
+	}
+
+	result, err := client.EntityManagementCreateFederatedLogPartition(createInput)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+var (
+	testUpdateFederatedLogSetupResponseJSON = `
+	{
+		"data": {
+			"EntityManagementUpdateFederatedLogSetup": {
+				"entity": {
+					"id": "MXxYY0YYxYYYYYYYYY6YY0YYY1YYY1YYYYY9YYY6YYYxY3YxYyyyYY04YYY3YYy0YYYyYYYyYyYyYYYyYYYy",
+					"name": "Test Federated Log Setup Updated",
+					"cloudProvider": "AWS",
+					"cloudProviderRegion": "us-east-1",
+					"dataLocationBucket": "my-updated-bucket",
+					"description": "Updated description",
+					"nrAccountId": "12345",
+					"nrRegion": "US",
+					"status": "ACTIVE",
+					"metadata": {
+						"version": 2
+					},
+					"scope": {
+						"id": "12345",
+						"type": "ACCOUNT"
+					},
+					"tags": []
+				}
+			}
+		}
+	}`
+
+	testUpdateFederatedLogSetupErrorResponseJSON = `
+	{
+		"errors": [
+			{
+				"message": "Entity not found"
+			}
+		]
+	}`
+
+	testUpdateFederatedLogPartitionResponseJSON = `
+	{
+		"data": {
+			"EntityManagementUpdateFederatedLogPartition": {
+				"entity": {
+					"id": "MXxWW0WWxWWWWWWWWW8WW0WWW1WWW1WWWWW2WWW8WWWxW5WxWwwwWW06WWW5WWw0WWWwWWWwWwWwWWWwWWWw",
+					"name": "Test Partition Updated",
+					"dataLocationUri": "s3://my-bucket/logs/partition-updated",
+					"description": "Updated partition description",
+					"isDefault": true,
+					"nrAccountId": "12345",
+					"partitionDatabase": "my_database_updated",
+					"partitionTable": "my_table_updated",
+					"status": "ACTIVE",
+					"retentionPolicy": {
+						"duration": 60,
+						"unit": "DAYS"
+					},
+					"metadata": {
+						"version": 2
+					},
+					"scope": {
+						"id": "12345",
+						"type": "ACCOUNT"
+					},
+					"tags": [],
+					"type": "FEDERATED_LOG_PARTITION"
+				}
+			}
+		}
+	}`
+
+	testUpdateFederatedLogPartitionErrorResponseJSON = `
+	{
+		"errors": [
+			{
+				"message": "Entity not found"
+			}
+		]
+	}`
+)
+
+func TestUnitEntityManagement_UpdateFederatedLogSetup(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testUpdateFederatedLogSetupResponseJSON, http.StatusOK)
+
+	updateInput := EntityManagementFederatedLogSetupEntityUpdateInput{
+		Name:                       "Test Federated Log Setup Updated",
+		Description:                "Updated description",
+		CloudProvider:              EntityManagementCloudProviderTypes.AWS,
+		CloudProviderRegion:        "us-east-1",
+		DataLocationBucket:         "my-updated-bucket",
+		DataProcessingConnectionId: "connection-123",
+		NrAccountId:                "12345",
+		NrRegion:                   EntityManagementNrRegionTypes.US,
+		QueryConnectionId:          "query-connection-456",
+		Status:                     EntityManagementFederatedLogSetupStatusTypes.ACTIVE,
+	}
+
+	result, err := client.EntityManagementUpdateFederatedLogSetup(updateInput, testFederatedLogSetupID, 1)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, testFederatedLogSetupID, result.Entity.ID)
+	require.Equal(t, "Test Federated Log Setup Updated", result.Entity.Name)
+	require.Equal(t, "my-updated-bucket", result.Entity.DataLocationBucket)
+	require.Equal(t, EntityManagementFederatedLogSetupStatusTypes.ACTIVE, result.Entity.Status)
+	require.Equal(t, 2, result.Entity.Metadata.Version)
+}
+
+func TestUnitEntityManagement_UpdateFederatedLogSetupWithContext(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testUpdateFederatedLogSetupResponseJSON, http.StatusOK)
+
+	updateInput := EntityManagementFederatedLogSetupEntityUpdateInput{
+		Name:        "Test Federated Log Setup Updated",
+		Description: "Updated description",
+	}
+
+	result, err := client.EntityManagementUpdateFederatedLogSetupWithContext(context.Background(), updateInput, testFederatedLogSetupID, 1)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, testFederatedLogSetupID, result.Entity.ID)
+	require.Equal(t, "Test Federated Log Setup Updated", result.Entity.Name)
+}
+
+func TestUnitEntityManagement_UpdateFederatedLogSetup_Error(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testUpdateFederatedLogSetupErrorResponseJSON, http.StatusNotFound)
+
+	updateInput := EntityManagementFederatedLogSetupEntityUpdateInput{
+		Name: "Test Federated Log Setup Updated",
+	}
+
+	result, err := client.EntityManagementUpdateFederatedLogSetup(updateInput, "non-existent-id", 1)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+func TestUnitEntityManagement_UpdateFederatedLogPartition(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testUpdateFederatedLogPartitionResponseJSON, http.StatusOK)
+
+	updateInput := EntityManagementFederatedLogPartitionEntityUpdateInput{
+		Name:              "Test Partition Updated",
+		Description:       "Updated partition description",
+		DataLocationUri:   "s3://my-bucket/logs/partition-updated",
+		IsDefault:         true,
+		NrAccountId:       "12345",
+		PartitionDatabase: "my_database_updated",
+		PartitionTable:    "my_table_updated",
+		SetupId:           "setup-789",
+		Status:            EntityManagementLogPartitionStatusTypes.ACTIVE,
+		RetentionPolicy: &EntityManagementRetentionPolicyUpdateInput{
+			Duration: 60,
+			Unit:     EntityManagementRetentionUnitTypes.DAYS,
+		},
+	}
+
+	result, err := client.EntityManagementUpdateFederatedLogPartition(updateInput, testFederatedLogPartitionID, 1)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, testFederatedLogPartitionID, result.Entity.ID)
+	require.Equal(t, "Test Partition Updated", result.Entity.Name)
+	require.Equal(t, "s3://my-bucket/logs/partition-updated", result.Entity.DataLocationUri)
+	require.True(t, result.Entity.IsDefault)
+	require.Equal(t, "my_database_updated", result.Entity.PartitionDatabase)
+	require.Equal(t, "my_table_updated", result.Entity.PartitionTable)
+	require.Equal(t, 60, result.Entity.RetentionPolicy.Duration)
+	require.Equal(t, EntityManagementRetentionUnitTypes.DAYS, result.Entity.RetentionPolicy.Unit)
+	require.Equal(t, 2, result.Entity.Metadata.Version)
+}
+
+func TestUnitEntityManagement_UpdateFederatedLogPartitionWithContext(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testUpdateFederatedLogPartitionResponseJSON, http.StatusOK)
+
+	updateInput := EntityManagementFederatedLogPartitionEntityUpdateInput{
+		Name:        "Test Partition Updated",
+		Description: "Updated partition description",
+	}
+
+	result, err := client.EntityManagementUpdateFederatedLogPartitionWithContext(context.Background(), updateInput, testFederatedLogPartitionID, 1)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, testFederatedLogPartitionID, result.Entity.ID)
+	require.Equal(t, "Test Partition Updated", result.Entity.Name)
+}
+
+func TestUnitEntityManagement_UpdateFederatedLogPartition_Error(t *testing.T) {
+	t.Parallel()
+	client := newMockClient(t, testUpdateFederatedLogPartitionErrorResponseJSON, http.StatusNotFound)
+
+	updateInput := EntityManagementFederatedLogPartitionEntityUpdateInput{
+		Name: "Test Partition Updated",
+	}
+
+	result, err := client.EntityManagementUpdateFederatedLogPartition(updateInput, "non-existent-id", 1)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+}

--- a/pkg/pipelinecontrol/types.go
+++ b/pkg/pipelinecontrol/types.go
@@ -24,7 +24,7 @@ var AgentApplicationSegmentsListTypeTypes = struct {
 	USER: "USER",
 }
 
-// AgentApplicationSettingsBrowserLoader - Determines which browser loader will be configured. Some allowed return values are specified for backwards-compatability and do not represent currently allowed values for new applications.
+// AgentApplicationSettingsBrowserLoader - Determines which browser loader will be configured. Some allowed return values are specified for backwards-compatibility and do not represent currently allowed values for new applications.
 // See [documentation](https://docs.newrelic.com/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#agent-types) for further information.
 type AgentApplicationSettingsBrowserLoader string
 
@@ -41,7 +41,7 @@ var AgentApplicationSettingsBrowserLoaderTypes = struct {
 	RUM AgentApplicationSettingsBrowserLoader
 	// Pro+SPA: This is the default installed agent when you enable browser monitoring. Gives you access to all of the Browser Pro features and to Single Page App (SPA) monitoring. Provides detailed page timing data and the most up-to-date New Relic features, including distributed tracing, for all types of applications.
 	SPA AgentApplicationSettingsBrowserLoader
-	// This value is specified for backwards-compatability.
+	// This value is specified for backwards-compatibility.
 	XHR AgentApplicationSettingsBrowserLoader
 }{
 	// Use PRO instead
@@ -56,7 +56,7 @@ var AgentApplicationSettingsBrowserLoaderTypes = struct {
 	RUM: "RUM",
 	// Pro+SPA: This is the default installed agent when you enable browser monitoring. Gives you access to all of the Browser Pro features and to Single Page App (SPA) monitoring. Provides detailed page timing data and the most up-to-date New Relic features, including distributed tracing, for all types of applications.
 	SPA: "SPA",
-	// This value is specified for backwards-compatability.
+	// This value is specified for backwards-compatibility.
 	XHR: "XHR",
 }
 
@@ -1335,6 +1335,29 @@ var EntityManagementCategoryScopeTypeTypes = struct {
 	GLOBAL: "GLOBAL",
 }
 
+// EntityManagementCloudProvider - Supported cloud providers for federated log deployments.
+type EntityManagementCloudProvider string
+
+var EntityManagementCloudProviderTypes = struct {
+	// Amazon Web Services
+	AWS EntityManagementCloudProvider
+	// Microsoft Azure
+	AZURE EntityManagementCloudProvider
+	// Google Cloud Platform
+	GCP EntityManagementCloudProvider
+	// Oracle Cloud Infrastructure
+	OCI EntityManagementCloudProvider
+}{
+	// Amazon Web Services
+	AWS: "AWS",
+	// Microsoft Azure
+	AZURE: "AZURE",
+	// Google Cloud Platform
+	GCP: "GCP",
+	// Oracle Cloud Infrastructure
+	OCI: "OCI",
+}
+
 // EntityManagementEncodingName - The Encoding names options
 type EntityManagementEncodingName string
 
@@ -1413,6 +1436,29 @@ var EntityManagementExternalOwnerTypeTypes = struct {
 	USER: "USER",
 	// workspace if the source is bitbucket
 	WORKSPACE: "WORKSPACE",
+}
+
+// EntityManagementFederatedLogSetupStatus - Status of a federated log setup.
+type EntityManagementFederatedLogSetupStatus string
+
+var EntityManagementFederatedLogSetupStatusTypes = struct {
+	// Indicates the federated log setup is active.
+	ACTIVE EntityManagementFederatedLogSetupStatus
+	// Indicates the federated log setup is being created.
+	CREATING EntityManagementFederatedLogSetupStatus
+	// Indicates the federated log setup is in an error state.
+	ERROR EntityManagementFederatedLogSetupStatus
+	// Indicates the federated log setup is inactive.
+	INACTIVE EntityManagementFederatedLogSetupStatus
+}{
+	// Indicates the federated log setup is active.
+	ACTIVE: "ACTIVE",
+	// Indicates the federated log setup is being created.
+	CREATING: "CREATING",
+	// Indicates the federated log setup is in an error state.
+	ERROR: "ERROR",
+	// Indicates the federated log setup is inactive.
+	INACTIVE: "INACTIVE",
 }
 
 // EntityManagementFleetDeploymentPhase - Phases a fleet deployment can have
@@ -1592,6 +1638,21 @@ var EntityManagementManagedEntityTypeTypes = struct {
 	HOST: "HOST",
 	// Kubernetes Cluster
 	KUBERNETESCLUSTER: "KUBERNETESCLUSTER",
+}
+
+// EntityManagementNrRegion - New Relic regions for federated log.
+type EntityManagementNrRegion string
+
+var EntityManagementNrRegionTypes = struct {
+	// EU region
+	EU EntityManagementNrRegion
+	// US region
+	US EntityManagementNrRegion
+}{
+	// EU region
+	EU: "EU",
+	// US region
+	US: "US",
 }
 
 // EntityManagementStatusCode - Rule execution status codes
@@ -2551,7 +2612,7 @@ type ApmApplicationDeployment struct {
 	Permalink string `json:"permalink,omitempty"`
 	// The revision of the app that was deployed
 	Revision string `json:"revision,omitempty"`
-	// The moment the deployment occured
+	// The moment the deployment occurred
 	Timestamp *nrtime.EpochMilliseconds `json:"timestamp,omitempty"`
 	// The user who triggered the deployment
 	User string `json:"user,omitempty"`
@@ -2616,7 +2677,7 @@ type ApmApplicationEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -2822,7 +2883,7 @@ type ApmDatabaseInstanceEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -2950,7 +3011,7 @@ type ApmExternalServiceEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -3094,7 +3155,7 @@ type BrowserApplicationEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -3376,7 +3437,7 @@ type DashboardEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -3787,7 +3848,7 @@ type Entity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -4445,6 +4506,201 @@ type EntityManagementExternalOwner struct {
 	ID string `json:"id"`
 	// Type of owner of the repository eg:- user,organisation etc.
 	Type EntityManagementExternalOwnerType `json:"type"`
+}
+
+// EntityManagementFederatedLogSetupEntity - Federated Log Setup Entity.
+type EntityManagementFederatedLogSetupEntity struct {
+	// The cloud provider where this Federated Log setup is deployed.
+	CloudProvider EntityManagementCloudProvider `json:"cloudProvider"`
+	// The cloud provider region where the Federated Log setup is deployed.
+	CloudProviderRegion string `json:"cloudProviderRegion"`
+	// The object storage bucket where log data is stored.
+	DataLocationBucket string `json:"dataLocationBucket"`
+	// The data processing component that defines transformation rules and partition routing logic for this federated log setup.
+	DataProcessingComponent EntityManagementEntityInterface `json:"dataProcessingComponent,omitempty"`
+	// The connection manager entity used for data processing, transformation, and partition routing.
+	DataProcessingConnection EntityManagementEntityInterface `json:"dataProcessingConnection"`
+	// The description of the Federated Log setup.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID string `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the federated log setup.
+	Name string `json:"name"`
+	// The NR account ID associated with the federated log setup.
+	NrAccountId string `json:"nrAccountId"`
+	// The NR region associated with the federated log setup.
+	NrRegion EntityManagementNrRegion `json:"nrRegion"`
+	// The connection manager entity used by query workers for reading and accessing federated log resources.
+	QueryConnection EntityManagementEntityInterface `json:"queryConnection"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The status of the federated log setup.
+	Status EntityManagementFederatedLogSetupStatus `json:"status"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementFederatedLogSetupEntity) ImplementsEntityManagementEntity() {}
+
+// special
+func (x *EntityManagementFederatedLogSetupEntity) UnmarshalJSON(b []byte) error {
+	var objMap map[string]*json.RawMessage
+	err := json.Unmarshal(b, &objMap)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range objMap {
+		if v == nil {
+			continue
+		}
+
+		switch k {
+		case "cloudProvider":
+			err = json.Unmarshal(*v, &x.CloudProvider)
+			if err != nil {
+				return err
+			}
+		case "cloudProviderRegion":
+			err = json.Unmarshal(*v, &x.CloudProviderRegion)
+			if err != nil {
+				return err
+			}
+		case "dataLocationBucket":
+			err = json.Unmarshal(*v, &x.DataLocationBucket)
+			if err != nil {
+				return err
+			}
+		case "dataProcessingComponent":
+			if v == nil {
+				continue
+			}
+			xxx, err := UnmarshalEntityManagementEntityInterface(*v)
+			if err != nil {
+				return err
+			}
+
+			if xxx != nil {
+				x.DataProcessingComponent = *xxx
+			}
+		case "dataProcessingConnection":
+			if v == nil {
+				continue
+			}
+			xxx, err := UnmarshalEntityManagementEntityInterface(*v)
+			if err != nil {
+				return err
+			}
+
+			if xxx != nil {
+				x.DataProcessingConnection = *xxx
+			}
+		case "description":
+			err = json.Unmarshal(*v, &x.Description)
+			if err != nil {
+				return err
+			}
+		case "id":
+			err = json.Unmarshal(*v, &x.ID)
+			if err != nil {
+				return err
+			}
+		case "metadata":
+			err = json.Unmarshal(*v, &x.Metadata)
+			if err != nil {
+				return err
+			}
+		case "name":
+			err = json.Unmarshal(*v, &x.Name)
+			if err != nil {
+				return err
+			}
+		case "nrAccountId":
+			err = json.Unmarshal(*v, &x.NrAccountId)
+			if err != nil {
+				return err
+			}
+		case "nrRegion":
+			err = json.Unmarshal(*v, &x.NrRegion)
+			if err != nil {
+				return err
+			}
+		case "queryConnection":
+			if v == nil {
+				continue
+			}
+			xxx, err := UnmarshalEntityManagementEntityInterface(*v)
+			if err != nil {
+				return err
+			}
+
+			if xxx != nil {
+				x.QueryConnection = *xxx
+			}
+		case "scope":
+			err = json.Unmarshal(*v, &x.Scope)
+			if err != nil {
+				return err
+			}
+		case "status", "setupStatus":
+			err = json.Unmarshal(*v, &x.Status)
+			if err != nil {
+				return err
+			}
+		case "tags":
+			err = json.Unmarshal(*v, &x.Tags)
+			if err != nil {
+				return err
+			}
+		case "type":
+			err = json.Unmarshal(*v, &x.Type)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// EntityManagementFederatedLogSetupEntityCreateInput - Create input for FederatedLogSetupEntity entity type.
+type EntityManagementFederatedLogSetupEntityCreateInput struct {
+	// See cloudProvider in FederatedLogSetupEntity.
+	CloudProvider EntityManagementCloudProvider `json:"cloudProvider"`
+	// See cloudProviderRegion in FederatedLogSetupEntity.
+	CloudProviderRegion string `json:"cloudProviderRegion"`
+	// See dataLocationBucket in FederatedLogSetupEntity.
+	DataLocationBucket string `json:"dataLocationBucket"`
+	// See dataProcessingComponentId in FederatedLogSetupEntity.
+	DataProcessingComponentId string `json:"dataProcessingComponentId,omitempty"`
+	// See dataProcessingConnectionId in FederatedLogSetupEntity.
+	DataProcessingConnectionId string `json:"dataProcessingConnectionId"`
+	// See description in FederatedLogSetupEntity.
+	Description string `json:"description,omitempty"`
+	// See name in FederatedLogSetupEntity.
+	Name string `json:"name"`
+	// See nrAccountId in FederatedLogSetupEntity.
+	NrAccountId string `json:"nrAccountId"`
+	// See nrRegion in FederatedLogSetupEntity.
+	NrRegion EntityManagementNrRegion `json:"nrRegion"`
+	// See queryConnectionId in FederatedLogSetupEntity.
+	QueryConnectionId string `json:"queryConnectionId"`
+	// See scope in FederatedLogSetupEntity.
+	Scope EntityManagementScopedReferenceInput `json:"scope,omitempty"`
+	// See status in FederatedLogSetupEntity.
+	Status EntityManagementFederatedLogSetupStatus `json:"status"`
+	// See tags in FederatedLogSetupEntity.
+	Tags []EntityManagementTagInput `json:"tags,omitempty"`
+}
+
+// EntityManagementFederatedLogSetupEntityCreateResult - The result of creating an entity.
+type EntityManagementFederatedLogSetupEntityCreateResult struct {
+	// The created entity.
+	Entity EntityManagementFederatedLogSetupEntity `json:"entity"`
 }
 
 // EntityManagementFleetDeployment - Deprecated: A set of configurations that are currently deployed
@@ -5588,7 +5844,7 @@ type ExternalEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -5703,7 +5959,7 @@ type GenericEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -5819,7 +6075,7 @@ type GenericInfrastructureEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -5940,7 +6196,7 @@ type InfrastructureAwsLambdaFunctionEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -6064,7 +6320,7 @@ type InfrastructureHostEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -6279,7 +6535,7 @@ type KeyTransactionEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -6478,7 +6734,7 @@ type MobileApplicationEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -6733,7 +6989,7 @@ type SecureCredentialEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -7183,7 +7439,7 @@ type SyntheticMonitorEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -7330,7 +7586,7 @@ type TeamEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -7447,7 +7703,7 @@ type ThirdPartyServiceEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -7578,7 +7834,7 @@ type UnavailableEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -7706,7 +7962,7 @@ type WorkloadEntity struct {
 	//
 	// See the [NRQL Docs](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions) for more information about generating a query string.
 	NRDBQuery NRDBResultContainer `json:"nrdbQuery,omitempty"`
-	// Poll for the results of a previously-executed asychronous NRDB query.
+	// Poll for the results of a previously-executed asynchronous NRDB query.
 	//
 	// The `queryId` is available in the `queryProgress` data returned by the original asynchronous query.
 	//
@@ -7851,6 +8107,9 @@ type EntityAlertViolationInt string
 
 // EntityGUID - An encoded Entity GUID
 type EntityGUID string
+
+// EntityManagementDynamicString - A string meant to be generated at runtime by a function in the form of a directive.
+type EntityManagementDynamicString string
 
 // Float - The `Float` scalar type represents signed double-precision fractional
 // values as specified by
@@ -8811,6 +9070,37 @@ func UnmarshalEntityManagementEntityInterface(b []byte) (*EntityManagementEntity
 			var xxx EntityManagementEntityInterface = &interfaceType
 
 			return &xxx, nil
+		case "EntityManagementFederatedLogSetupEntity":
+			var interfaceType EntityManagementFederatedLogSetupEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementFederatedLogPartitionEntity":
+			var interfaceType EntityManagementFederatedLogPartitionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+
+		case "EntityManagementAwsConnectionEntity":
+			var interfaceType EntityManagementAwsConnectionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
 		}
 	} else {
 		keys := []string{}
@@ -9327,4 +9617,306 @@ func (x *EntityManagementActorStitchedFields) UnmarshalJSON(b []byte) error {
 	}
 
 	return nil
+}
+
+// EntityManagementAwsAssumeRoleConfig - Configuration for accessing an Aws account via AssumeRole
+type EntityManagementAwsAssumeRoleConfig struct {
+	// External ID to use when assuming the role
+	ExternalId EntityManagementDynamicString `json:"externalId,omitempty"`
+	// The ARN of the role to assume
+	RoleArn string `json:"roleArn"`
+}
+
+// EntityManagementAwsConnectionEntity - Connection entity type for Aws
+type EntityManagementAwsConnectionEntity struct {
+	// A single credential from the choice of AwsCredential
+	Credential EntityManagementAwsCredentials `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. True by default
+	Enabled bool `json:"enabled,omitempty"`
+	// Optional field representing an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID string `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// Default region for this connection
+	Region string `json:"region,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity's type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementAwsConnectionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementAwsCredentials - Base Credential type for Aws
+type EntityManagementAwsCredentials struct {
+	// AssumeRole type
+	AssumeRole EntityManagementAwsAssumeRoleConfig `json:"assumeRole,omitempty"`
+}
+
+// EntityManagementConnectionSettings - Connection settings type for all connections
+type EntityManagementConnectionSettings struct {
+	// The key or name of the setting
+	Key string `json:"key"`
+	// The value of the setting.
+	Value string `json:"value"`
+}
+
+// EntityManagementAwsConnectionEntityCreateInput - Create input for AwsConnectionEntity entity type.
+type EntityManagementAwsConnectionEntityCreateInput struct {
+	// See credential in AwsConnectionEntity.
+	Credential EntityManagementAwsCredentialsCreateInput `json:"credential,omitempty"`
+	// See description in AwsConnectionEntity.
+	Description string `json:"description,omitempty"`
+	// See enabled in AwsConnectionEntity.
+	Enabled bool `json:"enabled,omitempty"`
+	// See externalId in AwsConnectionEntity.
+	ExternalId string `json:"externalId,omitempty"`
+	// See name in AwsConnectionEntity.
+	Name string `json:"name"`
+	// See region in AwsConnectionEntity.
+	Region string `json:"region,omitempty"`
+	// See scope in AwsConnectionEntity.
+	Scope EntityManagementScopedReferenceInput `json:"scope,omitempty"`
+	// See settings in AwsConnectionEntity.
+	Settings []EntityManagementConnectionSettingsCreateInput `json:"settings,omitempty"`
+	// See tags in AwsConnectionEntity.
+	Tags []EntityManagementTagInput `json:"tags,omitempty"`
+}
+
+// EntityManagementAwsConnectionEntityCreateResult - The result of creating an entity.
+type EntityManagementAwsConnectionEntityCreateResult struct {
+	// The created entity.
+	Entity EntityManagementAwsConnectionEntity `json:"entity"`
+}
+
+// EntityManagementConnectionSettingsCreateInput - Create input for ConnectionSettings.
+type EntityManagementConnectionSettingsCreateInput struct {
+	// See key in ConnectionSettings.
+	Key string `json:"key"`
+	// See value in ConnectionSettings.
+	Value string `json:"value"`
+}
+
+// EntityManagementAwsCredentialsCreateInput - Create input for AwsCredentials.
+type EntityManagementAwsCredentialsCreateInput struct {
+	// See assumeRole in AwsCredentials.
+	AssumeRole EntityManagementAwsAssumeRoleConfigCreateInput `json:"assumeRole,omitempty"`
+}
+
+// EntityManagementAwsAssumeRoleConfigCreateInput - Create input for AwsAssumeRoleConfig.
+type EntityManagementAwsAssumeRoleConfigCreateInput struct {
+	// See roleArn in AwsAssumeRoleConfig.
+	RoleArn string `json:"roleArn"`
+}
+
+// EntityManagementFederatedLogPartitionEntity - Federated Log partition entity.
+type EntityManagementFederatedLogPartitionEntity struct {
+	// The URI location of the log partition in object storage.
+	DataLocationUri string `json:"dataLocationURI"`
+	// The description of the log partition.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID string `json:"id"`
+	// Indicates if this log partition is the default partition.
+	IsDefault bool `json:"isDefault"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the log partition. This corresponds to the partition/event type used in log queries.
+	Name string `json:"name"`
+	// The NR account ID associated with the federated log partition.
+	NrAccountId string `json:"nrAccountId"`
+	// The database name associated with the log partition. This could refer to a data catalog database or similar structure.
+	PartitionDatabase string `json:"partitionDatabase"`
+	// The table name associated with the log partition. This could refer to a data catalog table or similar structure.
+	PartitionTable string `json:"partitionTable"`
+	// The optional retention policy for logs in this partition.
+	RetentionPolicy EntityManagementRetentionPolicy `json:"retentionPolicy,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The federated log setup this partition belongs to.
+	Setup EntityManagementFederatedLogSetupEntity `json:"setup"`
+	// The status of the log partition.
+	Status EntityManagementLogPartitionStatus `json:"status"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+// EntityManagementRetentionPolicy - Retention policy for log data.
+type EntityManagementRetentionPolicy struct {
+	// The duration value for retention.
+	Duration int `json:"duration"`
+	// The time unit for the retention duration.
+	Unit EntityManagementRetentionUnit `json:"unit"`
+}
+
+// EntityManagementRetentionPolicyCreateInput - Create input for RetentionPolicy.
+type EntityManagementRetentionPolicyCreateInput struct {
+	// See duration in RetentionPolicy.
+	Duration int `json:"duration"`
+	// See unit in RetentionPolicy.
+	Unit EntityManagementRetentionUnit `json:"unit"`
+}
+
+func (x *EntityManagementFederatedLogPartitionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementFederatedLogPartitionEntityCreateInput - Create input for FederatedLogPartitionEntity entity type.
+type EntityManagementFederatedLogPartitionEntityCreateInput struct {
+	// See dataLocationURI in FederatedLogPartitionEntity.
+	DataLocationUri string `json:"dataLocationURI"`
+	// See description in FederatedLogPartitionEntity.
+	Description string `json:"description,omitempty"`
+	// See isDefault in FederatedLogPartitionEntity.
+	IsDefault bool `json:"isDefault"`
+	// See name in FederatedLogPartitionEntity.
+	Name string `json:"name"`
+	// See nrAccountId in FederatedLogPartitionEntity.
+	NrAccountId string `json:"nrAccountId"`
+	// See partitionDatabase in FederatedLogPartitionEntity.
+	PartitionDatabase string `json:"partitionDatabase"`
+	// See partitionTable in FederatedLogPartitionEntity.
+	PartitionTable string `json:"partitionTable"`
+	// See retentionPolicy in FederatedLogPartitionEntity.
+	RetentionPolicy *EntityManagementRetentionPolicyCreateInput `json:"retentionPolicy,omitempty"`
+	// See scope in FederatedLogPartitionEntity.
+	Scope EntityManagementScopedReferenceInput `json:"scope,omitempty"`
+	// See setupId in FederatedLogPartitionEntity.
+	SetupId string `json:"setupId"`
+	// See status in FederatedLogPartitionEntity.
+	Status EntityManagementLogPartitionStatus `json:"status"`
+	// See tags in FederatedLogPartitionEntity.
+	Tags []EntityManagementTagInput `json:"tags,omitempty"`
+}
+
+// EntityManagementFederatedLogPartitionEntityCreateResult - The result of creating an entity.
+type EntityManagementFederatedLogPartitionEntityCreateResult struct {
+	// The created entity.
+	Entity EntityManagementFederatedLogPartitionEntity `json:"entity"`
+}
+
+// EntityManagementLogPartitionStatus - Status of a log partition.
+type EntityManagementLogPartitionStatus string
+
+var EntityManagementLogPartitionStatusTypes = struct {
+	// Indicates the log partition is active.
+	ACTIVE EntityManagementLogPartitionStatus
+	// Indicates the log partition is being created.
+	CREATING EntityManagementLogPartitionStatus
+	// Indicates the log partition is in an error state.
+	ERROR EntityManagementLogPartitionStatus
+	// Indicates the log partition is inactive.
+	INACTIVE EntityManagementLogPartitionStatus
+}{
+	// Indicates the log partition is active.
+	ACTIVE: "ACTIVE",
+	// Indicates the log partition is being created.
+	CREATING: "CREATING",
+	// Indicates the log partition is in an error state.
+	ERROR: "ERROR",
+	// Indicates the log partition is inactive.
+	INACTIVE: "INACTIVE",
+}
+
+// EntityManagementRetentionUnit - Time units for retention policies.
+type EntityManagementRetentionUnit string
+
+var EntityManagementRetentionUnitTypes = struct {
+	// Days
+	DAYS EntityManagementRetentionUnit
+	// Months
+	MONTHS EntityManagementRetentionUnit
+	// Weeks
+	WEEKS EntityManagementRetentionUnit
+}{
+	// Days
+	DAYS: "DAYS",
+	// Months
+	MONTHS: "MONTHS",
+	// Weeks
+	WEEKS: "WEEKS",
+}
+
+// EntityManagementFederatedLogPartitionEntityUpdateResult - The result of updating an entity.
+type EntityManagementFederatedLogPartitionEntityUpdateResult struct {
+	// The updated entity.
+	Entity EntityManagementFederatedLogPartitionEntity `json:"entity"`
+}
+
+// EntityManagementFederatedLogPartitionEntityUpdateInput - Update input for FederatedLogPartitionEntity entity type.
+type EntityManagementFederatedLogPartitionEntityUpdateInput struct {
+	// See dataLocationURI in FederatedLogPartitionEntity.
+	DataLocationUri string `json:"dataLocationURI,omitempty"`
+	// See description in FederatedLogPartitionEntity.
+	Description string `json:"description,omitempty"`
+	// See isDefault in FederatedLogPartitionEntity.
+	IsDefault bool `json:"isDefault,omitempty"`
+	// See name in FederatedLogPartitionEntity.
+	Name string `json:"name,omitempty"`
+	// See nrAccountId in FederatedLogPartitionEntity.
+	NrAccountId string `json:"nrAccountId,omitempty"`
+	// See partitionDatabase in FederatedLogPartitionEntity.
+	PartitionDatabase string `json:"partitionDatabase,omitempty"`
+	// See partitionTable in FederatedLogPartitionEntity.
+	PartitionTable string `json:"partitionTable,omitempty"`
+	// See retentionPolicy in FederatedLogPartitionEntity.
+	RetentionPolicy *EntityManagementRetentionPolicyUpdateInput `json:"retentionPolicy,omitempty"`
+	// See setupId in FederatedLogPartitionEntity.
+	SetupId string `json:"setupId,omitempty"`
+	// See status in FederatedLogPartitionEntity.
+	Status EntityManagementLogPartitionStatus `json:"status,omitempty"`
+	// See tags in FederatedLogPartitionEntity.
+	Tags []EntityManagementTagInput `json:"tags,omitempty"`
+}
+
+// EntityManagementFederatedLogSetupEntityUpdateResult - The result of updating an entity.
+type EntityManagementFederatedLogSetupEntityUpdateResult struct {
+	// The updated entity.
+	Entity EntityManagementFederatedLogSetupEntity `json:"entity"`
+}
+
+// EntityManagementFederatedLogSetupEntityUpdateInput - Update input for FederatedLogSetupEntity entity type.
+type EntityManagementFederatedLogSetupEntityUpdateInput struct {
+	// See cloudProvider in FederatedLogSetupEntity.
+	CloudProvider EntityManagementCloudProvider `json:"cloudProvider,omitempty"`
+	// See cloudProviderRegion in FederatedLogSetupEntity.
+	CloudProviderRegion string `json:"cloudProviderRegion,omitempty"`
+	// See dataLocationBucket in FederatedLogSetupEntity.
+	DataLocationBucket string `json:"dataLocationBucket,omitempty"`
+	// See dataProcessingComponentId in FederatedLogSetupEntity.
+	DataProcessingComponentId string `json:"dataProcessingComponentId,omitempty"`
+	// See dataProcessingConnectionId in FederatedLogSetupEntity.
+	DataProcessingConnectionId string `json:"dataProcessingConnectionId,omitempty"`
+	// See description in FederatedLogSetupEntity.
+	Description string `json:"description,omitempty"`
+	// See name in FederatedLogSetupEntity.
+	Name string `json:"name,omitempty"`
+	// See nrAccountId in FederatedLogSetupEntity.
+	NrAccountId string `json:"nrAccountId,omitempty"`
+	// See nrRegion in FederatedLogSetupEntity.
+	NrRegion EntityManagementNrRegion `json:"nrRegion,omitempty"`
+	// See queryConnectionId in FederatedLogSetupEntity.
+	QueryConnectionId string `json:"queryConnectionId,omitempty"`
+	// See status in FederatedLogSetupEntity.
+	Status EntityManagementFederatedLogSetupStatus `json:"status,omitempty"`
+	// See tags in FederatedLogSetupEntity.
+	Tags []EntityManagementTagInput `json:"tags,omitempty"`
+}
+
+// EntityManagementRetentionPolicyUpdateInput - Update input for RetentionPolicy.
+type EntityManagementRetentionPolicyUpdateInput struct {
+	// See duration in RetentionPolicy.
+	Duration int `json:"duration"`
+	// See unit in RetentionPolicy.
+	Unit EntityManagementRetentionUnit `json:"unit"`
 }


### PR DESCRIPTION
**Summary**
Adds support for three new entity types in the pipelinecontrol package: FederatedLogSetupEntity, AwsConnectionEntity, and FederatedLogPartitionEntity. These enable full lifecycle management of federated log infrastructure resources via the Entity Management API.

**Changes**
New API Methods
Federated Log Setup

EntityManagementCreateFederatedLogSetup / WithContext — create a Federated Log Setup entity
EntityManagementUpdateFederatedLogSetup / WithContext — update an existing Federated Log Setup entity
Federated Log Partition

EntityManagementCreateFederatedLogPartition / WithContext — create a Federated Log Partition entity
EntityManagementUpdateFederatedLogPartition / WithContext — update an existing Federated Log Partition entity
AWS Connection

EntityManagementCreateAwsConnection / WithContext — create an AWS Connection entity
Search

GetEntitySearch / WithContext — search entities with filters and cursor-based pagination


**Tests**
Unit Tests (27 total)
Federated Log Setup (6)

Create: success, with-context, error
Update: success, with-context, error
Federated Log Partition (6)

Create: success, with-context, error
Update: success, with-context, error
AWS Connection (3)

Create: success, with-context, error
GetEntity (2)

Returns FederatedLogSetupEntity type assertion
Returns AwsConnectionEntity type assertion
GetEntitySearch (4)

Success, with-context, empty results, error


**Integration Tests**
TestIntegrationEntityManagement_FederatedLogSetup_CRUD — full create/read/update/delete cycle (gated by RUN_FEDERATED_LOG_SETUP_TEST=true)
TestIntegrationEntityManagement_FederatedLogSetup_Create — standalone create test with real credentials (gated by env vars)