### PR TITLE
feat(region): add Japan (JP) region support

### DIFF
--- a/pkg/region/region_constants.go
+++ b/pkg/region/region_constants.go
@@ -51,7 +51,7 @@ var Regions = map[Name]*Region{
 	},
 	JP: {
 		name:             "JP",
-		nerdGraphBaseURL: "https://one.jp.newrelic.com/graphql",
+		nerdGraphBaseURL: "https://api.jp.newrelic.com/graphql",
 	},
 	Staging: {
 		name:                  "Staging",

--- a/pkg/region/region_constants.go
+++ b/pkg/region/region_constants.go
@@ -12,6 +12,9 @@ const (
 	// EU represents New Relic's EU-based production deployment.
 	EU Name = "EU"
 
+	// JP represents New Relic's Japan-based production deployment.
+	JP Name = "JP"
+
 	// Staging represents New Relic's US-based staging deployment.
 	// This is for internal New Relic use only.
 	Staging Name = "Staging"
@@ -45,6 +48,10 @@ var Regions = map[Name]*Region{
 		syntheticsBaseURL:     "https://synthetics.eu.newrelic.com/synthetics/api",
 		metricsBaseURL:        "https://metric-api.eu.newrelic.com/metric/v1",
 		blobServiceBaseURL:    "https://blob-api.service.eu.newrelic.com/v1/e",
+	},
+	JP: {
+		name:             "JP",
+		nerdGraphBaseURL: "https://one.jp.newrelic.com/graphql",
 	},
 	Staging: {
 		name:                  "Staging",
@@ -83,6 +90,8 @@ func Parse(r string) (Name, error) {
 		return US, nil
 	case "eu":
 		return EU, nil
+	case "jp":
+		return JP, nil
 	case "staging":
 		return Staging, nil
 	case "local":

--- a/pkg/region/region_test.go
+++ b/pkg/region/region_test.go
@@ -143,7 +143,7 @@ func TestNerdgraphURLs(t *testing.T) {
 	pairs := map[Name]string{
 		US:      "https://api.newrelic.com/graphql",
 		EU:      "https://api.eu.newrelic.com/graphql",
-		JP:      "https://one.jp.newrelic.com/graphql",
+		JP:      "https://api.jp.newrelic.com/graphql",
 		Staging: "https://staging-api.newrelic.com/graphql",
 		Local:   "http://localhost:3000/graphql",
 	}

--- a/pkg/region/region_test.go
+++ b/pkg/region/region_test.go
@@ -21,6 +21,10 @@ func TestParse(t *testing.T) {
 		"Eu":      EU,
 		"eU":      EU,
 		"EU":      EU,
+		"jp":      JP,
+		"Jp":      JP,
+		"jP":      JP,
+		"JP":      JP,
 		"staging": Staging,
 		"Staging": Staging,
 		"STAGING": Staging,
@@ -48,6 +52,7 @@ func TestRegionGet(t *testing.T) {
 	pairs := map[Name]*Region{
 		US:      Regions[US],
 		EU:      Regions[EU],
+		JP:      Regions[JP],
 		Staging: Regions[Staging],
 	}
 
@@ -71,6 +76,7 @@ func TestRegionString(t *testing.T) {
 	pairs := map[Name]string{
 		US:      "US",
 		EU:      "EU",
+		JP:      "JP",
 		Staging: "Staging",
 		Local:   "Local",
 	}
@@ -137,6 +143,7 @@ func TestNerdgraphURLs(t *testing.T) {
 	pairs := map[Name]string{
 		US:      "https://api.newrelic.com/graphql",
 		EU:      "https://api.eu.newrelic.com/graphql",
+		JP:      "https://one.jp.newrelic.com/graphql",
 		Staging: "https://staging-api.newrelic.com/graphql",
 		Local:   "http://localhost:3000/graphql",
 	}


### PR DESCRIPTION
## Summary
- Add JP region constant for Japan datacenter deployment
- Add JP entry in Regions map with NerdGraph endpoint (`https://one.jp.newrelic.com/graphql`)
- Add 'jp' case in Parse function for region string parsing
- Add corresponding unit tests

## Context
This change supports deploying New Relic services in the new Japan (jp-production) datacenter, enabling customers to link their AWS and GCP accounts to New Relic via Terraform in the JP region.

## Test plan
- [x] Unit tests added for JP region parsing
- [x] Unit tests added for JP NerdGraph URL
- [x] All existing tests pass (`go test -tags unit ./pkg/region/...`)

🤖 Generated with [Claude Code](https://claude.ai/code)