### PR TITLE
feat(serialization): implement EpochMilliseconds JSON marshalling and unmarshalling

### DIFF
--- a/internal/serialization/epoch_milliseconds.go
+++ b/internal/serialization/epoch_milliseconds.go
@@ -1,0 +1,67 @@
+package serialization
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// MarshalEpochMillisecondsJSON returns JSON bytes for a Unix millisecond count
+// (GraphQL EpochMilliseconds scalar), including when sub-second nanoseconds are zero.
+func MarshalEpochMillisecondsJSON(t time.Time) ([]byte, error) {
+	return []byte(strconv.FormatInt(t.UTC().UnixMilli(), 10)), nil
+}
+
+// UnmarshalEpochMillisecondsJSON parses JSON for EpochMilliseconds: null, numeric
+// epoch forms handled by EpochTime, RFC3339 / RFC3339Nano strings (optionally JSON-quoted).
+func UnmarshalEpochMillisecondsJSON(s []byte, e *EpochTime) error {
+	if string(s) == "null" {
+		return nil
+	}
+
+	inner := s
+	if len(s) >= 2 && s[0] == '"' {
+		out, err := strconv.Unquote(string(s))
+		if err != nil {
+			return fmt.Errorf("epoch milliseconds: unquote: %w", err)
+		}
+		inner = []byte(out)
+	}
+
+	if len(inner) == 0 {
+		return fmt.Errorf("epoch milliseconds: empty value")
+	}
+
+	if isEpochNumericToken(inner) {
+		return (*EpochTime)(e).UnmarshalJSON(inner)
+	}
+
+	if tm, err := time.Parse(time.RFC3339Nano, string(inner)); err == nil {
+		*(*time.Time)(e) = tm.UTC()
+		return nil
+	}
+	if tm, err := time.Parse(time.RFC3339, string(inner)); err == nil {
+		*(*time.Time)(e) = tm.UTC()
+		return nil
+	}
+
+	return fmt.Errorf("epoch milliseconds: unable to parse %q", inner)
+}
+
+func isEpochNumericToken(b []byte) bool {
+	if len(b) == 0 {
+		return false
+	}
+	if string(b) == emptyTimeCase {
+		return true
+	}
+	for i, c := range b {
+		if i == 0 && c == '-' {
+			continue
+		}
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/serialization/epoch_milliseconds_test.go
+++ b/internal/serialization/epoch_milliseconds_test.go
@@ -1,0 +1,88 @@
+//go:build unit
+// +build unit
+
+package serialization
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalEpochMillisecondsJSON_CodyCase(t *testing.T) {
+	t.Parallel()
+
+	tm, err := time.Parse(time.RFC3339, "2021-05-17T21:28:04Z")
+	require.NoError(t, err)
+
+	b, err := MarshalEpochMillisecondsJSON(tm)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("1621286884000"), b)
+}
+
+func TestUnmarshalEpochMillisecondsJSON_RFC3339(t *testing.T) {
+	t.Parallel()
+
+	want, err := time.Parse(time.RFC3339, "2021-05-17T21:28:04Z")
+	require.NoError(t, err)
+
+	for name, input := range map[string][]byte{
+		"unquoted": []byte("2021-05-17T21:28:04Z"),
+		"json":     []byte(`"2021-05-17T21:28:04Z"`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var et EpochTime
+			require.NoError(t, UnmarshalEpochMillisecondsJSON(input, &et))
+			assert.True(t, time.Time(et).Equal(want.UTC()))
+		})
+	}
+}
+
+func TestUnmarshalEpochMillisecondsJSON_NumericDelegatesToEpochTime(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		input []byte
+		want  time.Time
+	}{
+		{
+			name:  "seconds",
+			input: []byte(`1587654321`),
+			want:  time.Unix(1587654321, 0).UTC(),
+		},
+		{
+			name:  "milliseconds",
+			input: []byte(`1587654321012`),
+			want:  time.Unix(1587654321, 12*int64(time.Millisecond)).UTC(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var et EpochTime
+			require.NoError(t, UnmarshalEpochMillisecondsJSON(tc.input, &et))
+			assert.True(t, time.Time(et).Equal(tc.want))
+		})
+	}
+}
+
+func TestUnmarshalEpochMillisecondsJSON_QuotedNumeric(t *testing.T) {
+	t.Parallel()
+
+	var et EpochTime
+	require.NoError(t, UnmarshalEpochMillisecondsJSON([]byte(`"1587654321012"`), &et))
+	want := time.Unix(1587654321, 12*int64(time.Millisecond)).UTC()
+	assert.True(t, time.Time(et).Equal(want))
+}
+
+func TestEpochSecondsMarshalJSON_StillTenDigitsWithoutSubsecond(t *testing.T) {
+	t.Parallel()
+
+	et := EpochTime(time.Unix(1587654321, 0).UTC())
+	b, err := et.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, []byte(`1587654321`), b)
+}

--- a/pkg/nrtime/types_func.go
+++ b/pkg/nrtime/types_func.go
@@ -1,6 +1,8 @@
 package nrtime
 
 import (
+	"time"
+
 	"github.com/newrelic/newrelic-client-go/v2/internal/serialization"
 )
 
@@ -25,12 +27,12 @@ func (t EpochSeconds) String() string {
 
 // MarshalJSON wrapper for EpochMilliseconds
 func (t EpochMilliseconds) MarshalJSON() ([]byte, error) {
-	return serialization.EpochTime(t).MarshalJSON()
+	return serialization.MarshalEpochMillisecondsJSON(time.Time(t))
 }
 
 // UnmarshalJSON wrapper for EpochMilliseconds
 func (t *EpochMilliseconds) UnmarshalJSON(s []byte) error {
-	return (*serialization.EpochTime)(t).UnmarshalJSON(s)
+	return serialization.UnmarshalEpochMillisecondsJSON(s, (*serialization.EpochTime)(t))
 }
 
 // String returns the time formatted using the format string

--- a/pkg/nrtime/types_func_test.go
+++ b/pkg/nrtime/types_func_test.go
@@ -1,0 +1,29 @@
+//go:build unit
+// +build unit
+
+package nrtime
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEpochMillisecondsJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tm, err := time.Parse(time.RFC3339, "2021-05-17T21:28:04Z")
+	require.NoError(t, err)
+
+	ms := EpochMilliseconds(tm)
+	out, err := json.Marshal(ms)
+	require.NoError(t, err)
+	assert.Equal(t, "1621286884000", string(out))
+
+	var back EpochMilliseconds
+	require.NoError(t, json.Unmarshal(out, &back))
+	assert.True(t, time.Time(back).Equal(tm.UTC()))
+}


### PR DESCRIPTION
Added functions to marshal and unmarshal time in EpochMilliseconds format, including support for RFC3339 strings and numeric values. Introduced unit tests to validate functionality.

Big thanks to @cglenn36 for tracking this down and reporting it.

Fix for #1395 