### PR TITLE
fix(alerts): add policy entity guid

### DIFF
--- a/pkg/alerts/policies.go
+++ b/pkg/alerts/policies.go
@@ -363,6 +363,7 @@ const (
 						name
 						incidentPreference
 						accountId
+						entityGuid
 	`
 	alertPolicyQueryPolicy = `query($accountID: Int!, $policyID: ID!) {
 		actor {
@@ -387,6 +388,7 @@ const (
 							id
 							incidentPreference
 							name
+							entityGuid
 						}
 					}
 				}

--- a/pkg/alerts/policies_integration_test.go
+++ b/pkg/alerts/policies_integration_test.go
@@ -76,16 +76,23 @@ func TestAlertsQueryPolicy_GraphQL_Enabled(t *testing.T) {
 	createResult, err := a.CreatePolicyMutation(accountID, policy)
 	require.NoError(t, err)
 	require.NotNil(t, createResult)
+	require.NotEmpty(t, createResult.EntityGuid, "EntityGuid should be returned on create")
 
 	// Query for the policy we policy we just created
 	queryResult, err := a.QueryPolicy(accountID, createResult.ID)
 	require.NoError(t, err)
 	require.NotNil(t, queryResult)
+	require.NotEmpty(t, queryResult.EntityGuid, "EntityGuid should be returned on query")
+	assert.Equal(t, createResult.EntityGuid, queryResult.EntityGuid, "EntityGuid should match between create and query")
 
 	// Search
 	searchResults, err := a.QueryPolicySearch(accountID, AlertsPoliciesSearchCriteriaInput{})
 	require.NoError(t, err)
 	require.NotNil(t, searchResults)
+	// Verify entityGuid is present in search results
+	if len(searchResults) > 0 {
+		require.NotEmpty(t, searchResults[0].EntityGuid, "EntityGuid should be returned in search results")
+	}
 
 	// Test: Update
 	updatePolicy := AlertsPolicyUpdateInput{}
@@ -97,6 +104,8 @@ func TestAlertsQueryPolicy_GraphQL_Enabled(t *testing.T) {
 	require.NotNil(t, updateResult)
 	assert.Equal(t, updateResult.Name, updatePolicy.Name)
 	assert.Equal(t, updateResult.IncidentPreference, updatePolicy.IncidentPreference)
+	require.NotEmpty(t, updateResult.EntityGuid, "EntityGuid should be returned on update")
+	assert.Equal(t, createResult.EntityGuid, updateResult.EntityGuid, "EntityGuid should remain the same after update")
 
 	// Test: Delete
 	deleteResult, err := a.DeletePolicyMutation(accountID, createResult.ID)

--- a/pkg/alerts/policies_test.go
+++ b/pkg/alerts/policies_test.go
@@ -200,3 +200,180 @@ func TestDeletePolicy(t *testing.T) {
 	require.NotNil(t, actual)
 	require.Equal(t, expected, actual)
 }
+
+// NerdGraph Policy Tests (with entityGuid support)
+
+var (
+	testAlertsPolicyQueryResponseJSON = `{
+		"data": {
+			"actor": {
+				"account": {
+					"alerts": {
+						"policy": {
+							"id": "123456",
+							"name": "test-alert-policy-1",
+							"incidentPreference": "PER_POLICY",
+							"accountId": 123456,
+							"entityGuid": "MTIzNDU2fEFMRVJUU3xQT0xJQ1l8MTIzNDU2"
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	testAlertsPolicySearchResponseJSON = `{
+		"data": {
+			"actor": {
+				"account": {
+					"alerts": {
+						"policiesSearch": {
+							"nextCursor": null,
+							"totalCount": 2,
+							"policies": [
+								{
+									"id": "123456",
+									"name": "test-alert-policy-1",
+									"incidentPreference": "PER_POLICY",
+									"accountId": 123456,
+									"entityGuid": "MTIzNDU2fEFMRVJUU3xQT0xJQ1l8MTIzNDU2"
+								},
+								{
+									"id": "123457",
+									"name": "test-alert-policy-2",
+									"incidentPreference": "PER_CONDITION",
+									"accountId": 123456,
+									"entityGuid": "MTIzNDU2fEFMRVJUU3xQT0xJQ1l8MTIzNDU3"
+								}
+							]
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	testAlertsPolicyCreateResponseJSON = `{
+		"data": {
+			"alertsPolicyCreate": {
+				"id": "123456",
+				"name": "test-alert-policy-1",
+				"incidentPreference": "PER_POLICY",
+				"accountId": 123456,
+				"entityGuid": "MTIzNDU2fEFMRVJUU3xQT0xJQ1l8MTIzNDU2"
+			}
+		}
+	}`
+
+	testAlertsPolicyUpdateResponseJSON = `{
+		"data": {
+			"alertsPolicyUpdate": {
+				"id": "123456",
+				"name": "test-alert-policy-updated",
+				"incidentPreference": "PER_CONDITION",
+				"accountId": 123456,
+				"entityGuid": "MTIzNDU2fEFMRVJUU3xQT0xJQ1l8MTIzNDU2"
+			}
+		}
+	}`
+)
+
+func TestQueryPolicy(t *testing.T) {
+	t.Parallel()
+	alerts := newMockResponse(t, testAlertsPolicyQueryResponseJSON, http.StatusOK)
+
+	expected := &AlertsPolicy{
+		ID:                 "123456",
+		Name:               "test-alert-policy-1",
+		IncidentPreference: AlertsIncidentPreferenceTypes.PER_POLICY,
+		AccountID:          123456,
+		EntityGuid:         "MTIzNDU2fEFMRVJUU3xQT0xJQ1l8MTIzNDU2",
+	}
+
+	actual, err := alerts.QueryPolicy(123456, "123456")
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.Equal(t, expected.ID, actual.ID)
+	require.Equal(t, expected.Name, actual.Name)
+	require.Equal(t, expected.IncidentPreference, actual.IncidentPreference)
+	require.Equal(t, expected.AccountID, actual.AccountID)
+	require.Equal(t, expected.EntityGuid, actual.EntityGuid)
+}
+
+func TestQueryPolicySearch(t *testing.T) {
+	t.Parallel()
+	alerts := newMockResponse(t, testAlertsPolicySearchResponseJSON, http.StatusOK)
+
+	actual, err := alerts.QueryPolicySearch(123456, AlertsPoliciesSearchCriteriaInput{})
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.Len(t, actual, 2)
+
+	// Check first policy
+	require.Equal(t, "123456", actual[0].ID)
+	require.Equal(t, "test-alert-policy-1", actual[0].Name)
+	require.Equal(t, "MTIzNDU2fEFMRVJUU3xQT0xJQ1l8MTIzNDU2", actual[0].EntityGuid)
+
+	// Check second policy
+	require.Equal(t, "123457", actual[1].ID)
+	require.Equal(t, "test-alert-policy-2", actual[1].Name)
+	require.Equal(t, "MTIzNDU2fEFMRVJUU3xQT0xJQ1l8MTIzNDU3", actual[1].EntityGuid)
+}
+
+func TestCreatePolicyMutation(t *testing.T) {
+	t.Parallel()
+	alerts := newMockResponse(t, testAlertsPolicyCreateResponseJSON, http.StatusOK)
+
+	policy := AlertsPolicyInput{
+		Name:               "test-alert-policy-1",
+		IncidentPreference: AlertsIncidentPreferenceTypes.PER_POLICY,
+	}
+
+	expected := &AlertsPolicy{
+		ID:                 "123456",
+		Name:               "test-alert-policy-1",
+		IncidentPreference: AlertsIncidentPreferenceTypes.PER_POLICY,
+		AccountID:          123456,
+		EntityGuid:         "MTIzNDU2fEFMRVJUU3xQT0xJQ1l8MTIzNDU2",
+	}
+
+	actual, err := alerts.CreatePolicyMutation(123456, policy)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.Equal(t, expected.ID, actual.ID)
+	require.Equal(t, expected.Name, actual.Name)
+	require.Equal(t, expected.IncidentPreference, actual.IncidentPreference)
+	require.Equal(t, expected.AccountID, actual.AccountID)
+	require.Equal(t, expected.EntityGuid, actual.EntityGuid)
+}
+
+func TestUpdatePolicyMutation(t *testing.T) {
+	t.Parallel()
+	alerts := newMockResponse(t, testAlertsPolicyUpdateResponseJSON, http.StatusOK)
+
+	policy := AlertsPolicyUpdateInput{
+		Name:               "test-alert-policy-updated",
+		IncidentPreference: AlertsIncidentPreferenceTypes.PER_CONDITION,
+	}
+
+	expected := &AlertsPolicy{
+		ID:                 "123456",
+		Name:               "test-alert-policy-updated",
+		IncidentPreference: AlertsIncidentPreferenceTypes.PER_CONDITION,
+		AccountID:          123456,
+		EntityGuid:         "MTIzNDU2fEFMRVJUU3xQT0xJQ1l8MTIzNDU2",
+	}
+
+	actual, err := alerts.UpdatePolicyMutation(123456, "123456", policy)
+
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.Equal(t, expected.ID, actual.ID)
+	require.Equal(t, expected.Name, actual.Name)
+	require.Equal(t, expected.IncidentPreference, actual.IncidentPreference)
+	require.Equal(t, expected.AccountID, actual.AccountID)
+	require.Equal(t, expected.EntityGuid, actual.EntityGuid)
+}

--- a/pkg/alerts/types.go
+++ b/pkg/alerts/types.go
@@ -313,6 +313,8 @@ type AlertsPoliciesSearchResultSet struct {
 type AlertsPolicy struct {
 	// Account ID of the policy.
 	AccountID int `json:"accountId"`
+	// The entity GUID for the policy.
+	EntityGuid string `json:"entityGuid"`
 	// Primary key for policies.
 	ID string `json:"id"`
 	// Determines how incidents are created for critical violations of the conditions contained in the policy.


### PR DESCRIPTION
This adds entityGuid field in the response for policies for the nerdgraph methods. This field was recently added and has already been stitched. After this is merged in, I will add a PR to the terraform provider to give terraform policy resource the entityGuid field, allowing users to leverage tag creation via the policy.entityGuid.

jira: https://new-relic.atlassian.net/browse/NR-529749