### PR TITLE
fix(fleetcontrol): restore GetEntity behaviour broken by PR #1394 Tutone regen

### DIFF
--- a/pkg/fleetcontrol/fleetcontrol_api.go
+++ b/pkg/fleetcontrol/fleetcontrol_api.go
@@ -636,7 +636,6 @@ const getEntityQuery = `query(
 		__typename
 		agentType
 		configurationType
-		managedEntityType
 		metadata {
 			createdAt
 			createdBy {
@@ -1007,7 +1006,6 @@ const getEntitySearchQuery = `query(
 			__typename
 			agentType
 			configurationType
-			managedEntityType
 			metadata {
 				createdAt
 				createdBy {

--- a/pkg/fleetcontrol/fleetcontrol_integration_test.go
+++ b/pkg/fleetcontrol/fleetcontrol_integration_test.go
@@ -361,7 +361,7 @@ func TestIntegrationFleetLifecycle(t *testing.T) {
 		Ring:    "default",
 	}
 
-	fleetMembersResponse, err := client.GetFleetMembers("", getFleetMembersFilter)
+	fleetMembersResponse, err := client.GetFleetMembers(nil, getFleetMembersFilter)
 	require.NoError(t, err)
 	require.NotNil(t, fleetMembersResponse)
 	require.NotNil(t, fleetMembersResponse.Items)
@@ -401,7 +401,7 @@ func TestIntegrationFleetLifecycle(t *testing.T) {
 
 	// Verify members were removed
 	fmt.Println("Verifying members were removed...")
-	fleetMembersAfterRemoval, err := client.GetFleetMembers("", getFleetMembersFilter)
+	fleetMembersAfterRemoval, err := client.GetFleetMembers(nil, getFleetMembersFilter)
 	require.NoError(t, err)
 	require.NotNil(t, fleetMembersAfterRemoval)
 

--- a/pkg/fleetcontrol/types.go
+++ b/pkg/fleetcontrol/types.go
@@ -4250,6 +4250,39 @@ type EntityManagementActorStitchedFields struct {
 	EntitySearch EntityManagementEntitySearchResult `json:"entitySearch,omitempty"`
 }
 
+// special
+func (x *EntityManagementActorStitchedFields) UnmarshalJSON(b []byte) error {
+	var objMap map[string]*json.RawMessage
+	err := json.Unmarshal(b, &objMap)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range objMap {
+		if v == nil {
+			continue
+		}
+
+		switch k {
+		case "entity":
+			xxx, err := UnmarshalEntityManagementEntityInterface(*v)
+			if err != nil {
+				return err
+			}
+			if xxx != nil {
+				x.Entity = *xxx
+			}
+		case "entitySearch":
+			err = json.Unmarshal(*v, &x.EntitySearch)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 // EntityManagementAgentConfigurationEntity - A configuration that can contain multiple immutable versions and can be deployed to a fleet
 type EntityManagementAgentConfigurationEntity struct {
 	// The agentType

--- a/pkg/fleetcontrol/types.go
+++ b/pkg/fleetcontrol/types.go
@@ -4265,6 +4265,9 @@ func (x *EntityManagementActorStitchedFields) UnmarshalJSON(b []byte) error {
 
 		switch k {
 		case "entity":
+			if v == nil {
+				continue
+			}
 			xxx, err := UnmarshalEntityManagementEntityInterface(*v)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

PR #1394 ran Tutone to keep things in sync with the cursor fix, but the regeneration accidentally introduced two regressions that broke all `GetEntity` and `GetEntitySearch` calls:

- **Added `managedEntityType` to `EntityManagementAgentConfigurationEntity` query fragments** — this field is nullable on `AgentConfigurationEntity` but non-nullable on `FleetEntity`, violating GraphQL's field-merging rule. NerdGraph rejects the query entirely with a schema validation error.
- **Deleted the hand-written `UnmarshalJSON` on `EntityManagementActorStitchedFields`** — this method (marked `// special`) was written to handle the interface-typed `Entity` field, which the standard JSON decoder cannot unmarshal. Without it, all `GetEntity` responses fail to deserialize.

Both were correct in v2.82.1. This PR restores them exactly.

## Note for future Tutone runs

The `// special` annotated `UnmarshalJSON` functions are hand-written and not generated by Tutone. When re-running Tutone in the `fleetcontrol` package, these need to be preserved manually. The affected function is `EntityManagementActorStitchedFields.UnmarshalJSON` in `types.go`.

## Test plan

- [ ] Verify `GetEntity` with a fleet entity GUID returns a correctly typed `EntityManagementFleetEntity`
- [ ] Verify `GetEntity` with a config entity GUID returns a correctly typed `EntityManagementAgentConfigurationEntity`
- [ ] Verify `GetEntitySearch` does not fail with a GraphQL schema validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)