### PR TITLE
fix(fleetcontrol): restore managedEntityType in AgentConfigurationEntity GetEntity fragments

### DIFF
--- a/pkg/fleetcontrol/fleetcontrol_api.go
+++ b/pkg/fleetcontrol/fleetcontrol_api.go
@@ -636,6 +636,7 @@ const getEntityQuery = `query(
 		__typename
 		agentType
 		configurationType
+		managedEntityType
 		metadata {
 			createdAt
 			createdBy {
@@ -1006,6 +1007,7 @@ const getEntitySearchQuery = `query(
 			__typename
 			agentType
 			configurationType
+			managedEntityType
 			metadata {
 				createdAt
 				createdBy {


### PR DESCRIPTION
## Summary

- Adds `managedEntityType` back to the `EntityManagementAgentConfigurationEntity` inline fragment in both `getEntityQuery` and `getEntitySearchQuery`
- It was removed in #1402 as a precaution alongside the real nullability fix (custom `UnmarshalJSON` on `EntityManagementActorStitchedFields`)
- With the unmarshal now robust, the field is safe to re-add for this specific entity type
- Required by [terraform-provider-newrelic#3079](https://github.com/newrelic/terraform-provider-newrelic/pull/3079) so the import flow can populate `managed_entity_type` from the API response

## Test plan

- [ ] Local build passes: `go build ./pkg/fleetcontrol/...`
- [ ] Integration tests in terraform-provider-newrelic pass with this client version

🤖 Generated with [Claude Code](https://claude.com/claude-code)