### PR TITLE
fix(fleetcontrol): remove omitempty from FleetControlAgentInput.ConfigurationVersionList

### DIFF
--- a/pkg/fleetcontrol/types.go
+++ b/pkg/fleetcontrol/types.go
@@ -6132,7 +6132,7 @@ type FleetControlAgentInput struct {
 	// Agent type
 	AgentType string `json:"agentType"`
 	// Configuration version list for this agent
-	ConfigurationVersionList []FleetControlConfigurationVersionListInput `json:"configurationVersionList,omitempty"`
+	ConfigurationVersionList []FleetControlConfigurationVersionListInput `json:"configurationVersionList"`
 	// Agent version
 	Version string `json:"version"`
 }


### PR DESCRIPTION
## Summary

- `FleetControlAgentInput.ConfigurationVersionList` had `json:"configurationVersionList,omitempty"` which causes an empty slice to be omitted from the JSON variables sent to GraphQL
- The GraphQL schema types this field as `[FleetControlConfigurationVersionListInput!]!` (non-nullable), so omitting it results in `null`, which the API rejects with: `In field "configurationVersionList": Expected type "[FleetControlConfigurationVersionListInput!]!", found null.`
- Removing `omitempty` ensures an initialized empty slice serializes as `[]` (a valid empty non-null array)

## Test plan

- [ ] Fleet deployment tests in terraform-provider-newrelic pass after pointing go.mod at this branch