### PR TITLE
fix(entities): change EntityAlertViolationInt from int to int64

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -865,7 +865,7 @@ packages:
       - name: WorkloadEntityOutline
         generate_struct_getters: true
       - name: EntityAlertViolationInt
-        create_as: int
+        create_as: int64
 
       # TODO: These should be generated and referenced from the dashboards package
       - name: DashboardVariable
@@ -2046,3 +2046,4 @@ packages:
       - name: EntityGuid
         field_type_override: common.EntityGUID
         skip_type_create: true
+

--- a/pkg/entities/entity_test.go
+++ b/pkg/entities/entity_test.go
@@ -4,9 +4,14 @@
 package entities
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 )
 
 func TestFindTagByKey(t *testing.T) {
@@ -189,4 +194,75 @@ func TestBuildEntitySearchNrqlQuery(t *testing.T) {
 	require.Contains(t, result, "domain = 'APM'")
 	require.Contains(t, result, "type = 'APPLICATION'")
 	require.Contains(t, result, " AND tags.`tagKey` = 'tagValue' AND tags.`tagKey2` = 'tagValue2'")
+}
+
+// TestEntityAlertViolationInt_LargeID verifies that violationIds exceeding the int32 range
+// (as returned by the Alerts backend for 16-digit IDs) unmarshal without overflow or error.
+func TestEntityAlertViolationInt_LargeID(t *testing.T) {
+	t.Parallel()
+
+	// These are real violation IDs from the bug report (NR-561784) that exceed int32 max (2,147,483,647).
+	cases := []struct {
+		json string
+		want EntityAlertViolationInt
+	}{
+		{`{"violationId": 1773950568354017}`, EntityAlertViolationInt(1773950568354017)},
+		{`{"violationId": 1777567939793015}`, EntityAlertViolationInt(1777567939793015)},
+		{`{"violationId": 2147483647}`, EntityAlertViolationInt(2147483647)}, // int32 max — still works
+		{`{"violationId": 2147483648}`, EntityAlertViolationInt(2147483648)}, // one above int32 max
+	}
+
+	for _, tc := range cases {
+		var v EntityAlertViolation
+		err := json.Unmarshal([]byte(tc.json), &v)
+		require.NoError(t, err, "unmarshal failed for input %s", tc.json)
+		require.Equal(t, tc.want, v.ViolationId)
+	}
+}
+
+// TestGetEntityWithContext_LargeViolationId simulates the full Terraform read path for
+// newrelic_synthetics_monitor: a mock NerdGraph server returns a SyntheticMonitorEntity
+// with a 16-digit violationId, and GetEntityWithContext must parse it without error.
+// This reproduces the crash reported in NR-561784 on 32-bit platforms where
+// EntityAlertViolationInt was int (32-bit) instead of int64.
+func TestGetEntityWithContext_LargeViolationId(t *testing.T) {
+	t.Parallel()
+
+	// Real violation IDs from the bug report that overflow int32.
+	const violationID int64 = 1773950568354017
+
+	mockResponse := `{
+		"data": {
+			"actor": {
+				"entity": {
+					"__typename": "SyntheticMonitorEntity",
+					"guid": "MTAwMjMzMjUwOHxTWU5USHxNT05JVE9SfDEyMzQ1Njc4",
+					"name": "test-monitor",
+					"recentAlertViolations": [
+						{
+							"violationId": 1773950568354017,
+							"label": "Synthetics monitor test-monitor",
+							"level": "CRITICAL",
+							"alertSeverity": "CRITICAL"
+						}
+					]
+				}
+			}
+		}
+	}`
+
+	ts := mock.NewMockServer(t, mockResponse, http.StatusOK)
+	defer ts.Close()
+
+	cfg := mock.NewTestConfig(t, ts)
+	client := New(cfg)
+
+	entity, err := client.GetEntityWithContext(context.Background(), "MTAwMjMzMjUwOHxTWU5USHxNT05JVE9SfDEyMzQ1Njc4")
+	require.NoError(t, err)
+	require.NotNil(t, entity)
+
+	synthEntity, ok := (*entity).(*SyntheticMonitorEntity)
+	require.True(t, ok, "expected *SyntheticMonitorEntity, got %T", *entity)
+	require.Len(t, synthEntity.RecentAlertViolations, 1)
+	require.Equal(t, EntityAlertViolationInt(violationID), synthEntity.RecentAlertViolations[0].ViolationId)
 }

--- a/pkg/entities/types.go
+++ b/pkg/entities/types.go
@@ -11971,7 +11971,7 @@ type AttributeMap map[string]interface{}
 type DashboardWidgetRawConfiguration []byte
 
 // EntityAlertViolationInt - The `ViolationInt` scalar type represents 52-bit signed integers
-type EntityAlertViolationInt int
+type EntityAlertViolationInt int64
 
 // Float - The `Float` scalar type represents signed double-precision fractional
 // values as specified by


### PR DESCRIPTION
The Alerts backend now generates 16-digit violation IDs (e.g. `1773950568354017`) that exceed the maximum value of a 32-bit signed integer (~2.1B). On 32-bit platforms (Windows 386, Linux 386), Go's `int` type is 32-bit, causing `json.Unmarshal` to return an overflow error when parsing `recentAlertViolations.violationId` in any entity response. This crashes the Terraform provider during `terraform plan`/`apply` state refresh for resources like `newrelic_synthetics_monitor` that fetch entity data via `GetEntityWithContext`. The root cause is that `EntityAlertViolationInt` was typed as `int` in `pkg/entities/types.go`, despite the GraphQL scalar comment explicitly stating it represents 52-bit signed integers.

This fix changes `EntityAlertViolationInt` to `int64`, which is explicitly 64-bit on all platforms and can safely hold any value the backend produces. The `.tutone.yml` codegen config is updated accordingly to prevent regression on future regenerations. Two unit tests are added: one directly testing JSON unmarshal of `EntityAlertViolation` with the exact violation IDs from the bug report, and one exercising the full `GetEntityWithContext` → `SyntheticMonitorEntity` → `RecentAlertViolations` pipeline via a mock NerdGraph server.

Fixes: NR-561784