### PR TITLE
feat(synthetics): add shared parameter to private location mutations

### DIFF
--- a/pkg/synthetics/synthetics_api.go
+++ b/pkg/synthetics/synthetics_api.go
@@ -403,12 +403,14 @@ func (a *Synthetics) SyntheticsCreatePrivateLocation(
 	accountID int,
 	description string,
 	name string,
+	shared bool,
 	verifiedScriptExecution bool,
 ) (*SyntheticsPrivateLocationMutationResult, error) {
 	return a.SyntheticsCreatePrivateLocationWithContext(context.Background(),
 		accountID,
 		description,
 		name,
+		shared,
 		verifiedScriptExecution,
 	)
 }
@@ -419,6 +421,7 @@ func (a *Synthetics) SyntheticsCreatePrivateLocationWithContext(
 	accountID int,
 	description string,
 	name string,
+	shared bool,
 	verifiedScriptExecution bool,
 ) (*SyntheticsPrivateLocationMutationResult, error) {
 
@@ -427,6 +430,7 @@ func (a *Synthetics) SyntheticsCreatePrivateLocationWithContext(
 		"accountId":               accountID,
 		"description":             description,
 		"name":                    name,
+		"shared":                  shared,
 		"verifiedScriptExecution": verifiedScriptExecution,
 	}
 
@@ -445,11 +449,13 @@ const SyntheticsCreatePrivateLocationMutation = `mutation(
 	$accountId: Int!,
 	$description: String,
 	$name: String!,
+	$shared: Boolean,
 	$verifiedScriptExecution: Boolean!,
 ) { syntheticsCreatePrivateLocation(
 	accountId: $accountId,
 	description: $description,
 	name: $name,
+	shared: $shared,
 	verifiedScriptExecution: $verifiedScriptExecution,
 ) {
 	accountId
@@ -463,6 +469,7 @@ const SyntheticsCreatePrivateLocationMutation = `mutation(
 	key
 	locationId
 	name
+	shared
 	verifiedScriptExecution
 } }`
 
@@ -1481,11 +1488,13 @@ const SyntheticsUpdateCertCheckMonitorMutation = `mutation(
 func (a *Synthetics) SyntheticsUpdatePrivateLocation(
 	description string,
 	gUID EntityGUID,
+	shared bool,
 	verifiedScriptExecution bool,
 ) (*SyntheticsPrivateLocationMutationResult, error) {
 	return a.SyntheticsUpdatePrivateLocationWithContext(context.Background(),
 		description,
 		gUID,
+		shared,
 		verifiedScriptExecution,
 	)
 }
@@ -1495,6 +1504,7 @@ func (a *Synthetics) SyntheticsUpdatePrivateLocationWithContext(
 	ctx context.Context,
 	description string,
 	gUID EntityGUID,
+	shared bool,
 	verifiedScriptExecution bool,
 ) (*SyntheticsPrivateLocationMutationResult, error) {
 
@@ -1502,6 +1512,7 @@ func (a *Synthetics) SyntheticsUpdatePrivateLocationWithContext(
 	vars := map[string]interface{}{
 		"description":             description,
 		"guid":                    gUID,
+		"shared":                  shared,
 		"verifiedScriptExecution": verifiedScriptExecution,
 	}
 
@@ -1519,10 +1530,12 @@ type SyntheticsUpdatePrivateLocationQueryResponse struct {
 const SyntheticsUpdatePrivateLocationMutation = `mutation(
 	$description: String,
 	$guid: EntityGuid!,
+	$shared: Boolean,
 	$verifiedScriptExecution: Boolean,
 ) { syntheticsUpdatePrivateLocation(
 	description: $description,
 	guid: $guid,
+	shared: $shared,
 	verifiedScriptExecution: $verifiedScriptExecution,
 ) {
 	accountId
@@ -1536,6 +1549,7 @@ const SyntheticsUpdatePrivateLocationMutation = `mutation(
 	key
 	locationId
 	name
+	shared
 	verifiedScriptExecution
 } }`
 

--- a/pkg/synthetics/synthetics_api_integration_test.go
+++ b/pkg/synthetics/synthetics_api_integration_test.go
@@ -951,6 +951,7 @@ func TestSyntheticsPrivateLocation_Basic(t *testing.T) {
 		testAccountID,
 		"Test Private Location",
 		generateSyntheticsEntityNameForIntegrationTest("PRIVATE_LOCATION", false),
+		false,
 		true,
 	)
 
@@ -960,6 +961,7 @@ func TestSyntheticsPrivateLocation_Basic(t *testing.T) {
 	updateResp, err := a.SyntheticsUpdatePrivateLocation(
 		"Test Private Location Description Updated",
 		createResp.GUID,
+		false,
 		true,
 	)
 

--- a/pkg/synthetics/types.go
+++ b/pkg/synthetics/types.go
@@ -1409,6 +1409,8 @@ type SyntheticsPrivateLocationMutationResult struct {
 	LocationId string `json:"locationId,omitempty"`
 	// The name of the private location
 	Name string `json:"name,omitempty"`
+	// Specifies whether the private location is shared across the organization
+	Shared bool `json:"shared,omitempty"`
 	// Specifies whether the private location requires a password for scripted monitors
 	VerifiedScriptExecution bool `json:"verifiedScriptExecution,omitempty"`
 }


### PR DESCRIPTION
# Summary 
Adds the `shared` parameter to the Synthetics private location create and update                                                                                  
  mutations, enabling callers to specify whether a private location should be shared                                                                                
  across the organization.                                                                                                                                          
                                                                                                                                                                    
##  Changes:                                                                                                                                                          
  - `SyntheticsCreatePrivateLocation` / `SyntheticsCreatePrivateLocationWithContext`:                                                                               
    added `shared bool` parameter; included in GraphQL mutation variables and returned fields                                                                       
  - `SyntheticsUpdatePrivateLocation` / `SyntheticsUpdatePrivateLocationWithContext`:                                                                               
    added `shared bool` parameter; included in GraphQL mutation variables and returned fields                                                                       
  - `SyntheticsPrivateLocationMutationResult`: added `Shared bool` field                                                                                            
  - Integration test updated to pass the new parameter  
  
This PR supports the FR for the New Relic Terraform Provider [asked for here](https://github.com/newrelic/terraform-provider-newrelic/issues/3058).