### PR TITLE
feat(workloads): add intelligent workload support with dynamic flows and alert policy

### DIFF
--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -52,6 +52,16 @@ func GetNonExistentIDs() (string, string) {
 	return "00000FF000F0FFFF000F0F0000FF0FF0000000F000F00F0FF000FFFFF0FF00F0", "00000HH000H0HHHH000H0H0000HH0HH0000000H000H00H0HH000HHHHH0HH00H0"
 }
 
+// GetTestEntityGUID returns the entity GUID for intelligent workload integration tests from the environment.
+func GetTestEntityGUID() (string, error) {
+	return getEnvString("NEW_RELIC_TEST_ENTITY_GUID")
+}
+
+// GetTestTransactionName returns the transaction name for intelligent workload integration tests from the environment.
+func GetTestTransactionName() (string, error) {
+	return getEnvString("NEW_RELIC_TEST_TRANSACTION_NAME")
+}
+
 // getEnvInt helper to DRY up the other env get calls for integers
 func getEnvInt(name string) (int, error) {
 	if name == "" {
@@ -70,6 +80,20 @@ func getEnvInt(name string) (int, error) {
 	}
 
 	return n, nil
+}
+
+// getEnvString helper to DRY up the other env get calls for strings
+func getEnvString(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("failed to get environment value, no name specified")
+	}
+
+	value := os.Getenv(name)
+	if value == "" {
+		return "", fmt.Errorf("failed to get environment value due to undefined environment variable %s", name)
+	}
+
+	return value, nil
 }
 
 // Use this method to generate a random name to be used in integration tests

--- a/pkg/workloads/example_basic_test.go
+++ b/pkg/workloads/example_basic_test.go
@@ -65,3 +65,68 @@ func Example_basic() {
 		log.Fatal("error deleting workload: ", err)
 	}
 }
+
+func Example_intelligentWorkload() {
+	// Initialize the client configuration. A Personal API key is required to
+	// communicate with the backend API.
+	cfg := config.New()
+	cfg.PersonalAPIKey = os.Getenv("NEW_RELIC_API_KEY")
+
+	// Initialize the client.
+	client := New(cfg)
+
+	accountID := 12345678
+	entityGUID := common.EntityGUID("MjUwODy1OXxOUjF8V097S0xPQ3R8ODcz")
+
+	// Create a new intelligent workload using dynamic flows.
+	// New Relic auto-discovers related entities via Transaction 360 distributed tracing.
+	// If set alongside entityGuids or entitySearchQueries, dynamicFlows takes precedence
+	// and others will be ignored.
+	createInput := WorkloadCreateInput{
+		Name: "Example intelligent workload",
+		ScopeAccounts: &WorkloadScopeAccountsInput{
+			AccountIDs: []int{accountID},
+		},
+		DynamicFlows: []WorkloadDynamicFlowInput{
+			{
+				EntityGUID:      entityGUID,
+				TransactionName: "WebTransaction/Action/index",
+			},
+		},
+		StatusConfig: &WorkloadStatusConfigInput{
+			AlertPolicy: &WorkloadAlertPolicyInput{
+				Enabled: true,
+			},
+		},
+	}
+
+	workload, err := client.WorkloadCreate(accountID, createInput)
+	if err != nil {
+		log.Fatal("error creating intelligent workload: ", err)
+	}
+
+	// Update an existing intelligent workload.
+	updated, err := client.WorkloadUpdate(workload.GUID, WorkloadUpdateInput{
+		Name: "Example intelligent workload - updated",
+		DynamicFlows: []WorkloadUpdateDynamicFlowInput{
+			{
+				EntityGUID:      entityGUID,
+				TransactionName: "WebTransaction/Action/index",
+			},
+		},
+		StatusConfig: &WorkloadUpdateStatusConfigInput{
+			AlertPolicy: &WorkloadUpdateAlertPolicyInput{
+				Enabled: false,
+			},
+		},
+	})
+	if err != nil {
+		log.Fatal("error updating intelligent workload: ", err)
+	}
+
+	// Delete an existing intelligent workload.
+	_, err = client.WorkloadDelete(updated.GUID)
+	if err != nil {
+		log.Fatal("error deleting intelligent workload: ", err)
+	}
+}

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -191,6 +191,18 @@ type WorkloadAutomaticStatus struct {
 	Rules []WorkloadRegularRule `json:"rules"`
 }
 
+// WorkloadAlertPolicy - The alert policy status configuration (response type).
+type WorkloadAlertPolicy struct {
+	// Whether the alert policy status configuration is enabled or not.
+	Enabled bool `json:"enabled"`
+}
+
+// WorkloadAlertPolicyInput - The input object used to represent the alert policy status configuration for create.
+type WorkloadAlertPolicyInput struct {
+	// Whether the alert policy status configuration is enabled or not.
+	Enabled bool `json:"enabled"`
+}
+
 // WorkloadAutomaticStatusInput - An input object used to represent an automatic status configuration. If not provided, a status configuration will be created by default.
 type WorkloadAutomaticStatusInput struct {
 	// Whether the automatic status configuration is enabled or not.
@@ -231,6 +243,8 @@ type WorkloadCollection struct {
 	Status WorkloadWorkloadStatus `json:"status"`
 	// The configuration that defines how the status of the workload is calculated.
 	StatusConfig WorkloadStatusConfig `json:"statusConfig,omitempty"`
+	// A list of dynamic flow entries for an intelligent workload.
+	DynamicFlows []WorkloadDynamicFlow `json:"dynamicFlows,omitempty"`
 	// The moment when the object was last updated, represented in milliseconds since the Unix epoch.
 	UpdatedAt *nrtime.EpochMilliseconds `json:"updatedAt,omitempty"`
 	// The user who last updated the workload.
@@ -241,6 +255,8 @@ type WorkloadCollection struct {
 type WorkloadCreateInput struct {
 	// Relevant information about the workload.
 	Description string `json:"description,omitempty"`
+	// A list of dynamic flow entries for an intelligent workload. When provided alongside entityGuids or entitySearchQueries, dynamicFlows takes precedence and others will be ignored.
+	DynamicFlows []WorkloadDynamicFlowInput `json:"dynamicFlows,omitempty"`
 	// A list of entity GUIDs composing the workload.
 	EntityGUIDs []common.EntityGUID `json:"entityGuids"`
 	// A list of entity search queries used to retrieve the entities that compose the workload.
@@ -257,6 +273,24 @@ type WorkloadCreateInput struct {
 type WorkloadDuplicateInput struct {
 	// The name of the workload duplicate. If the name isn't specified, the name + ' copy' of the source workload is used to compose the new name.
 	Name string `json:"name,omitempty"`
+}
+
+// WorkloadDynamicFlow - A dynamic flow entry in an intelligent workload (response type).
+type WorkloadDynamicFlow struct {
+	// The unique entity identifier of the dynamic flow entry.
+	EntityGUID common.EntityGUID `json:"entityGuid"`
+	// The unique identifier of the dynamic flow entry.
+	ID int `json:"id"`
+	// The transaction name associated with the dynamic flow entry.
+	TransactionName string `json:"transactionName"`
+}
+
+// WorkloadDynamicFlowInput - The input object used to represent a dynamic flow entry for create.
+type WorkloadDynamicFlowInput struct {
+	// The unique entity identifier of the dynamic flow entry.
+	EntityGUID common.EntityGUID `json:"entityGuid"`
+	// The transaction name associated with the dynamic flow entry.
+	TransactionName string `json:"transactionName"`
 }
 
 // WorkloadEntityRef - A reference to a New Relic entity.
@@ -459,6 +493,8 @@ type WorkloadStatus struct {
 
 // WorkloadStatusConfig - The configuration that defines how the status of the workload is calculated.
 type WorkloadStatusConfig struct {
+	// An alert policy status configuration for intelligent workloads.
+	AlertPolicy WorkloadAlertPolicy `json:"alertPolicy,omitempty"`
 	// An automatic status configuration.
 	Automatic WorkloadAutomaticStatus `json:"automatic,omitempty"`
 	// A list of static status configurations.
@@ -467,6 +503,8 @@ type WorkloadStatusConfig struct {
 
 // WorkloadStatusConfigInput - The input object used to provide the configuration that defines how the status of the workload is calculated.
 type WorkloadStatusConfigInput struct {
+	// An alert policy status configuration for intelligent workloads.
+	AlertPolicy *WorkloadAlertPolicyInput `json:"alertPolicy,omitempty"`
 	// An input object used to represent an automatic status configuration.
 	Automatic *WorkloadAutomaticStatusInput `json:"automatic,omitempty"`
 	// A list of static status configurations. You can only configure one static status for a workload.
@@ -483,6 +521,12 @@ type WorkloadStatusResult struct {
 
 func (x *WorkloadStatusResult) ImplementsWorkloadStatusResult() {}
 
+// WorkloadUpdateAlertPolicyInput - The input object used to represent the alert policy status configuration for update.
+type WorkloadUpdateAlertPolicyInput struct {
+	// Whether the alert policy status configuration is enabled or not.
+	Enabled bool `json:"enabled"`
+}
+
 // WorkloadUpdateAutomaticStatusInput - An input object used to represent an automatic status configuration.
 type WorkloadUpdateAutomaticStatusInput struct {
 	// Whether the automatic status configuration is enabled or not.
@@ -491,6 +535,16 @@ type WorkloadUpdateAutomaticStatusInput struct {
 	RemainingEntitiesRule *WorkloadRemainingEntitiesRuleInput `json:"remainingEntitiesRule,omitempty"`
 	// A list of rules.
 	Rules []WorkloadUpdateRegularRuleInput `json:"rules,omitempty"`
+}
+
+// WorkloadUpdateDynamicFlowInput - The input object used to represent a dynamic flow entry for update.
+type WorkloadUpdateDynamicFlowInput struct {
+	// The unique entity identifier of the dynamic flow entry.
+	EntityGUID common.EntityGUID `json:"entityGuid"`
+	// The unique identifier of the dynamic flow entry to be updated. If not provided, a new entry is created.
+	ID int `json:"id,omitempty"`
+	// The transaction name associated with the dynamic flow entry.
+	TransactionName string `json:"transactionName"`
 }
 
 // WorkloadUpdateCollectionEntitySearchQueryInput - The input object used to represent the entity search query to be updated.
@@ -505,6 +559,8 @@ type WorkloadUpdateCollectionEntitySearchQueryInput struct {
 type WorkloadUpdateInput struct {
 	// Relevant information about the workload.
 	Description string `json:"description,omitempty"`
+	// A list of dynamic flow entries for an intelligent workload. When provided alongside entityGuids or entitySearchQueries, dynamicFlows takes precedence and others will be ignored.
+	DynamicFlows []WorkloadUpdateDynamicFlowInput `json:"dynamicFlows,omitempty"`
 	// A list of entity GUIDs composing the workload.
 	EntityGUIDs []common.EntityGUID `json:"entityGuids"`
 	// A list of entity search queries used to retrieve the groups of entities that compose the workload.
@@ -545,6 +601,8 @@ type WorkloadUpdateStaticStatusInput struct {
 
 // WorkloadUpdateStatusConfigInput - The input object used to provide the configuration that defines how the status of the workload is calculated.
 type WorkloadUpdateStatusConfigInput struct {
+	// An alert policy status configuration for intelligent workloads.
+	AlertPolicy *WorkloadUpdateAlertPolicyInput `json:"alertPolicy,omitempty"`
 	// An input object used to represent an automatic status configuration.
 	Automatic *WorkloadUpdateAutomaticStatusInput `json:"automatic,omitempty"`
 	// A list of static status configurations. You can only configure one static status for a workload.

--- a/pkg/workloads/workloads_api.go
+++ b/pkg/workloads/workloads_api.go
@@ -77,6 +77,11 @@ const WorkloadCreateMutation = `mutation(
 		updatedAt
 	}
 	entitySearchQuery
+	dynamicFlows {
+		entityGuid
+		id
+		transactionName
+	}
 	guid
 	id
 	name
@@ -153,6 +158,9 @@ const WorkloadCreateMutation = `mutation(
 			id
 			status
 			summary
+		}
+		alertPolicy {
+			enabled
 		}
 	}
 	updatedAt
@@ -228,6 +236,11 @@ const WorkloadDeleteMutation = `mutation(
 		updatedAt
 	}
 	entitySearchQuery
+	dynamicFlows {
+		entityGuid
+		id
+		transactionName
+	}
 	guid
 	id
 	name
@@ -304,6 +317,9 @@ const WorkloadDeleteMutation = `mutation(
 			id
 			status
 			summary
+		}
+		alertPolicy {
+			enabled
 		}
 	}
 	updatedAt
@@ -391,6 +407,11 @@ const WorkloadDuplicateMutation = `mutation(
 		updatedAt
 	}
 	entitySearchQuery
+	dynamicFlows {
+		entityGuid
+		id
+		transactionName
+	}
 	guid
 	id
 	name
@@ -467,6 +488,9 @@ const WorkloadDuplicateMutation = `mutation(
 			id
 			status
 			summary
+		}
+		alertPolicy {
+			enabled
 		}
 	}
 	updatedAt
@@ -548,6 +572,11 @@ const WorkloadUpdateMutation = `mutation(
 		updatedAt
 	}
 	entitySearchQuery
+	dynamicFlows {
+		entityGuid
+		id
+		transactionName
+	}
 	guid
 	id
 	name
@@ -624,6 +653,9 @@ const WorkloadUpdateMutation = `mutation(
 			id
 			status
 			summary
+		}
+		alertPolicy {
+			enabled
 		}
 	}
 	updatedAt
@@ -700,6 +732,11 @@ const getCollectionQuery = `query(
 		updatedAt
 	}
 	entitySearchQuery
+	dynamicFlows {
+		entityGuid
+		id
+		transactionName
+	}
 	guid
 	id
 	name
@@ -776,6 +813,9 @@ const getCollectionQuery = `query(
 			id
 			status
 			summary
+		}
+		alertPolicy {
+			enabled
 		}
 	}
 	updatedAt

--- a/pkg/workloads/workloads_api_integration_test.go
+++ b/pkg/workloads/workloads_api_integration_test.go
@@ -198,6 +198,140 @@ func TestIntegrationWorkloadGet(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestIntegrationWorkloadCreate_IntelligentWorkload(t *testing.T) {
+	t.Parallel()
+
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	testEntityGUID, err := mock.GetTestEntityGUID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	testTransactionName, err := mock.GetTestTransactionName()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	client := newIntegrationTestClient(t)
+
+	name := "newrelic-client-go-test-intelligent-workload-" + mock.RandSeq(5)
+	workload := WorkloadCreateInput{
+		Name: name,
+		ScopeAccounts: &WorkloadScopeAccountsInput{
+			AccountIDs: []int{testAccountID},
+		},
+		DynamicFlows: []WorkloadDynamicFlowInput{
+			{
+				EntityGUID:      common.EntityGUID(testEntityGUID),
+				TransactionName: testTransactionName,
+			},
+		},
+		StatusConfig: &WorkloadStatusConfigInput{
+			AlertPolicy: &WorkloadAlertPolicyInput{
+				Enabled: true,
+			},
+		},
+	}
+
+	created, err := client.WorkloadCreate(testAccountID, workload)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	assert.Equal(t, name, created.Name)
+	assert.NotEmpty(t, created.GUID)
+	assert.Equal(t, testAccountID, created.Account.ID)
+	assert.Equal(t, 1, len(created.DynamicFlows))
+	assert.Equal(t, common.EntityGUID(testEntityGUID), created.DynamicFlows[0].EntityGUID)
+	assert.Equal(t, testTransactionName, created.DynamicFlows[0].TransactionName)
+	assert.True(t, created.StatusConfig.AlertPolicy.Enabled)
+
+	// Wait for indexing to catch up
+	time.Sleep(30 * time.Second)
+
+	// Cleanup
+	_, err = client.WorkloadDelete(common.EntityGUID(created.GUID))
+	require.NoError(t, err)
+}
+
+func TestIntegrationWorkloadUpdate_IntelligentWorkload(t *testing.T) {
+	t.Parallel()
+
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	testEntityGUID, err := mock.GetTestEntityGUID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	testTransactionName, err := mock.GetTestTransactionName()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	client := newIntegrationTestClient(t)
+
+	name := "newrelic-client-go-test-intelligent-workload-" + mock.RandSeq(5)
+	workload := WorkloadCreateInput{
+		Name: name,
+		ScopeAccounts: &WorkloadScopeAccountsInput{
+			AccountIDs: []int{testAccountID},
+		},
+		DynamicFlows: []WorkloadDynamicFlowInput{
+			{
+				EntityGUID:      common.EntityGUID(testEntityGUID),
+				TransactionName: testTransactionName,
+			},
+		},
+		StatusConfig: &WorkloadStatusConfigInput{
+			AlertPolicy: &WorkloadAlertPolicyInput{
+				Enabled: true,
+			},
+		},
+	}
+
+	created, err := client.WorkloadCreate(testAccountID, workload)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	require.NotEmpty(t, created.GUID)
+
+	// Wait for indexing to catch up
+	time.Sleep(30 * time.Second)
+
+	// Update: rename and disable alert policy
+	updatedName := name + "-updated"
+	updated, err := client.WorkloadUpdate(created.GUID, WorkloadUpdateInput{
+		Name: updatedName,
+		DynamicFlows: []WorkloadUpdateDynamicFlowInput{
+			{
+				EntityGUID:      common.EntityGUID(testEntityGUID),
+				TransactionName: testTransactionName,
+			},
+		},
+		StatusConfig: &WorkloadUpdateStatusConfigInput{
+			AlertPolicy: &WorkloadUpdateAlertPolicyInput{
+				Enabled: false,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	assert.Equal(t, updatedName, updated.Name)
+	assert.Equal(t, 1, len(updated.DynamicFlows))
+	assert.False(t, updated.StatusConfig.AlertPolicy.Enabled)
+
+	// Cleanup
+	_, err = client.WorkloadDelete(common.EntityGUID(updated.GUID))
+	assert.NoError(t, err)
+}
+
 func newIntegrationTestClient(t *testing.T) Workloads {
 	cfg := mock.NewIntegrationTestConfig(t)
 	client := New(cfg)


### PR DESCRIPTION
Adds support for intelligent workloads in the workloads package, enabling callers to create and update workloads anchored to a transaction entry point via dynamic flows. New Relic auto-discovers related entities using Transaction 360 distributed tracing. If dynamicFlows is set alongside entityGuids or entitySearchQueries, dynamicFlows takes precedence, others will be ignored, and an intelligent workload is created.

  Changes:

  types.go
  - Added WorkloadDynamicFlow, WorkloadDynamicFlowInput, WorkloadUpdateDynamicFlowInput structs
  - Added WorkloadAlertPolicy, WorkloadAlertPolicyInput, WorkloadUpdateAlertPolicyInput structs
  - Added DynamicFlows field to WorkloadCreateInput, WorkloadUpdateInput, and WorkloadCollection
  - Added AlertPolicy field to WorkloadStatusConfig, WorkloadStatusConfigInput, and WorkloadUpdateStatusConfigInput

  workloads_api.go
  - Added dynamicFlows { entityGuid, id, transactionName } to all 5 GraphQL strings (WorkloadCreateMutation, WorkloadDeleteMutation, WorkloadDuplicateMutation, WorkloadUpdateMutation, getCollectionQuery)
  - Added alertPolicy { enabled } to statusConfig block in all 5 GraphQL strings

  pkg/testhelpers/helpers.go
  - Added GetTestEntityGUID() — reads NEW_RELIC_TEST_ENTITY_GUID env var
  - Added GetTestTransactionName() — reads NEW_RELIC_TEST_TRANSACTION_NAME env var
  - Added private getEnvString() helper

  Tests:

  Integration Tests
  - TestIntegrationWorkloadCreate_IntelligentWorkload — creates an intelligent workload with DynamicFlows and AlertPolicy enabled, asserts all fields, cleans up
  - TestIntegrationWorkloadUpdate_IntelligentWorkload — creates an intelligent workload, updates name and disables AlertPolicy, asserts updated fields, cleans up

  Example
  - Example_intelligentWorkload() — demonstrates full create/update/delete lifecycle with DynamicFlows and StatusConfig.AlertPolicy

  ---
  Note: types.go and workloads_api.go carry a // Code generated by tutone: DO NOT EDIT header. The additions in this PR are intentional manual changes. Please do not regenerate these files without first updating the tutone configuration to include the new fields.

  Follow-up: Once this PR is merged and a new version is released, a follow-up PR will be raised on https://github.com/newrelic/terraform-provider-newrelic to add dynamic_flows and status_config_alert_policy support to the newrelic_workload resource.