### PR TITLE
feat(alerts): add EntityGuid field to CompoundCondition struct

### DIFF
--- a/pkg/alerts/compound_conditions.go
+++ b/pkg/alerts/compound_conditions.go
@@ -17,6 +17,7 @@ type CompoundCondition struct {
 	RunbookURL            string               `json:"runbookUrl,omitempty"`
 	ThresholdDuration     int                  `json:"thresholdDuration,omitempty"`
 	TriggerExpression     string               `json:"triggerExpression,omitempty"`
+	EntityGuid            string               `json:"entityGuid,omitempty"`
 }
 
 // ComponentCondition represents a component condition within a compound condition.
@@ -272,6 +273,7 @@ const (
 			alias
 		}
 		enabled
+		entityGuid
 		facetMatchingBehavior
 		name
 		policyId

--- a/pkg/alerts/compound_conditions_integration_test.go
+++ b/pkg/alerts/compound_conditions_integration_test.go
@@ -118,6 +118,7 @@ func TestIntegrationCompoundConditions_Basic(t *testing.T) {
 	require.Equal(t, 60, created.ThresholdDuration)
 	require.Equal(t, "A AND B", created.TriggerExpression)
 	require.Len(t, created.ComponentConditions, 2)
+	require.NotEmpty(t, created.EntityGuid)
 
 	// Test: Search compound conditions (search all, then filter in code)
 	searchResults, err := client.SearchCompoundConditions(testAccountID, nil, nil, nil)
@@ -133,6 +134,7 @@ func TestIntegrationCompoundConditions_Basic(t *testing.T) {
 	}
 	require.NotNil(t, foundCondition)
 	require.Equal(t, conditionName, foundCondition.Name)
+	require.NotEmpty(t, foundCondition.EntityGuid)
 
 	// Test: Update compound condition
 	updateInput := CompoundConditionUpdateInput{
@@ -164,6 +166,7 @@ func TestIntegrationCompoundConditions_Basic(t *testing.T) {
 	require.Equal(t, "https://example.com/updated-runbook", updated.RunbookURL)
 	require.Equal(t, 60, updated.ThresholdDuration)
 	require.Equal(t, "A OR B", updated.TriggerExpression)
+	require.NotEmpty(t, updated.EntityGuid)
 
 	// Test: Delete compound condition
 	deletedID, err := client.DeleteCompoundCondition(testAccountID, created.ID)

--- a/pkg/alerts/compound_conditions_test.go
+++ b/pkg/alerts/compound_conditions_test.go
@@ -29,6 +29,7 @@ var (
 									"runbookUrl": "https://example.com/runbook",
 									"thresholdDuration": 60,
 									"triggerExpression": "a and b",
+									"entityGuid": "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
 									"componentConditions": [
 										{
 											"id": "1",
@@ -55,6 +56,7 @@ var (
 				"runbookUrl": "https://example.com/runbook",
 				"thresholdDuration": 60,
 				"triggerExpression": "a and b",
+				"entityGuid": "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
 				"componentConditions": [
 					{
 						"id": "1",
@@ -76,6 +78,7 @@ var (
 				"runbookUrl": "https://example.com/updated-runbook",
 				"thresholdDuration": 60,
 				"triggerExpression": "a or b",
+				"entityGuid": "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
 				"componentConditions": [
 					{
 						"id": "1",
@@ -126,6 +129,7 @@ func TestSearchCompoundConditions(t *testing.T) {
 			RunbookURL:            "https://example.com/runbook",
 			ThresholdDuration:     60,
 			TriggerExpression:     "a and b",
+			EntityGuid:            "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
 			ComponentConditions: []ComponentCondition{
 				{
 					ID:    "1",
@@ -170,6 +174,7 @@ func TestCreateCompoundCondition(t *testing.T) {
 		RunbookURL:            "https://example.com/runbook",
 		ThresholdDuration:     60,
 		TriggerExpression:     "a and b",
+		EntityGuid:            "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
 		ComponentConditions: []ComponentCondition{
 			{
 				ID:    "1",
@@ -218,6 +223,7 @@ func TestUpdateCompoundCondition(t *testing.T) {
 		RunbookURL:            "https://example.com/updated-runbook",
 		ThresholdDuration:     60,
 		TriggerExpression:     "a or b",
+		EntityGuid:            "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
 		ComponentConditions: []ComponentCondition{
 			{
 				ID:    "1",


### PR DESCRIPTION
Adds the EntityGuid response field to the CompoundCondition struct and includes it in the GraphQL query fields constant so it is returned by all compound condition queries and mutations.

- Added EntityGuid string field to CompoundCondition struct
- Added entityGuid to graphqlCompoundConditionStructFields constant
- Updated unit test JSON fixtures and assertions to include entityGuid

🤖 Generated with [Claude Code](https://claude.com/claude-code)