### PR TITLE
feat(workloads): add intelligent workload support with dynamic flows and alert policy

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -1663,6 +1663,8 @@ packages:
     types:
       - name: WorkloadCreateInput
       - name: WorkloadDuplicateInput
+      - name: WorkloadDynamicFlowInput
+      - name: WorkloadUpdateDynamicFlowInput
 
       # Some overrides we need
       - name: WorkloadStatusConfigInput
@@ -1672,6 +1674,10 @@ packages:
       - name: WorkloadUpdateStatusConfigInput
         field_type_override: "*WorkloadUpdateStatusConfigInput"
       # Status config overrides
+      - name: WorkloadAlertPolicyInput
+        field_type_override: "*WorkloadAlertPolicyInput"
+      - name: WorkloadUpdateAlertPolicyInput
+        field_type_override: "*WorkloadUpdateAlertPolicyInput"
       - name: WorkloadAutomaticStatusInput
         field_type_override: "*WorkloadAutomaticStatusInput"
       - name: WorkloadUpdateAutomaticStatusInput

--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -58,6 +58,11 @@ func GetNonExistentIDs() (string, string) {
 	return "00000FF000F0FFFF000F0F0000FF0FF0000000F000F00F0FF000FFFFF0FF00F0", "00000HH000H0HHHH000H0H0000HH0HH0000000H000H00H0HH000HHHHH0HH00H0"
 }
 
+// GetTestTransactionName returns the transaction name for intelligent workload integration tests from the environment.
+func GetTestTransactionName() (string, error) {
+	return "WebTransaction/Function/__main__:all_books", nil
+}
+
 // getEnvInt helper to DRY up the other env get calls for integers
 func getEnvInt(name string) (int, error) {
 	if name == "" {

--- a/pkg/workloads/example_basic_test.go
+++ b/pkg/workloads/example_basic_test.go
@@ -65,3 +65,68 @@ func Example_basic() {
 		log.Fatal("error deleting workload: ", err)
 	}
 }
+
+func Example_intelligentWorkload() {
+	// Initialize the client configuration. A Personal API key is required to
+	// communicate with the backend API.
+	cfg := config.New()
+	cfg.PersonalAPIKey = os.Getenv("NEW_RELIC_API_KEY")
+
+	// Initialize the client.
+	client := New(cfg)
+
+	accountID := 12345678
+	entityGUID := common.EntityGUID("MjUwODy1OXxOUjF8V097S0xPQ3R8ODcz")
+
+	// Create a new intelligent workload using dynamic flows.
+	// New Relic auto-discovers related entities via Transaction 360 distributed tracing.
+	// If set alongside entityGuids or entitySearchQueries, dynamicFlows takes precedence
+	// and others will be ignored.
+	createInput := WorkloadCreateInput{
+		Name: "Example intelligent workload",
+		ScopeAccounts: &WorkloadScopeAccountsInput{
+			AccountIDs: []int{accountID},
+		},
+		DynamicFlows: []WorkloadDynamicFlowInput{
+			{
+				EntityGUID:      entityGUID,
+				TransactionName: "WebTransaction/Action/index",
+			},
+		},
+		StatusConfig: &WorkloadStatusConfigInput{
+			AlertPolicy: &WorkloadAlertPolicyInput{
+				Enabled: true,
+			},
+		},
+	}
+
+	workload, err := client.WorkloadCreate(accountID, createInput)
+	if err != nil {
+		log.Fatal("error creating intelligent workload: ", err)
+	}
+
+	// Update an existing intelligent workload.
+	updated, err := client.WorkloadUpdate(workload.GUID, WorkloadUpdateInput{
+		Name: "Example intelligent workload - updated",
+		DynamicFlows: []WorkloadDynamicFlowInput{
+			{
+				EntityGUID:      entityGUID,
+				TransactionName: "WebTransaction/Action/index",
+			},
+		},
+		StatusConfig: &WorkloadUpdateStatusConfigInput{
+			AlertPolicy: &WorkloadAlertPolicyInput{
+				Enabled: false,
+			},
+		},
+	})
+	if err != nil {
+		log.Fatal("error updating intelligent workload: ", err)
+	}
+
+	// Delete an existing intelligent workload.
+	_, err = client.WorkloadDelete(updated.GUID)
+	if err != nil {
+		log.Fatal("error deleting intelligent workload: ", err)
+	}
+}

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -11,19 +11,1835 @@ import (
 	"github.com/newrelic/newrelic-client-go/v2/pkg/users"
 )
 
+// BrowserAgentInstallType - Browser agent install types.
+type BrowserAgentInstallType string
+
+var BrowserAgentInstallTypeTypes = struct {
+	// Lite agent install type.
+	LITE BrowserAgentInstallType
+	// Pro agent install type.
+	PRO BrowserAgentInstallType
+	// Pro + SPA agent install type.
+	PRO_SPA BrowserAgentInstallType
+}{
+	// Lite agent install type.
+	LITE: "LITE",
+	// Pro agent install type.
+	PRO: "PRO",
+	// Pro + SPA agent install type.
+	PRO_SPA: "PRO_SPA",
+}
+
+// DashboardEntityOwnerType - Specifies the type of principal that owns a dashboard.
+type DashboardEntityOwnerType string
+
+var DashboardEntityOwnerTypeTypes = struct {
+	// System Identity identified by a UUID.
+	SYSTEM_IDENTITY DashboardEntityOwnerType
+	// Regular New Relic user identified by a numeric user ID.
+	USER DashboardEntityOwnerType
+}{
+	// System Identity identified by a UUID.
+	SYSTEM_IDENTITY: "SYSTEM_IDENTITY",
+	// Regular New Relic user identified by a numeric user ID.
+	USER: "USER",
+}
+
+// DashboardEntityPermissions - Permisions that represent visibility & editability
+type DashboardEntityPermissions string
+
+var DashboardEntityPermissionsTypes = struct {
+	// Private
+	PRIVATE DashboardEntityPermissions
+	// Public read only
+	PUBLIC_READ_ONLY DashboardEntityPermissions
+	// Public read & write
+	PUBLIC_READ_WRITE DashboardEntityPermissions
+}{
+	// Private
+	PRIVATE: "PRIVATE",
+	// Public read only
+	PUBLIC_READ_ONLY: "PUBLIC_READ_ONLY",
+	// Public read & write
+	PUBLIC_READ_WRITE: "PUBLIC_READ_WRITE",
+}
+
+// EntityAlertSeverity - The alert severity of the entity.
+type EntityAlertSeverity string
+
+var EntityAlertSeverityTypes = struct {
+	// Indicates an entity has a critical violation in progress.
+	CRITICAL EntityAlertSeverity
+	// Indicates an entity has no violations and therefore is not alerting.
+	NOT_ALERTING EntityAlertSeverity
+	// Indicates an entity is not configured for alerting.
+	NOT_CONFIGURED EntityAlertSeverity
+	// Indicates an entity  has a warning violation in progress.
+	WARNING EntityAlertSeverity
+}{
+	// Indicates an entity has a critical violation in progress.
+	CRITICAL: "CRITICAL",
+	// Indicates an entity has no violations and therefore is not alerting.
+	NOT_ALERTING: "NOT_ALERTING",
+	// Indicates an entity is not configured for alerting.
+	NOT_CONFIGURED: "NOT_CONFIGURED",
+	// Indicates an entity  has a warning violation in progress.
+	WARNING: "WARNING",
+}
+
 // EntityCollectionType - Indicates where this collection is used
 type EntityCollectionType string
 
 var EntityCollectionTypeTypes = struct {
+	// Collections that define the entities that belong to a team
+	TEAM EntityCollectionType
 	// Collections that define the entities that belong to a workload
 	WORKLOAD EntityCollectionType
 	// Collections that define the entity groups that are used to calculate the status of a workload
 	WORKLOAD_STATUS_RULE_GROUP EntityCollectionType
 }{
+	// Collections that define the entities that belong to a team
+	TEAM: "TEAM",
 	// Collections that define the entities that belong to a workload
 	WORKLOAD: "WORKLOAD",
 	// Collections that define the entity groups that are used to calculate the status of a workload
 	WORKLOAD_STATUS_RULE_GROUP: "WORKLOAD_STATUS_RULE_GROUP",
+}
+
+// EntityGoldenEventObjectId - Types of references for the default WHERE clause.
+type EntityGoldenEventObjectId string
+
+var EntityGoldenEventObjectIdTypes = struct {
+	// The WHERE clause will be done against a domainId.
+	DOMAIN_IDS EntityGoldenEventObjectId
+	// The WHERE clause will be done against a GUID.
+	ENTITY_GUIDS EntityGoldenEventObjectId
+	// The WHERE clause will be done against the name of the entity.
+	ENTITY_NAMES EntityGoldenEventObjectId
+}{
+	// The WHERE clause will be done against a domainId.
+	DOMAIN_IDS: "DOMAIN_IDS",
+	// The WHERE clause will be done against a GUID.
+	ENTITY_GUIDS: "ENTITY_GUIDS",
+	// The WHERE clause will be done against the name of the entity.
+	ENTITY_NAMES: "ENTITY_NAMES",
+}
+
+// EntityGoldenMetricUnit - The different units that can be used to express golden metrics.
+type EntityGoldenMetricUnit string
+
+var EntityGoldenMetricUnitTypes = struct {
+	// Apdex (Application Performance Index).
+	APDEX EntityGoldenMetricUnit
+	// Bits.
+	BITS EntityGoldenMetricUnit
+	// Bits per second.
+	BITS_PER_SECOND EntityGoldenMetricUnit
+	// Bytes.
+	BYTES EntityGoldenMetricUnit
+	// Bytes per second.
+	BYTES_PER_SECOND EntityGoldenMetricUnit
+	// Degrees celsius.
+	CELSIUS EntityGoldenMetricUnit
+	// Count.
+	COUNT EntityGoldenMetricUnit
+	// Hertz.
+	HERTZ EntityGoldenMetricUnit
+	// Messages per second.
+	MESSAGES_PER_SECOND EntityGoldenMetricUnit
+	// Milliseconds.
+	MS EntityGoldenMetricUnit
+	// Operations per second.
+	OPERATIONS_PER_SECOND EntityGoldenMetricUnit
+	// Pages loaded per second.
+	PAGES_PER_SECOND EntityGoldenMetricUnit
+	// Percentage.
+	PERCENTAGE EntityGoldenMetricUnit
+	// Requests received per minute.
+	REQUESTS_PER_MINUTE EntityGoldenMetricUnit
+	// Requests received per second.
+	REQUESTS_PER_SECOND EntityGoldenMetricUnit
+	// Seconds.
+	SECONDS EntityGoldenMetricUnit
+	// Timestamp.
+	TIMESTAMP EntityGoldenMetricUnit
+}{
+	// Apdex (Application Performance Index).
+	APDEX: "APDEX",
+	// Bits.
+	BITS: "BITS",
+	// Bits per second.
+	BITS_PER_SECOND: "BITS_PER_SECOND",
+	// Bytes.
+	BYTES: "BYTES",
+	// Bytes per second.
+	BYTES_PER_SECOND: "BYTES_PER_SECOND",
+	// Degrees celsius.
+	CELSIUS: "CELSIUS",
+	// Count.
+	COUNT: "COUNT",
+	// Hertz.
+	HERTZ: "HERTZ",
+	// Messages per second.
+	MESSAGES_PER_SECOND: "MESSAGES_PER_SECOND",
+	// Milliseconds.
+	MS: "MS",
+	// Operations per second.
+	OPERATIONS_PER_SECOND: "OPERATIONS_PER_SECOND",
+	// Pages loaded per second.
+	PAGES_PER_SECOND: "PAGES_PER_SECOND",
+	// Percentage.
+	PERCENTAGE: "PERCENTAGE",
+	// Requests received per minute.
+	REQUESTS_PER_MINUTE: "REQUESTS_PER_MINUTE",
+	// Requests received per second.
+	REQUESTS_PER_SECOND: "REQUESTS_PER_SECOND",
+	// Seconds.
+	SECONDS: "SECONDS",
+	// Timestamp.
+	TIMESTAMP: "TIMESTAMP",
+}
+
+// EntityManagementActorType - The available actor types.
+type EntityManagementActorType string
+
+var EntityManagementActorTypeTypes = struct {
+	// System actor type.
+	SYSTEM EntityManagementActorType
+	// User actor type.
+	USER EntityManagementActorType
+}{
+	// System actor type.
+	SYSTEM: "SYSTEM",
+	// User actor type.
+	USER: "USER",
+}
+
+// EntityManagementAiToolParameterType - Enum for AiToolParameter
+type EntityManagementAiToolParameterType string
+
+var EntityManagementAiToolParameterTypeTypes = struct {
+	// when the parameter type is boolean
+	BOOLEAN EntityManagementAiToolParameterType
+	// when the parameter type is integer
+	INTEGER EntityManagementAiToolParameterType
+	// when the parameter type is list
+	LIST EntityManagementAiToolParameterType
+	// when the parameter type is object/dict
+	OBJECT EntityManagementAiToolParameterType
+	// when the parameter type is String
+	STRING EntityManagementAiToolParameterType
+}{
+	// when the parameter type is boolean
+	BOOLEAN: "BOOLEAN",
+	// when the parameter type is integer
+	INTEGER: "INTEGER",
+	// when the parameter type is list
+	LIST: "LIST",
+	// when the parameter type is object/dict
+	OBJECT: "OBJECT",
+	// when the parameter type is String
+	STRING: "STRING",
+}
+
+// EntityManagementAiToolType - Enum for first class citizen tools on the agentic-platform
+type EntityManagementAiToolType string
+
+var EntityManagementAiToolTypeTypes = struct {
+	// when tool type is knowledge base
+	KNOWLEDGE_BASE EntityManagementAiToolType
+	// when tool type is nerdgraph query
+	NERDGRAPH EntityManagementAiToolType
+	// when tool type is workflow tools
+	WORKFLOW EntityManagementAiToolType
+}{
+	// when tool type is knowledge base
+	KNOWLEDGE_BASE: "KNOWLEDGE_BASE",
+	// when tool type is nerdgraph query
+	NERDGRAPH: "NERDGRAPH",
+	// when tool type is workflow tools
+	WORKFLOW: "WORKFLOW",
+}
+
+// EntityManagementArrayOperator - Enum defining the supported array operators.
+type EntityManagementArrayOperator string
+
+var EntityManagementArrayOperatorTypes = struct {
+	// Checks for empty array.
+	IS_EMPTY EntityManagementArrayOperator
+	// Checks for non-empty array.
+	IS_NOT_EMPTY EntityManagementArrayOperator
+}{
+	// Checks for empty array.
+	IS_EMPTY: "IS_EMPTY",
+	// Checks for non-empty array.
+	IS_NOT_EMPTY: "IS_NOT_EMPTY",
+}
+
+// EntityManagementAssignmentType - Work Item assignment type
+type EntityManagementAssignmentType string
+
+var EntityManagementAssignmentTypeTypes = struct {
+	// New Relic team ID
+	NEW_RELIC_TEAM_ID EntityManagementAssignmentType
+	// New Relic user ID
+	NEW_RELIC_USER_ID EntityManagementAssignmentType
+}{
+	// New Relic team ID
+	NEW_RELIC_TEAM_ID: "NEW_RELIC_TEAM_ID",
+	// New Relic user ID
+	NEW_RELIC_USER_ID: "NEW_RELIC_USER_ID",
+}
+
+// EntityManagementBackgroundProcessingType - At rest background processing types
+type EntityManagementBackgroundProcessingType string
+
+var EntityManagementBackgroundProcessingTypeTypes = struct {
+	// Data mutation
+	DATA_MUTATION EntityManagementBackgroundProcessingType
+	// Exporting processing type
+	EXPORT EntityManagementBackgroundProcessingType
+	// Importing processing type
+	IMPORT EntityManagementBackgroundProcessingType
+	// Index rule
+	INDEX EntityManagementBackgroundProcessingType
+	// Materialized view rule
+	MATERIALIZED_VIEW EntityManagementBackgroundProcessingType
+	// Schedule a query to be executed
+	SCHEDULED_QUERY_RESULT EntityManagementBackgroundProcessingType
+}{
+	// Data mutation
+	DATA_MUTATION: "DATA_MUTATION",
+	// Exporting processing type
+	EXPORT: "EXPORT",
+	// Importing processing type
+	IMPORT: "IMPORT",
+	// Index rule
+	INDEX: "INDEX",
+	// Materialized view rule
+	MATERIALIZED_VIEW: "MATERIALIZED_VIEW",
+	// Schedule a query to be executed
+	SCHEDULED_QUERY_RESULT: "SCHEDULED_QUERY_RESULT",
+}
+
+// EntityManagementBudgetType - Defines possible budget types.
+type EntityManagementBudgetType string
+
+var EntityManagementBudgetTypeTypes = struct {
+	// Compute Budget.
+	COMPUTE EntityManagementBudgetType
+	// Ingest Budget.
+	INGEST EntityManagementBudgetType
+}{
+	// Compute Budget.
+	COMPUTE: "COMPUTE",
+	// Ingest Budget.
+	INGEST: "INGEST",
+}
+
+// EntityManagementCategoryScopeType - Category scope can of two types: Account scope and Global scope
+type EntityManagementCategoryScopeType string
+
+var EntityManagementCategoryScopeTypeTypes = struct {
+	// Account scope
+	ACCOUNT EntityManagementCategoryScopeType
+	// Global scope
+	GLOBAL EntityManagementCategoryScopeType
+}{
+	// Account scope
+	ACCOUNT: "ACCOUNT",
+	// Global scope
+	GLOBAL: "GLOBAL",
+}
+
+// EntityManagementChannelType - Enum for Channel
+type EntityManagementChannelType string
+
+var EntityManagementChannelTypeTypes = struct {
+	// Browser
+	BROWSER EntityManagementChannelType
+	// Mobile
+	MOBILE EntityManagementChannelType
+}{
+	// Browser
+	BROWSER: "BROWSER",
+	// Mobile
+	MOBILE: "MOBILE",
+}
+
+// EntityManagementCloudProvider - Supported cloud providers for federated log deployments.
+type EntityManagementCloudProvider string
+
+var EntityManagementCloudProviderTypes = struct {
+	// Amazon Web Services
+	AWS EntityManagementCloudProvider
+	// Microsoft Azure
+	AZURE EntityManagementCloudProvider
+	// Google Cloud Platform
+	GCP EntityManagementCloudProvider
+	// Oracle Cloud Infrastructure
+	OCI EntityManagementCloudProvider
+}{
+	// Amazon Web Services
+	AWS: "AWS",
+	// Microsoft Azure
+	AZURE: "AZURE",
+	// Google Cloud Platform
+	GCP: "GCP",
+	// Oracle Cloud Infrastructure
+	OCI: "OCI",
+}
+
+// EntityManagementCommunicationMode - CommunicationMode represents the mode of communication for an incident.
+type EntityManagementCommunicationMode string
+
+var EntityManagementCommunicationModeTypes = struct {
+	// For Private status page communication.
+	ACCOUNT_STATUS EntityManagementCommunicationMode
+	// For Publicstatus page communication.
+	GLOBAL_STATUS EntityManagementCommunicationMode
+}{
+	// For Private status page communication.
+	ACCOUNT_STATUS: "ACCOUNT_STATUS",
+	// For Publicstatus page communication.
+	GLOBAL_STATUS: "GLOBAL_STATUS",
+}
+
+// EntityManagementCommunicationStatus - CommunicationStatus represents the status of the communication for an incident.
+type EntityManagementCommunicationStatus string
+
+var EntityManagementCommunicationStatusTypes = struct {
+	// Incident root cause has been identified.
+	IDENTIFIED EntityManagementCommunicationStatus
+	// Incident is being investigated.
+	INVESTIGATING EntityManagementCommunicationStatus
+	// Incident in Monitoring phase.
+	MONITORING EntityManagementCommunicationStatus
+	// Incident has been resolved.
+	RESOLVED EntityManagementCommunicationStatus
+}{
+	// Incident root cause has been identified.
+	IDENTIFIED: "IDENTIFIED",
+	// Incident is being investigated.
+	INVESTIGATING: "INVESTIGATING",
+	// Incident in Monitoring phase.
+	MONITORING: "MONITORING",
+	// Incident has been resolved.
+	RESOLVED: "RESOLVED",
+}
+
+// EntityManagementConsumptionMetric - Defines possible consumption metrics for a budget.
+type EntityManagementConsumptionMetric string
+
+var EntityManagementConsumptionMetricTypes = struct {
+	// Advanced CCU metric.
+	ADVANCED_CCU EntityManagementConsumptionMetric
+	// Legacy CCU metric.
+	CCU EntityManagementConsumptionMetric
+	// Core CCU metric.
+	CORE_CCU EntityManagementConsumptionMetric
+	// Gigabytes Ingested metric.
+	GIGABYTES_INGESTED EntityManagementConsumptionMetric
+}{
+	// Advanced CCU metric.
+	ADVANCED_CCU: "ADVANCED_CCU",
+	// Legacy CCU metric.
+	CCU: "CCU",
+	// Core CCU metric.
+	CORE_CCU: "CORE_CCU",
+	// Gigabytes Ingested metric.
+	GIGABYTES_INGESTED: "GIGABYTES_INGESTED",
+}
+
+// EntityManagementCorrelationAttributeConditionOperator - Enum defining attribute matching operators.
+type EntityManagementCorrelationAttributeConditionOperator string
+
+var EntityManagementCorrelationAttributeConditionOperatorTypes = struct {
+	// Contains substring.
+	CONTAINS EntityManagementCorrelationAttributeConditionOperator
+	// Exact equality match.
+	EQUALS EntityManagementCorrelationAttributeConditionOperator
+	// Regular expression match.
+	REGEX EntityManagementCorrelationAttributeConditionOperator
+	// Starts with prefix.
+	STARTS_WITH EntityManagementCorrelationAttributeConditionOperator
+}{
+	// Contains substring.
+	CONTAINS: "CONTAINS",
+	// Exact equality match.
+	EQUALS: "EQUALS",
+	// Regular expression match.
+	REGEX: "REGEX",
+	// Starts with prefix.
+	STARTS_WITH: "STARTS_WITH",
+}
+
+// EntityManagementCorrelationMatchingAlgorithm - Enum defining ML algorithms for probabilistic matching.
+type EntityManagementCorrelationMatchingAlgorithm string
+
+var EntityManagementCorrelationMatchingAlgorithmTypes = struct {
+	// Attribute similarity scoring.
+	ATTRIBUTE_SIMILARITY EntityManagementCorrelationMatchingAlgorithm
+	// BERT-based embedding similarity.
+	BERT_EMBEDDING EntityManagementCorrelationMatchingAlgorithm
+	// Historical pattern analysis.
+	HISTORICAL_PATTERNS EntityManagementCorrelationMatchingAlgorithm
+	// Incident Root Cause Analysis.
+	IRCA EntityManagementCorrelationMatchingAlgorithm
+}{
+	// Attribute similarity scoring.
+	ATTRIBUTE_SIMILARITY: "ATTRIBUTE_SIMILARITY",
+	// BERT-based embedding similarity.
+	BERT_EMBEDDING: "BERT_EMBEDDING",
+	// Historical pattern analysis.
+	HISTORICAL_PATTERNS: "HISTORICAL_PATTERNS",
+	// Incident Root Cause Analysis.
+	IRCA: "IRCA",
+}
+
+// EntityManagementCorrelationNormalizationDefault - Enum defining default behavior when no normalizer pattern matches.
+type EntityManagementCorrelationNormalizationDefault string
+
+var EntityManagementCorrelationNormalizationDefaultTypes = struct {
+	// Fail the condition (no match) when no pattern matches.
+	FAIL EntityManagementCorrelationNormalizationDefault
+	// Use the original (transformed) value as-is when no pattern matches.
+	PASSTHROUGH EntityManagementCorrelationNormalizationDefault
+}{
+	// Fail the condition (no match) when no pattern matches.
+	FAIL: "FAIL",
+	// Use the original (transformed) value as-is when no pattern matches.
+	PASSTHROUGH: "PASSTHROUGH",
+}
+
+// EntityManagementCorrelationOverrideAction - Enum defining user override actions for correlation links.
+type EntityManagementCorrelationOverrideAction string
+
+var EntityManagementCorrelationOverrideActionTypes = struct {
+	// User confirmed the correlation.
+	CONFIRMED EntityManagementCorrelationOverrideAction
+	// User unlinked the correlation.
+	UNLINKED EntityManagementCorrelationOverrideAction
+}{
+	// User confirmed the correlation.
+	CONFIRMED: "CONFIRMED",
+	// User unlinked the correlation.
+	UNLINKED: "UNLINKED",
+}
+
+// EntityManagementCorrelationSubjectType - Enum defining the type of correlation subject.
+type EntityManagementCorrelationSubjectType string
+
+var EntityManagementCorrelationSubjectTypeTypes = struct {
+	// Entity-based subject.
+	ENTITY EntityManagementCorrelationSubjectType
+	// Event-based subject.
+	EVENT EntityManagementCorrelationSubjectType
+}{
+	// Entity-based subject.
+	ENTITY: "ENTITY",
+	// Event-based subject.
+	EVENT: "EVENT",
+}
+
+// EntityManagementCorrelationTransformFunction - Enum defining transform functions for attribute value processing before comparison.
+type EntityManagementCorrelationTransformFunction string
+
+var EntityManagementCorrelationTransformFunctionTypes = struct {
+	// Remove all non-alphanumeric characters.
+	ALPHANUMERIC EntityManagementCorrelationTransformFunction
+	// Extract hostname portion, stripping domain suffix.
+	EXTRACT_HOSTNAME EntityManagementCorrelationTransformFunction
+	// Smart IP extraction from various formats (AWS EC2 DNS, dash-separated, embedded in hostname, etc.).
+	EXTRACT_IP EntityManagementCorrelationTransformFunction
+	// Convert to lowercase.
+	LOWERCASE EntityManagementCorrelationTransformFunction
+	// Remove leading/trailing whitespace.
+	TRIM EntityManagementCorrelationTransformFunction
+	// Convert to uppercase.
+	UPPERCASE EntityManagementCorrelationTransformFunction
+}{
+	// Remove all non-alphanumeric characters.
+	ALPHANUMERIC: "ALPHANUMERIC",
+	// Extract hostname portion, stripping domain suffix.
+	EXTRACT_HOSTNAME: "EXTRACT_HOSTNAME",
+	// Smart IP extraction from various formats (AWS EC2 DNS, dash-separated, embedded in hostname, etc.).
+	EXTRACT_IP: "EXTRACT_IP",
+	// Convert to lowercase.
+	LOWERCASE: "LOWERCASE",
+	// Remove leading/trailing whitespace.
+	TRIM: "TRIM",
+	// Convert to uppercase.
+	UPPERCASE: "UPPERCASE",
+}
+
+// EntityManagementDateOperator - Enum defining the supported date operators.
+type EntityManagementDateOperator string
+
+var EntityManagementDateOperatorTypes = struct {
+	// Date after the specified value.
+	AFTER EntityManagementDateOperator
+	// Date before the specified value.
+	BEFORE EntityManagementDateOperator
+	// Date within the specified range.
+	IN_RANGE EntityManagementDateOperator
+}{
+	// Date after the specified value.
+	AFTER: "AFTER",
+	// Date before the specified value.
+	BEFORE: "BEFORE",
+	// Date within the specified range.
+	IN_RANGE: "IN_RANGE",
+}
+
+// EntityManagementEncodingName - The Encoding names options
+type EntityManagementEncodingName string
+
+var EntityManagementEncodingNameTypes = struct {
+	// for gpt 4
+	CL100_K_BASE EntityManagementEncodingName
+	// For gpt 3
+	GPT_3_5_TURBO EntityManagementEncodingName
+	// For gpt4
+	O200_K_BASE EntityManagementEncodingName
+}{
+	// for gpt 4
+	CL100_K_BASE: "CL100_K_BASE",
+	// For gpt 3
+	GPT_3_5_TURBO: "GPT_3_5_TURBO",
+	// For gpt4
+	O200_K_BASE: "O200_K_BASE",
+}
+
+// EntityManagementEncodingType - Encoding type enum
+type EntityManagementEncodingType string
+
+var EntityManagementEncodingTypeTypes = struct {
+	// BASE64 encoding type
+	BASE64 EntityManagementEncodingType
+	// UTF8 encoding type
+	UTF8 EntityManagementEncodingType
+}{
+	// BASE64 encoding type
+	BASE64: "BASE64",
+	// UTF8 encoding type
+	UTF8: "UTF8",
+}
+
+// EntityManagementEntityScope - The list of possible scopes of an entity.
+type EntityManagementEntityScope string
+
+var EntityManagementEntityScopeTypes = struct {
+	// Account scope.
+	ACCOUNT EntityManagementEntityScope
+	// Organization scope.
+	ORGANIZATION EntityManagementEntityScope
+}{
+	// Account scope.
+	ACCOUNT: "ACCOUNT",
+	// Organization scope.
+	ORGANIZATION: "ORGANIZATION",
+}
+
+// EntityManagementEvaluationParameter - Parameters that can be used in custom evaluations
+type EntityManagementEvaluationParameter string
+
+var EntityManagementEvaluationParameterTypes = struct {
+	// Actual generated output
+	ACTUAL_OUTPUT EntityManagementEvaluationParameter
+	// Contextual information
+	CONTEXT EntityManagementEvaluationParameter
+	// Expected output for comparison
+	EXPECTED_OUTPUT EntityManagementEvaluationParameter
+	// Expected tools that should have been called
+	EXPECTED_TOOLS EntityManagementEvaluationParameter
+	// Input prompt or query
+	INPUT EntityManagementEvaluationParameter
+	// Retrieved context from RAG systems
+	RETRIEVAL_CONTEXT EntityManagementEvaluationParameter
+	// Tools that were called during execution
+	TOOLS_CALLED EntityManagementEvaluationParameter
+}{
+	// Actual generated output
+	ACTUAL_OUTPUT: "ACTUAL_OUTPUT",
+	// Contextual information
+	CONTEXT: "CONTEXT",
+	// Expected output for comparison
+	EXPECTED_OUTPUT: "EXPECTED_OUTPUT",
+	// Expected tools that should have been called
+	EXPECTED_TOOLS: "EXPECTED_TOOLS",
+	// Input prompt or query
+	INPUT: "INPUT",
+	// Retrieved context from RAG systems
+	RETRIEVAL_CONTEXT: "RETRIEVAL_CONTEXT",
+	// Tools that were called during execution
+	TOOLS_CALLED: "TOOLS_CALLED",
+}
+
+// EntityManagementEventBridgeEventSourceType - An enum representing the different event source systems.
+type EntityManagementEventBridgeEventSourceType string
+
+var EntityManagementEventBridgeEventSourceTypeTypes = struct {
+	// Events originating from the entity pipeline.
+	ENTITY EntityManagementEventBridgeEventSourceType
+}{
+	// Events originating from the entity pipeline.
+	ENTITY: "ENTITY",
+}
+
+// EntityManagementEventBridgeTargetType - Enum defining the supported types of target actions.
+type EntityManagementEventBridgeTargetType string
+
+var EntityManagementEventBridgeTargetTypeTypes = struct {
+	// Target type WORKFLOW
+	WORKFLOW EntityManagementEventBridgeTargetType
+}{
+	// Target type WORKFLOW
+	WORKFLOW: "WORKFLOW",
+}
+
+// EntityManagementEventBridgeWorkflowDefinitionScopeType - Specifies the scope at which the workflow is defined.
+type EntityManagementEventBridgeWorkflowDefinitionScopeType string
+
+var EntityManagementEventBridgeWorkflowDefinitionScopeTypeTypes = struct {
+	// Account scope
+	ACCOUNT EntityManagementEventBridgeWorkflowDefinitionScopeType
+	// Global scope
+	GLOBAL EntityManagementEventBridgeWorkflowDefinitionScopeType
+	// Organization scope.
+	ORGANIZATION EntityManagementEventBridgeWorkflowDefinitionScopeType
+}{
+	// Account scope
+	ACCOUNT: "ACCOUNT",
+	// Global scope
+	GLOBAL: "GLOBAL",
+	// Organization scope.
+	ORGANIZATION: "ORGANIZATION",
+}
+
+// EntityManagementExecutionStatus - Rule execution status
+type EntityManagementExecutionStatus string
+
+var EntityManagementExecutionStatusTypes = struct {
+	// Rule execution failed due to an error.
+	FAILED EntityManagementExecutionStatus
+	// Rule executed with partial success, some issues occurred.
+	PARTIAL_SUCCESS EntityManagementExecutionStatus
+	// Rule executed successfully without any issues.
+	SUCCESS EntityManagementExecutionStatus
+}{
+	// Rule execution failed due to an error.
+	FAILED: "FAILED",
+	// Rule executed with partial success, some issues occurred.
+	PARTIAL_SUCCESS: "PARTIAL_SUCCESS",
+	// Rule executed successfully without any issues.
+	SUCCESS: "SUCCESS",
+}
+
+// EntityManagementExternalOwnerType - List of possible owner types of the repository.
+type EntityManagementExternalOwnerType string
+
+var EntityManagementExternalOwnerTypeTypes = struct {
+	// group if the source is gitlab
+	GROUP EntityManagementExternalOwnerType
+	// organization if the source is github
+	ORGANIZATION EntityManagementExternalOwnerType
+	// Default value when the owner type cannot be found
+	OTHER EntityManagementExternalOwnerType
+	// individual user
+	USER EntityManagementExternalOwnerType
+	// workspace if the source is bitbucket
+	WORKSPACE EntityManagementExternalOwnerType
+}{
+	// group if the source is gitlab
+	GROUP: "GROUP",
+	// organization if the source is github
+	ORGANIZATION: "ORGANIZATION",
+	// Default value when the owner type cannot be found
+	OTHER: "OTHER",
+	// individual user
+	USER: "USER",
+	// workspace if the source is bitbucket
+	WORKSPACE: "WORKSPACE",
+}
+
+// EntityManagementFleetDeploymentPhase - Phases a fleet deployment can have
+type EntityManagementFleetDeploymentPhase string
+
+var EntityManagementFleetDeploymentPhaseTypes = struct {
+	// Deployment rollout completed
+	COMPLETED EntityManagementFleetDeploymentPhase
+	// Deployment is in editable phase
+	CREATED EntityManagementFleetDeploymentPhase
+	// Indicates a deployment failed to deploy to all agents
+	FAILED EntityManagementFleetDeploymentPhase
+	// Indicates an internal failure in the deployment process
+	INTERNAL_FAILURE EntityManagementFleetDeploymentPhase
+	// Deployment is under rollout
+	IN_PROGRESS EntityManagementFleetDeploymentPhase
+}{
+	// Deployment rollout completed
+	COMPLETED: "COMPLETED",
+	// Deployment is in editable phase
+	CREATED: "CREATED",
+	// Indicates a deployment failed to deploy to all agents
+	FAILED: "FAILED",
+	// Indicates an internal failure in the deployment process
+	INTERNAL_FAILURE: "INTERNAL_FAILURE",
+	// Deployment is under rollout
+	IN_PROGRESS: "IN_PROGRESS",
+}
+
+// EntityManagementForwarderType - Supported forwarder types for log processing.
+type EntityManagementForwarderType string
+
+var EntityManagementForwarderTypeTypes = struct {
+	// Logs are forwarded via a pipeline control fleet deployment.
+	PIPELINE_CONTROL EntityManagementForwarderType
+}{
+	// Logs are forwarded via a pipeline control fleet deployment.
+	PIPELINE_CONTROL: "PIPELINE_CONTROL",
+}
+
+// EntityManagementHealthCheckState - Health check states for a federated log setup or partition.
+type EntityManagementHealthCheckState string
+
+var EntityManagementHealthCheckStateTypes = struct {
+	// Indicates the setup or partition and its dependencies are operating correctly.
+	HEALTHY EntityManagementHealthCheckState
+	// Indicates the setup or partition has issues. The message field will contain details about the failures.
+	UNHEALTHY EntityManagementHealthCheckState
+	// Indicates no health check has been run yet.
+	UNKNOWN EntityManagementHealthCheckState
+}{
+	// Indicates the setup or partition and its dependencies are operating correctly.
+	HEALTHY: "HEALTHY",
+	// Indicates the setup or partition has issues. The message field will contain details about the failures.
+	UNHEALTHY: "UNHEALTHY",
+	// Indicates no health check has been run yet.
+	UNKNOWN: "UNKNOWN",
+}
+
+// EntityManagementHostingPlatform - List of possible hosting platforms of the repository.
+type EntityManagementHostingPlatform string
+
+var EntityManagementHostingPlatformTypes = struct {
+	// when the hosting platform is bitbucket
+	BITBUCKET EntityManagementHostingPlatform
+	// when the hosting platform is devlake
+	DEVLAKE EntityManagementHostingPlatform
+	// when the hosting platform is github
+	GITHUB EntityManagementHostingPlatform
+	// when the hosting platform is gitlab
+	GITLAB EntityManagementHostingPlatform
+	// Default value when the hosting platform cannot be found
+	OTHER EntityManagementHostingPlatform
+}{
+	// when the hosting platform is bitbucket
+	BITBUCKET: "BITBUCKET",
+	// when the hosting platform is devlake
+	DEVLAKE: "DEVLAKE",
+	// when the hosting platform is github
+	GITHUB: "GITHUB",
+	// when the hosting platform is gitlab
+	GITLAB: "GITLAB",
+	// Default value when the hosting platform cannot be found
+	OTHER: "OTHER",
+}
+
+// EntityManagementIncidentSource - Defines the possible sources for an incident record.
+type EntityManagementIncidentSource string
+
+var EntityManagementIncidentSourceTypes = struct {
+	// The source representing manual entry.
+	MANUAL EntityManagementIncidentSource
+	// The source representing New Relic Agent.
+	NEW_RELIC_AGENT EntityManagementIncidentSource
+	// The source representing Slack.
+	NEW_RELIC_SLACK EntityManagementIncidentSource
+	// The source representing New Relic.
+	NEW_RELIC_UI EntityManagementIncidentSource
+}{
+	// The source representing manual entry.
+	MANUAL: "MANUAL",
+	// The source representing New Relic Agent.
+	NEW_RELIC_AGENT: "NEW_RELIC_AGENT",
+	// The source representing Slack.
+	NEW_RELIC_SLACK: "NEW_RELIC_SLACK",
+	// The source representing New Relic.
+	NEW_RELIC_UI: "NEW_RELIC_UI",
+}
+
+// EntityManagementIncidentStatus - IncidentStatus represents the status of an incident.
+type EntityManagementIncidentStatus string
+
+var EntityManagementIncidentStatusTypes = struct {
+	// The incident is closed.
+	CLOSED EntityManagementIncidentStatus
+	// The incident is ongoing.
+	ONGOING EntityManagementIncidentStatus
+}{
+	// The incident is closed.
+	CLOSED: "CLOSED",
+	// The incident is ongoing.
+	ONGOING: "ONGOING",
+}
+
+// EntityManagementIncidentTimelineSource - Defines the possible timeline sources for an incident record.
+type EntityManagementIncidentTimelineSource string
+
+var EntityManagementIncidentTimelineSourceTypes = struct {
+	// The source representing manual entry.
+	MANUAL EntityManagementIncidentTimelineSource
+	// The source representing New Relic Agent.
+	NEW_RELIC_AGENT EntityManagementIncidentTimelineSource
+	// The source representing Slack.
+	NEW_RELIC_SLACK EntityManagementIncidentTimelineSource
+	// The source representing New Relic.
+	NEW_RELIC_UI EntityManagementIncidentTimelineSource
+}{
+	// The source representing manual entry.
+	MANUAL: "MANUAL",
+	// The source representing New Relic Agent.
+	NEW_RELIC_AGENT: "NEW_RELIC_AGENT",
+	// The source representing Slack.
+	NEW_RELIC_SLACK: "NEW_RELIC_SLACK",
+	// The source representing New Relic.
+	NEW_RELIC_UI: "NEW_RELIC_UI",
+}
+
+// EntityManagementInstallationSource - Source of github integration installation
+type EntityManagementInstallationSource string
+
+var EntityManagementInstallationSourceTypes = struct {
+	// GitHub Cloud installation
+	GITHUB_CLOUD EntityManagementInstallationSource
+	// GitHub Enterprise installation
+	GITHUB_ENTERPRISE EntityManagementInstallationSource
+}{
+	// GitHub Cloud installation
+	GITHUB_CLOUD: "GITHUB_CLOUD",
+	// GitHub Enterprise installation
+	GITHUB_ENTERPRISE: "GITHUB_ENTERPRISE",
+}
+
+// EntityManagementInstallationStatus - List of possible installation statuses.
+type EntityManagementInstallationStatus string
+
+var EntityManagementInstallationStatusTypes = struct {
+	// App currently active and running
+	INSTALLED EntityManagementInstallationStatus
+	// Uninstallation process has begun.
+	UNINSTALLATION_IN_PROGRESS EntityManagementInstallationStatus
+	// App has been uninstalled.
+	UNINSTALLED EntityManagementInstallationStatus
+}{
+	// App currently active and running
+	INSTALLED: "INSTALLED",
+	// Uninstallation process has begun.
+	UNINSTALLATION_IN_PROGRESS: "UNINSTALLATION_IN_PROGRESS",
+	// App has been uninstalled.
+	UNINSTALLED: "UNINSTALLED",
+}
+
+// EntityManagementIssueType - Top level type for Inbox
+type EntityManagementIssueType string
+
+var EntityManagementIssueTypeTypes = struct {
+	// Error issue
+	ERROR EntityManagementIssueType
+	// Performance issue
+	PERFORMANCE EntityManagementIssueType
+}{
+	// Error issue
+	ERROR: "ERROR",
+	// Performance issue
+	PERFORMANCE: "PERFORMANCE",
+}
+
+// EntityManagementJiraIssueType - Jira issue type to be used in Jira Sync Configuration
+type EntityManagementJiraIssueType string
+
+var EntityManagementJiraIssueTypeTypes = struct {
+	// Bug issue type in Jira
+	BUG EntityManagementJiraIssueType
+	// Story issue type in Jira
+	STORY EntityManagementJiraIssueType
+	// Task issue type in Jira
+	TASK EntityManagementJiraIssueType
+}{
+	// Bug issue type in Jira
+	BUG: "BUG",
+	// Story issue type in Jira
+	STORY: "STORY",
+	// Task issue type in Jira
+	TASK: "TASK",
+}
+
+// EntityManagementKeyType - Base credentials type for New Relic
+type EntityManagementKeyType string
+
+var EntityManagementKeyTypeTypes = struct {
+	// Ingest API key
+	INGEST EntityManagementKeyType
+	// User API key
+	USER EntityManagementKeyType
+}{
+	// Ingest API key
+	INGEST: "INGEST",
+	// User API key
+	USER: "USER",
+}
+
+// EntityManagementLicenseName - List of possible repository license name.
+type EntityManagementLicenseName string
+
+var EntityManagementLicenseNameTypes = struct {
+	// Academic Free License 3.0
+	AFL_3_0 EntityManagementLicenseName
+	// GNU Affero General Public License v3.0
+	AGPL_3_0 EntityManagementLicenseName
+	// Apache License 2.0
+	APACHE_2_0 EntityManagementLicenseName
+	// BSD 2-Clause License
+	BSD_2_CLAUSE EntityManagementLicenseName
+	// BSD 3-Clause License
+	BSD_3_CLAUSE EntityManagementLicenseName
+	// Boost Software License 1.0
+	BSL_1_0 EntityManagementLicenseName
+	// Creative Commons Zero v1.0 Universal
+	CC0_1_0 EntityManagementLicenseName
+	// Common Development and Distribution License
+	CDDL EntityManagementLicenseName
+	// Eclipse Public License 2.0
+	EPL_2_0 EntityManagementLicenseName
+	// GNU General Public License v2.0
+	GPL_2_0 EntityManagementLicenseName
+	// GNU General Public License v3.0
+	GPL_3_0 EntityManagementLicenseName
+	// GNU General Public License v3.0 only
+	GPL_3_0_ONLY EntityManagementLicenseName
+	// GNU General Public License v3.0 or later
+	GPL_3_0_PLUS EntityManagementLicenseName
+	// GNU Lesser General Public License v2.1
+	LGPL_2_1 EntityManagementLicenseName
+	// GNU Lesser General Public License v3.0
+	LGPL_3_0 EntityManagementLicenseName
+	// GNU Lesser General Public License v3.0 only
+	LGPL_3_0_ONLY EntityManagementLicenseName
+	// GNU Lesser General Public License v3.0 or later
+	LGPL_3_0_PLUS EntityManagementLicenseName
+	// MIT License
+	MIT EntityManagementLicenseName
+	// Mozilla Public License 1.1
+	MPL_1_1 EntityManagementLicenseName
+	// Mozilla Public License 2.0
+	MPL_2_0 EntityManagementLicenseName
+	// Default value when the license cannot be found
+	NA EntityManagementLicenseName
+	// The Unlicense
+	UNLICENSE EntityManagementLicenseName
+}{
+	// Academic Free License 3.0
+	AFL_3_0: "AFL_3_0",
+	// GNU Affero General Public License v3.0
+	AGPL_3_0: "AGPL_3_0",
+	// Apache License 2.0
+	APACHE_2_0: "APACHE_2_0",
+	// BSD 2-Clause License
+	BSD_2_CLAUSE: "BSD_2_CLAUSE",
+	// BSD 3-Clause License
+	BSD_3_CLAUSE: "BSD_3_CLAUSE",
+	// Boost Software License 1.0
+	BSL_1_0: "BSL_1_0",
+	// Creative Commons Zero v1.0 Universal
+	CC0_1_0: "CC0_1_0",
+	// Common Development and Distribution License
+	CDDL: "CDDL",
+	// Eclipse Public License 2.0
+	EPL_2_0: "EPL_2_0",
+	// GNU General Public License v2.0
+	GPL_2_0: "GPL_2_0",
+	// GNU General Public License v3.0
+	GPL_3_0: "GPL_3_0",
+	// GNU General Public License v3.0 only
+	GPL_3_0_ONLY: "GPL_3_0_ONLY",
+	// GNU General Public License v3.0 or later
+	GPL_3_0_PLUS: "GPL_3_0_PLUS",
+	// GNU Lesser General Public License v2.1
+	LGPL_2_1: "LGPL_2_1",
+	// GNU Lesser General Public License v3.0
+	LGPL_3_0: "LGPL_3_0",
+	// GNU Lesser General Public License v3.0 only
+	LGPL_3_0_ONLY: "LGPL_3_0_ONLY",
+	// GNU Lesser General Public License v3.0 or later
+	LGPL_3_0_PLUS: "LGPL_3_0_PLUS",
+	// MIT License
+	MIT: "MIT",
+	// Mozilla Public License 1.1
+	MPL_1_1: "MPL_1_1",
+	// Mozilla Public License 2.0
+	MPL_2_0: "MPL_2_0",
+	// Default value when the license cannot be found
+	NA: "NA",
+	// The Unlicense
+	UNLICENSE: "UNLICENSE",
+}
+
+// EntityManagementLifecycleStatePartition - Possible lifecycle states for a federated log partition.
+type EntityManagementLifecycleStatePartition string
+
+var EntityManagementLifecycleStatePartitionTypes = struct {
+	// Indicates the partition has been successfully onboarded.
+	COMPLETE EntityManagementLifecycleStatePartition
+	// Indicates the initial data processing component configuration has been created during onboarding.
+	DATA_PROCESSING_CONFIG_CREATED EntityManagementLifecycleStatePartition
+	// Indicates a delete has been requested and an updated data processing component configuration (excluding this partition) is pending deployment.
+	DELETING EntityManagementLifecycleStatePartition
+	// Indicates there was an error during onboarding.
+	ERROR EntityManagementLifecycleStatePartition
+	// Indicates the entity resource creation is complete.
+	RESOURCE_CREATION_COMPLETE EntityManagementLifecycleStatePartition
+}{
+	// Indicates the partition has been successfully onboarded.
+	COMPLETE: "COMPLETE",
+	// Indicates the initial data processing component configuration has been created during onboarding.
+	DATA_PROCESSING_CONFIG_CREATED: "DATA_PROCESSING_CONFIG_CREATED",
+	// Indicates a delete has been requested and an updated data processing component configuration (excluding this partition) is pending deployment.
+	DELETING: "DELETING",
+	// Indicates there was an error during onboarding.
+	ERROR: "ERROR",
+	// Indicates the entity resource creation is complete.
+	RESOURCE_CREATION_COMPLETE: "RESOURCE_CREATION_COMPLETE",
+}
+
+// EntityManagementLifecycleStateSetup - Possible lifecycle states for a federated log setup.
+type EntityManagementLifecycleStateSetup string
+
+var EntityManagementLifecycleStateSetupTypes = struct {
+	// Indicates the setup has been successfully onboarded.
+	COMPLETE EntityManagementLifecycleStateSetup
+	// Indicates the initial data processing component configuration has been created during onboarding.
+	DATA_PROCESSING_CONFIG_CREATED EntityManagementLifecycleStateSetup
+	// Indicates a delete has been requested and an updated data processing component configuration (excluding this setup) is pending deployment.
+	DELETING EntityManagementLifecycleStateSetup
+	// Indicates there was an error during onboarding.
+	ERROR EntityManagementLifecycleStateSetup
+	// Indicates the entity resource creation is complete.
+	RESOURCE_CREATION_COMPLETE EntityManagementLifecycleStateSetup
+}{
+	// Indicates the setup has been successfully onboarded.
+	COMPLETE: "COMPLETE",
+	// Indicates the initial data processing component configuration has been created during onboarding.
+	DATA_PROCESSING_CONFIG_CREATED: "DATA_PROCESSING_CONFIG_CREATED",
+	// Indicates a delete has been requested and an updated data processing component configuration (excluding this setup) is pending deployment.
+	DELETING: "DELETING",
+	// Indicates there was an error during onboarding.
+	ERROR: "ERROR",
+	// Indicates the entity resource creation is complete.
+	RESOURCE_CREATION_COMPLETE: "RESOURCE_CREATION_COMPLETE",
+}
+
+// EntityManagementManagedEntityType - Entity types that a Fleet can manage
+type EntityManagementManagedEntityType string
+
+var EntityManagementManagedEntityTypeTypes = struct {
+	// Instrumented APM Application
+	APPLICATION EntityManagementManagedEntityType
+	// Infra Host
+	HOST EntityManagementManagedEntityType
+	// Kubernetes Cluster
+	KUBERNETESCLUSTER EntityManagementManagedEntityType
+}{
+	// Instrumented APM Application
+	APPLICATION: "APPLICATION",
+	// Infra Host
+	HOST: "HOST",
+	// Kubernetes Cluster
+	KUBERNETESCLUSTER: "KUBERNETESCLUSTER",
+}
+
+// EntityManagementManagedEvaluationType - Available types of managed evaluations
+type EntityManagementManagedEvaluationType string
+
+var EntityManagementManagedEvaluationTypeTypes = struct {
+	// Measures if the model's answer is relevant to the user's input question
+	ANSWER_RELEVANCY EntityManagementManagedEvaluationType
+	// Detects biased content
+	BIAS EntityManagementManagedEvaluationType
+	// Measure of how well the information retrieved by the system is relevant to the user's query and will lead to an accurate, useful answer
+	CONTEXTUAL_RELEVANCY EntityManagementManagedEvaluationType
+	// Measures how factually consistent a model's generated answer is with the provided context
+	FAITHFULNESS EntityManagementManagedEvaluationType
+	// Detects jailbreak attempts
+	JAILBREAK EntityManagementManagedEvaluationType
+	// Detects personally identifiable information leakage
+	PII_LEAKAGE EntityManagementManagedEvaluationType
+	// Detects prompt injection attacks
+	PROMPT_INJECTION EntityManagementManagedEvaluationType
+	// Validates topic control and consistency
+	TOPIC_CONTROL EntityManagementManagedEvaluationType
+	// Detects toxic content
+	TOXICITY EntityManagementManagedEvaluationType
+}{
+	// Measures if the model's answer is relevant to the user's input question
+	ANSWER_RELEVANCY: "ANSWER_RELEVANCY",
+	// Detects biased content
+	BIAS: "BIAS",
+	// Measure of how well the information retrieved by the system is relevant to the user's query and will lead to an accurate, useful answer
+	CONTEXTUAL_RELEVANCY: "CONTEXTUAL_RELEVANCY",
+	// Measures how factually consistent a model's generated answer is with the provided context
+	FAITHFULNESS: "FAITHFULNESS",
+	// Detects jailbreak attempts
+	JAILBREAK: "JAILBREAK",
+	// Detects personally identifiable information leakage
+	PII_LEAKAGE: "PII_LEAKAGE",
+	// Detects prompt injection attacks
+	PROMPT_INJECTION: "PROMPT_INJECTION",
+	// Validates topic control and consistency
+	TOPIC_CONTROL: "TOPIC_CONTROL",
+	// Detects toxic content
+	TOXICITY: "TOXICITY",
+}
+
+// EntityManagementMcpAuthType - Authentication types supported for MCP server connections
+type EntityManagementMcpAuthType string
+
+var EntityManagementMcpAuthTypeTypes = struct {
+	// Bearer token authentication using Authorization header
+	BEARER_TOKEN EntityManagementMcpAuthType
+	// Authentication delegated to a Connections Manager entity (e.g., GithubConnection)
+	CONNECTION_REFERENCE EntityManagementMcpAuthType
+	// Custom header-based authentication with arbitrary key-value pair
+	GENERIC_HEADER EntityManagementMcpAuthType
+	// No authentication required
+	NONE EntityManagementMcpAuthType
+	// OAuth 2.0 authentication
+	OAUTH EntityManagementMcpAuthType
+}{
+	// Bearer token authentication using Authorization header
+	BEARER_TOKEN: "BEARER_TOKEN",
+	// Authentication delegated to a Connections Manager entity (e.g., GithubConnection)
+	CONNECTION_REFERENCE: "CONNECTION_REFERENCE",
+	// Custom header-based authentication with arbitrary key-value pair
+	GENERIC_HEADER: "GENERIC_HEADER",
+	// No authentication required
+	NONE: "NONE",
+	// OAuth 2.0 authentication
+	OAUTH: "OAUTH",
+}
+
+// EntityManagementMcpTransport - Supported transport mechanisms for MCP servers
+type EntityManagementMcpTransport string
+
+var EntityManagementMcpTransportTypes = struct {
+	// HTTP transport for request-response communication
+	HTTP EntityManagementMcpTransport
+	// Server-Sent Events transport for streaming communication
+	SSE EntityManagementMcpTransport
+}{
+	// HTTP transport for request-response communication
+	HTTP: "HTTP",
+	// Server-Sent Events transport for streaming communication
+	SSE: "SSE",
+}
+
+// EntityManagementMessageType - Message type enum
+type EntityManagementMessageType string
+
+var EntityManagementMessageTypeTypes = struct {
+	// JSON message type
+	JSON EntityManagementMessageType
+	// Text message type
+	TEXT EntityManagementMessageType
+	// YAML message type
+	YAML EntityManagementMessageType
+}{
+	// JSON message type
+	JSON: "JSON",
+	// Text message type
+	TEXT: "TEXT",
+	// YAML message type
+	YAML: "YAML",
+}
+
+// EntityManagementNumericOperator - Enum defining the supported numeric operators.
+type EntityManagementNumericOperator string
+
+var EntityManagementNumericOperatorTypes = struct {
+	// Numeric values are exactly equal.
+	EQ EntityManagementNumericOperator
+	// Numeric values are greater than or equal.
+	GE EntityManagementNumericOperator
+	// Numeric values are greater than.
+	GT EntityManagementNumericOperator
+	// Numeric values are less than or equal.
+	LE EntityManagementNumericOperator
+	// Numeric values are less than.
+	LT EntityManagementNumericOperator
+}{
+	// Numeric values are exactly equal.
+	EQ: "EQ",
+	// Numeric values are greater than or equal.
+	GE: "GE",
+	// Numeric values are greater than.
+	GT: "GT",
+	// Numeric values are less than or equal.
+	LE: "LE",
+	// Numeric values are less than.
+	LT: "LT",
+}
+
+// EntityManagementOperatingSystemType - The operating system to which a host type can belong
+type EntityManagementOperatingSystemType string
+
+var EntityManagementOperatingSystemTypeTypes = struct {
+	// Linux based host
+	LINUX EntityManagementOperatingSystemType
+	// Windows based host
+	WINDOWS EntityManagementOperatingSystemType
+}{
+	// Linux based host
+	LINUX: "LINUX",
+	// Windows based host
+	WINDOWS: "WINDOWS",
+}
+
+// EntityManagementOverlapPolicy - Possible types for the Overlap Policy of a Workflow Schedule
+type EntityManagementOverlapPolicy string
+
+var EntityManagementOverlapPolicyTypes = struct {
+	// Cancel the currently running workflow and start a new one
+	CANCEL EntityManagementOverlapPolicy
+	// Skip the current scheduled run if the previous one is still running
+	SKIP EntityManagementOverlapPolicy
+}{
+	// Cancel the currently running workflow and start a new one
+	CANCEL: "CANCEL",
+	// Skip the current scheduled run if the previous one is still running
+	SKIP: "SKIP",
+}
+
+// EntityManagementPrincipalType - Represents type of identity.
+type EntityManagementPrincipalType string
+
+var EntityManagementPrincipalTypeTypes = struct {
+	// Principal type SYSTEM_IDENTITY
+	SYSTEM_IDENTITY EntityManagementPrincipalType
+	// Principal type USER
+	USER EntityManagementPrincipalType
+}{
+	// Principal type SYSTEM_IDENTITY
+	SYSTEM_IDENTITY: "SYSTEM_IDENTITY",
+	// Principal type USER
+	USER: "USER",
+}
+
+// EntityManagementProcessStatus - At rest background processing types
+type EntityManagementProcessStatus string
+
+var EntityManagementProcessStatusTypes = struct {
+	// Process completed
+	COMPLETED EntityManagementProcessStatus
+	// Failed to process a rule
+	FAILED EntityManagementProcessStatus
+	// The rule is being processed
+	RUNNING EntityManagementProcessStatus
+	// A rule that was scheduled
+	SCHEDULED EntityManagementProcessStatus
+}{
+	// Process completed
+	COMPLETED: "COMPLETED",
+	// Failed to process a rule
+	FAILED: "FAILED",
+	// The rule is being processed
+	RUNNING: "RUNNING",
+	// A rule that was scheduled
+	SCHEDULED: "SCHEDULED",
+}
+
+// EntityManagementProvider - Enum for creator of the entity
+type EntityManagementProvider string
+
+var EntityManagementProviderTypes = struct {
+	// created by external user
+	EXTERNAL EntityManagementProvider
+	// created by NR
+	INTERNAL EntityManagementProvider
+}{
+	// created by external user
+	EXTERNAL: "EXTERNAL",
+	// created by NR
+	INTERNAL: "INTERNAL",
+}
+
+// EntityManagementRegion - Region represents the geographical region where the incident is impacting.
+type EntityManagementRegion string
+
+var EntityManagementRegionTypes = struct {
+	// EU Region
+	EU EntityManagementRegion
+	// Japan region
+	JP EntityManagementRegion
+	// Staging Region
+	STAGING EntityManagementRegion
+	// US Region
+	US EntityManagementRegion
+}{
+	// EU Region
+	EU: "EU",
+	// Japan region
+	JP: "JP",
+	// Staging Region
+	STAGING: "STAGING",
+	// US Region
+	US: "US",
+}
+
+// EntityManagementRetentionUnit - Time units for retention policies.
+type EntityManagementRetentionUnit string
+
+var EntityManagementRetentionUnitTypes = struct {
+	// Days
+	DAYS EntityManagementRetentionUnit
+	// Months
+	MONTHS EntityManagementRetentionUnit
+	// Weeks
+	WEEKS EntityManagementRetentionUnit
+}{
+	// Days
+	DAYS: "DAYS",
+	// Months
+	MONTHS: "MONTHS",
+	// Weeks
+	WEEKS: "WEEKS",
+}
+
+// EntityManagementSigningAlgorithm - Enum for JWT signing algorithm
+type EntityManagementSigningAlgorithm string
+
+var EntityManagementSigningAlgorithmTypes = struct {
+	// RSA256 signing algorithm
+	RSA256 EntityManagementSigningAlgorithm
+}{
+	// RSA256 signing algorithm
+	RSA256: "RSA256",
+}
+
+// EntityManagementStatusCode - Rule execution status codes
+type EntityManagementStatusCode string
+
+var EntityManagementStatusCodeTypes = struct {
+	// Indicates the rule execution was unable to proceed due to missing data from the source.
+	MISSING_DATA_SOURCE EntityManagementStatusCode
+	// System error
+	SYSTEM_ERROR EntityManagementStatusCode
+}{
+	// Indicates the rule execution was unable to proceed due to missing data from the source.
+	MISSING_DATA_SOURCE: "MISSING_DATA_SOURCE",
+	// System error
+	SYSTEM_ERROR: "SYSTEM_ERROR",
+}
+
+// EntityManagementStatusPageAnnouncementCategory - Type of announcement based on the category.
+type EntityManagementStatusPageAnnouncementCategory string
+
+var EntityManagementStatusPageAnnouncementCategoryTypes = struct {
+	// EOL Announcement category
+	END_OF_LIFE EntityManagementStatusPageAnnouncementCategory
+}{
+	// EOL Announcement category
+	END_OF_LIFE: "END_OF_LIFE",
+}
+
+// EntityManagementStatusPageAnnouncementState - The state of an announcement
+type EntityManagementStatusPageAnnouncementState string
+
+var EntityManagementStatusPageAnnouncementStateTypes = struct {
+	// Canceled state of the announcement.
+	CANCELED EntityManagementStatusPageAnnouncementState
+	// Draft state of the announcement.
+	DRAFT EntityManagementStatusPageAnnouncementState
+	// Published state of the announcement.
+	PUBLISHED EntityManagementStatusPageAnnouncementState
+	// Scheduled state of the announcement.
+	SCHEDULED EntityManagementStatusPageAnnouncementState
+}{
+	// Canceled state of the announcement.
+	CANCELED: "CANCELED",
+	// Draft state of the announcement.
+	DRAFT: "DRAFT",
+	// Published state of the announcement.
+	PUBLISHED: "PUBLISHED",
+	// Scheduled state of the announcement.
+	SCHEDULED: "SCHEDULED",
+}
+
+// EntityManagementStringOperator - Enum defining the supported string operators.
+type EntityManagementStringOperator string
+
+var EntityManagementStringOperatorTypes = struct {
+	// String contains the specified value.
+	CONTAINS EntityManagementStringOperator
+	// String are exactly equal.
+	EXACTLY EntityManagementStringOperator
+	// String start with the specified value.
+	PREFIX EntityManagementStringOperator
+}{
+	// String contains the specified value.
+	CONTAINS: "CONTAINS",
+	// String are exactly equal.
+	EXACTLY: "EXACTLY",
+	// String start with the specified value.
+	PREFIX: "PREFIX",
+}
+
+// EntityManagementSyncConfigurationMode - Enum for the sync configuration mode
+type EntityManagementSyncConfigurationMode string
+
+var EntityManagementSyncConfigurationModeTypes = struct {
+	// Sync all fields
+	ALL EntityManagementSyncConfigurationMode
+	// Sync only the messages
+	MESSAGES EntityManagementSyncConfigurationMode
+	// Sync only the WorkItem entity
+	WORKITEM EntityManagementSyncConfigurationMode
+}{
+	// Sync all fields
+	ALL: "ALL",
+	// Sync only the messages
+	MESSAGES: "MESSAGES",
+	// Sync only the WorkItem entity
+	WORKITEM: "WORKITEM",
+}
+
+// EntityManagementSyncDirection - Represents a connection direction for the Sync Configuration
+type EntityManagementSyncDirection string
+
+var EntityManagementSyncDirectionTypes = struct {
+	// Sync from the 3rd party system to New Relic only
+	INBOUND EntityManagementSyncDirection
+	// Sync from New Relic to the 3rd party system only
+	OUTBOUND EntityManagementSyncDirection
+}{
+	// Sync from the 3rd party system to New Relic only
+	INBOUND: "INBOUND",
+	// Sync from New Relic to the 3rd party system only
+	OUTBOUND: "OUTBOUND",
+}
+
+// EntityManagementSyncGroupRuleConditionType - The types of conditions for group sync rules.
+type EntityManagementSyncGroupRuleConditionType string
+
+var EntityManagementSyncGroupRuleConditionTypeTypes = struct {
+	// Group name contains.
+	CONTAINS EntityManagementSyncGroupRuleConditionType
+	// Group name ends with.
+	ENDS_WITH EntityManagementSyncGroupRuleConditionType
+	// Group name starts with.
+	STARTS_WITH EntityManagementSyncGroupRuleConditionType
+}{
+	// Group name contains.
+	CONTAINS: "CONTAINS",
+	// Group name ends with.
+	ENDS_WITH: "ENDS_WITH",
+	// Group name starts with.
+	STARTS_WITH: "STARTS_WITH",
+}
+
+// EntityManagementTeamExternalIntegrationType - Possible types for the External Integration.
+type EntityManagementTeamExternalIntegrationType string
+
+var EntityManagementTeamExternalIntegrationTypeTypes = struct {
+	// GitHub Team Integration.
+	GITHUB_TEAM EntityManagementTeamExternalIntegrationType
+	// IAM Group Integration.
+	IAM_GROUP EntityManagementTeamExternalIntegrationType
+	// ServiceNow Team Integration.
+	SERVICENOW_TEAM EntityManagementTeamExternalIntegrationType
+}{
+	// GitHub Team Integration.
+	GITHUB_TEAM: "GITHUB_TEAM",
+	// IAM Group Integration.
+	IAM_GROUP: "IAM_GROUP",
+	// ServiceNow Team Integration.
+	SERVICENOW_TEAM: "SERVICENOW_TEAM",
+}
+
+// EntityManagementTextSplitterType - The text splitter enum
+type EntityManagementTextSplitterType string
+
+var EntityManagementTextSplitterTypeTypes = struct {
+	// For character splitter
+	CHARACTER_TEXT_SPLITTER EntityManagementTextSplitterType
+	// For markdown content splitting
+	MARKDOWN_TEXT_SPLITTER EntityManagementTextSplitterType
+	// For token text splitting
+	TOKEN_TEXT_SPLITTER EntityManagementTextSplitterType
+}{
+	// For character splitter
+	CHARACTER_TEXT_SPLITTER: "CHARACTER_TEXT_SPLITTER",
+	// For markdown content splitting
+	MARKDOWN_TEXT_SPLITTER: "MARKDOWN_TEXT_SPLITTER",
+	// For token text splitting
+	TOKEN_TEXT_SPLITTER: "TOKEN_TEXT_SPLITTER",
+}
+
+// EntityManagementThresholdScope - Scope for threshold configuration
+type EntityManagementThresholdScope string
+
+var EntityManagementThresholdScopeTypes = struct {
+	// Account scope
+	ACCOUNT EntityManagementThresholdScope
+	// Entity scope
+	ENTITY EntityManagementThresholdScope
+	// Organization scope
+	ORGANIZATION EntityManagementThresholdScope
+}{
+	// Account scope
+	ACCOUNT: "ACCOUNT",
+	// Entity scope
+	ENTITY: "ENTITY",
+	// Organization scope
+	ORGANIZATION: "ORGANIZATION",
+}
+
+// EntityManagementWorkItemCategory - Enum for Category in Work Item V2
+type EntityManagementWorkItemCategory string
+
+var EntityManagementWorkItemCategoryTypes = struct {
+	// Incident category of the work item
+	INCIDENT EntityManagementWorkItemCategory
+	// Issue category of the work item
+	ISSUE EntityManagementWorkItemCategory
+	// Performance category of the work item
+	PERFORMANCE EntityManagementWorkItemCategory
+	// Vulnerability category of the work item
+	VULNERABILITY EntityManagementWorkItemCategory
+}{
+	// Incident category of the work item
+	INCIDENT: "INCIDENT",
+	// Issue category of the work item
+	ISSUE: "ISSUE",
+	// Performance category of the work item
+	PERFORMANCE: "PERFORMANCE",
+	// Vulnerability category of the work item
+	VULNERABILITY: "VULNERABILITY",
+}
+
+// EntityManagementWorkItemPriority - Enum for priority in Work Item V2
+type EntityManagementWorkItemPriority string
+
+var EntityManagementWorkItemPriorityTypes = struct {
+	// High priority of the work item
+	HIGH EntityManagementWorkItemPriority
+	// Highest priority of the work item
+	HIGHEST EntityManagementWorkItemPriority
+	// Low priority of the work item
+	LOW EntityManagementWorkItemPriority
+	// Lowest priority of the work item
+	LOWEST EntityManagementWorkItemPriority
+	// Medium priority of the work item
+	MEDIUM EntityManagementWorkItemPriority
+}{
+	// High priority of the work item
+	HIGH: "HIGH",
+	// Highest priority of the work item
+	HIGHEST: "HIGHEST",
+	// Low priority of the work item
+	LOW: "LOW",
+	// Lowest priority of the work item
+	LOWEST: "LOWEST",
+	// Medium priority of the work item
+	MEDIUM: "MEDIUM",
+}
+
+// EntitySearchCountsFacet - Possible entity search count facets.
+type EntitySearchCountsFacet string
+
+var EntitySearchCountsFacetTypes = struct {
+	// Facet by account id.
+	ACCOUNT_ID EntitySearchCountsFacet
+	// Facet by alert severity.
+	ALERT_SEVERITY EntitySearchCountsFacet
+	// Facet by entity domain.
+	DOMAIN EntitySearchCountsFacet
+	// Facet by entity domain and entity type.
+	DOMAIN_TYPE EntitySearchCountsFacet
+	// Facet by entity name
+	NAME EntitySearchCountsFacet
+	// Facet by reporting state.
+	REPORTING EntitySearchCountsFacet
+	// Facet by entity type.
+	TYPE EntitySearchCountsFacet
+}{
+	// Facet by account id.
+	ACCOUNT_ID: "ACCOUNT_ID",
+	// Facet by alert severity.
+	ALERT_SEVERITY: "ALERT_SEVERITY",
+	// Facet by entity domain.
+	DOMAIN: "DOMAIN",
+	// Facet by entity domain and entity type.
+	DOMAIN_TYPE: "DOMAIN_TYPE",
+	// Facet by entity name
+	NAME: "NAME",
+	// Facet by reporting state.
+	REPORTING: "REPORTING",
+	// Facet by entity type.
+	TYPE: "TYPE",
+}
+
+// EntityType - The specific type of entity
+type EntityType string
+
+var EntityTypeTypes = struct {
+	// An APM Application
+	APM_APPLICATION_ENTITY EntityType
+	// A database instance seen by an APM Application
+	APM_DATABASE_INSTANCE_ENTITY EntityType
+	// An external service seen by an APM Application
+	APM_EXTERNAL_SERVICE_ENTITY EntityType
+	// A Browser Application
+	BROWSER_APPLICATION_ENTITY EntityType
+	// A Dashboard entity
+	DASHBOARD_ENTITY EntityType
+	// An External entity. For more information about defining External entities, see the [open source documentation](https://github.com/newrelic-experimental/entity-synthesis-definitions).
+	EXTERNAL_ENTITY EntityType
+	// A Generic entity with no detailed data
+	GENERIC_ENTITY EntityType
+	// An Infrastructure entity
+	GENERIC_INFRASTRUCTURE_ENTITY EntityType
+	// An Infrastructure Integration AWS Lambda Function entity
+	INFRASTRUCTURE_AWS_LAMBDA_FUNCTION_ENTITY EntityType
+	// An Infrastructure Host entity
+	INFRASTRUCTURE_HOST_ENTITY EntityType
+	// A Key Transaction entity
+	KEY_TRANSACTION_ENTITY EntityType
+	// A Mobile Application
+	MOBILE_APPLICATION_ENTITY EntityType
+	// A Secure Credential entity
+	SECURE_CREDENTIAL_ENTITY EntityType
+	// A Synthetic Monitor entity
+	SYNTHETIC_MONITOR_ENTITY EntityType
+	// A Team Entity
+	TEAM_ENTITY EntityType
+	// A Third Party Service entity
+	THIRD_PARTY_SERVICE_ENTITY EntityType
+	// A entity that is unavailable
+	UNAVAILABLE_ENTITY EntityType
+	// A Workload entity
+	WORKLOAD_ENTITY EntityType
+}{
+	// An APM Application
+	APM_APPLICATION_ENTITY: "APM_APPLICATION_ENTITY",
+	// A database instance seen by an APM Application
+	APM_DATABASE_INSTANCE_ENTITY: "APM_DATABASE_INSTANCE_ENTITY",
+	// An external service seen by an APM Application
+	APM_EXTERNAL_SERVICE_ENTITY: "APM_EXTERNAL_SERVICE_ENTITY",
+	// A Browser Application
+	BROWSER_APPLICATION_ENTITY: "BROWSER_APPLICATION_ENTITY",
+	// A Dashboard entity
+	DASHBOARD_ENTITY: "DASHBOARD_ENTITY",
+	// An External entity. For more information about defining External entities, see the [open source documentation](https://github.com/newrelic-experimental/entity-synthesis-definitions).
+	EXTERNAL_ENTITY: "EXTERNAL_ENTITY",
+	// A Generic entity with no detailed data
+	GENERIC_ENTITY: "GENERIC_ENTITY",
+	// An Infrastructure entity
+	GENERIC_INFRASTRUCTURE_ENTITY: "GENERIC_INFRASTRUCTURE_ENTITY",
+	// An Infrastructure Integration AWS Lambda Function entity
+	INFRASTRUCTURE_AWS_LAMBDA_FUNCTION_ENTITY: "INFRASTRUCTURE_AWS_LAMBDA_FUNCTION_ENTITY",
+	// An Infrastructure Host entity
+	INFRASTRUCTURE_HOST_ENTITY: "INFRASTRUCTURE_HOST_ENTITY",
+	// A Key Transaction entity
+	KEY_TRANSACTION_ENTITY: "KEY_TRANSACTION_ENTITY",
+	// A Mobile Application
+	MOBILE_APPLICATION_ENTITY: "MOBILE_APPLICATION_ENTITY",
+	// A Secure Credential entity
+	SECURE_CREDENTIAL_ENTITY: "SECURE_CREDENTIAL_ENTITY",
+	// A Synthetic Monitor entity
+	SYNTHETIC_MONITOR_ENTITY: "SYNTHETIC_MONITOR_ENTITY",
+	// A Team Entity
+	TEAM_ENTITY: "TEAM_ENTITY",
+	// A Third Party Service entity
+	THIRD_PARTY_SERVICE_ENTITY: "THIRD_PARTY_SERVICE_ENTITY",
+	// A entity that is unavailable
+	UNAVAILABLE_ENTITY: "UNAVAILABLE_ENTITY",
+	// A Workload entity
+	WORKLOAD_ENTITY: "WORKLOAD_ENTITY",
+}
+
+// ServiceLevelEventsQuerySelectFunction - The function to use in the SELECT clause.
+type ServiceLevelEventsQuerySelectFunction string
+
+var ServiceLevelEventsQuerySelectFunctionTypes = struct {
+	// Use on events and unaggregated data.
+	COUNT ServiceLevelEventsQuerySelectFunction
+	// Use on distribution metric types.
+	GET_CDF_COUNT ServiceLevelEventsQuerySelectFunction
+	// Use in valid events combined with GET_CDF_COUNT.
+	GET_FIELD ServiceLevelEventsQuerySelectFunction
+	// Use on aggregated counts.
+	SUM ServiceLevelEventsQuerySelectFunction
+}{
+	// Use on events and unaggregated data.
+	COUNT: "COUNT",
+	// Use on distribution metric types.
+	GET_CDF_COUNT: "GET_CDF_COUNT",
+	// Use in valid events combined with GET_CDF_COUNT.
+	GET_FIELD: "GET_FIELD",
+	// Use on aggregated counts.
+	SUM: "SUM",
+}
+
+// ServiceLevelObjectiveRollingTimeWindowUnit - The rolling time window units.
+type ServiceLevelObjectiveRollingTimeWindowUnit string
+
+var ServiceLevelObjectiveRollingTimeWindowUnitTypes = struct {
+	// Day.
+	DAY ServiceLevelObjectiveRollingTimeWindowUnit
+}{
+	// Day.
+	DAY: "DAY",
+}
+
+// SyntheticMonitorStatus -
+type SyntheticMonitorStatus string
+
+var SyntheticMonitorStatusTypes = struct {
+	DELETED  SyntheticMonitorStatus
+	DISABLED SyntheticMonitorStatus
+	ENABLED  SyntheticMonitorStatus
+	FAULTY   SyntheticMonitorStatus
+	MUTED    SyntheticMonitorStatus
+	PAUSED   SyntheticMonitorStatus
+}{
+	DELETED:  "DELETED",
+	DISABLED: "DISABLED",
+	ENABLED:  "ENABLED",
+	FAULTY:   "FAULTY",
+	MUTED:    "MUTED",
+	PAUSED:   "PAUSED",
+}
+
+// SyntheticMonitorType - The types of Synthetic Monitors.
+type SyntheticMonitorType string
+
+var SyntheticMonitorTypeTypes = struct {
+	BROKEN_LINKS   SyntheticMonitorType
+	BROWSER        SyntheticMonitorType
+	CERT_CHECK     SyntheticMonitorType
+	SCRIPT_API     SyntheticMonitorType
+	SCRIPT_BROWSER SyntheticMonitorType
+	SIMPLE         SyntheticMonitorType
+	STEP_MONITOR   SyntheticMonitorType
+}{
+	BROKEN_LINKS:   "BROKEN_LINKS",
+	BROWSER:        "BROWSER",
+	CERT_CHECK:     "CERT_CHECK",
+	SCRIPT_API:     "SCRIPT_API",
+	SCRIPT_BROWSER: "SCRIPT_BROWSER",
+	SIMPLE:         "SIMPLE",
+	STEP_MONITOR:   "STEP_MONITOR",
 }
 
 // WorkloadGroupRemainingEntitiesRuleBy - Indicates by which field the remaining entities rule should be grouped.
@@ -167,18 +1983,5602 @@ type Account struct {
 	Workload WorkloadAccountStitchedFields `json:"workload,omitempty"`
 }
 
+// AccountOutline - The `AccountOutline` object provides basic data about an account.
+type AccountOutline struct {
+	//
+	ID int `json:"id,omitempty"`
+	//
+	Name string `json:"name,omitempty"`
+	// Returns event types that are currently reporting in the account.
+	ReportingEventTypes []string `json:"reportingEventTypes,omitempty"`
+}
+
 // Actor - The `Actor` object contains fields that are scoped to the API user's access level.
 type Actor struct {
 	// The `account` field is the entry point into data that is scoped to a single account.
 	Account Account `json:"account,omitempty"`
+	// The `accounts` field returns all accounts that the Actor is authorized to view.
+	Accounts []AccountOutline `json:"accounts,omitempty"`
+	// Search for entities using a custom query.
+	//
+	// For more details on how to create a custom query
+	// and what entity data you can request, visit our
+	// [entity docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities).
+	//
+	// Note: you must supply either a `query` OR a `queryBuilder` argument, not both.
+	EntitySearch EntitySearch `json:"entitySearch,omitempty"`
 }
+
+// AlertableEntityOutline -
+type AlertableEntityOutline struct {
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+}
+
+func (x *AlertableEntityOutline) ImplementsAlertableEntityOutline() {}
+
+// ApmApplicationEntityOutline - An APM Application entity outline.
+type ApmApplicationEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// Summary statistics about the Browser App injected by an APM Application.
+	ApmBrowserSummary ApmBrowserApplicationSummaryData `json:"apmBrowserSummary,omitempty"`
+	// Summary statistics about the APM App.
+	ApmSummary ApmApplicationSummaryData `json:"apmSummary,omitempty"`
+	// The ID of the APM Application.
+	ApplicationID int `json:"applicationId,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The programming language of the APM Application.
+	Language string `json:"language,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The running versions of the language agent in the APM Application.
+	RunningAgentVersions ApmApplicationRunningAgentVersions `json:"runningAgentVersions,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// Configuration settings for the APM Application
+	Settings ApmApplicationSettings `json:"settings,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *ApmApplicationEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *ApmApplicationEntityOutline) ImplementsApmBrowserApplicationEntityOutline() {}
+
+func (x *ApmApplicationEntityOutline) ImplementsEntityOutline() {}
+
+// ApmApplicationRunningAgentVersions - Represents the currently running agent versions in an APM Application.
+// An application could be running multiple versions of an agent (across different hosts, for example).
+type ApmApplicationRunningAgentVersions struct {
+	// The maximum (newest) language agent version running in the APM Application.
+	MaxVersion string `json:"maxVersion,omitempty"`
+	// The minimum (oldest) language agent version running in the APM Application.
+	MinVersion string `json:"minVersion,omitempty"`
+}
+
+// ApmApplicationSettings - Configuration settings for the APM Application
+type ApmApplicationSettings struct {
+	// The current Apdex target setting
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
+	// State of server-side configuration setting
+	ServerSideConfig bool `json:"serverSideConfig,omitempty"`
+}
+
+// ApmApplicationSummaryData - Summary statistics about the APM App.
+type ApmApplicationSummaryData struct {
+	// The apdex score. For more details on the use of apdex, visit [our docs](https://docs.newrelic.com/docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction).
+	ApdexScore float64 `json:"apdexScore,omitempty"`
+	// The percentage of responses to all transactions with an error.
+	ErrorRate float64 `json:"errorRate,omitempty"`
+	// The number of hosts this application is running on.
+	HostCount int `json:"hostCount,omitempty"`
+	// The number of instances of this application running.
+	InstanceCount int `json:"instanceCount,omitempty"`
+	// The average response time for non-web transactions in seconds.
+	NonWebResponseTimeAverage Seconds `json:"nonWebResponseTimeAverage,omitempty"`
+	// The number of non-web transactions per minute.
+	NonWebThroughput float64 `json:"nonWebThroughput,omitempty"`
+	// The average response time for all transactions in seconds.
+	ResponseTimeAverage Seconds `json:"responseTimeAverage,omitempty"`
+	// The number of all transactions per minute.
+	Throughput float64 `json:"throughput,omitempty"`
+	// The average response time for web transactions in seconds.
+	WebResponseTimeAverage Seconds `json:"webResponseTimeAverage,omitempty"`
+	// The number of web transactions per minute.
+	WebThroughput float64 `json:"webThroughput,omitempty"`
+}
+
+// ApmBrowserApplicationEntityOutline - The `ApmBrowserApplicationEntityOutline` interface provides detailed information for the Browser App injected by an APM Application.
+type ApmBrowserApplicationEntityOutline struct {
+	//
+	ApmBrowserSummary ApmBrowserApplicationSummaryData `json:"apmBrowserSummary,omitempty"`
+}
+
+func (x *ApmBrowserApplicationEntityOutline) ImplementsApmBrowserApplicationEntityOutline() {}
+
+// ApmBrowserApplicationSummaryData - Summary statistics about the Browser App injected by the APM Application.
+type ApmBrowserApplicationSummaryData struct {
+	// The number of AJAX requests per minute
+	AjaxRequestThroughput float64 `json:"ajaxRequestThroughput,omitempty"`
+	// The average AJAX response time in seconds.
+	AjaxResponseTimeAverage Seconds `json:"ajaxResponseTimeAverage,omitempty"`
+	// The percentage of page views with a JS error.
+	JsErrorRate float64 `json:"jsErrorRate,omitempty"`
+	// The number of page loads per minute
+	PageLoadThroughput float64 `json:"pageLoadThroughput,omitempty"`
+	// The average page view time in seconds.
+	PageLoadTimeAverage float64 `json:"pageLoadTimeAverage,omitempty"`
+}
+
+// ApmDatabaseInstanceEntityOutline - A database instance seen by an APM Application
+type ApmDatabaseInstanceEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The host the database instance is running on.
+	Host string `json:"host,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The port or path the database instance is running on. ex: `3306` | `/tmp/mysql.sock`
+	PortOrPath string `json:"portOrPath,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+	// The type of database. ex: `Postgres` | `Redis`
+	Vendor string `json:"vendor,omitempty"`
+}
+
+func (x *ApmDatabaseInstanceEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *ApmDatabaseInstanceEntityOutline) ImplementsEntityOutline() {}
+
+// ApmExternalServiceEntityOutline - An external service seen by an APM Application.
+type ApmExternalServiceEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	//
+	ExternalSummary ApmExternalServiceSummaryData `json:"externalSummary,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The host of the external service.
+	Host string `json:"host,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *ApmExternalServiceEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *ApmExternalServiceEntityOutline) ImplementsEntityOutline() {}
+
+// ApmExternalServiceSummaryData - Summary statistics about an External Service called by an APM App.
+type ApmExternalServiceSummaryData struct {
+	// The average response time for external service calls in seconds.
+	ResponseTimeAverage Seconds `json:"responseTimeAverage,omitempty"`
+	// The number of external service calls per minute.
+	Throughput float64 `json:"throughput,omitempty"`
+}
+
+// BrowserApplicationEntityOutline - A Browser Application entity outline.
+type BrowserApplicationEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The type of Browser agent installed for this application.
+	AgentInstallType BrowserAgentInstallType `json:"agentInstallType,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The ID of the Browser App.
+	ApplicationID int `json:"applicationId,omitempty"`
+	// Summary statistics about the Browser App.
+	BrowserSummary BrowserApplicationSummaryData `json:"browserSummary,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The running versions of the agent in the Browser App.
+	RunningAgentVersions BrowserApplicationRunningAgentVersions `json:"runningAgentVersions,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The ID of the APM Application that serves this Browser App.
+	ServingApmApplicationID int `json:"servingApmApplicationId,omitempty"`
+	// Configuration settings for the Browser App
+	Settings BrowserApplicationSettings `json:"settings,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *BrowserApplicationEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *BrowserApplicationEntityOutline) ImplementsEntityOutline() {}
+
+// BrowserApplicationRunningAgentVersions - Represents the currently running agent versions in a Browser App.
+// An app could be running multiple versions of an agent (across different browsers, for example).
+type BrowserApplicationRunningAgentVersions struct {
+	// The maximum (newest) agent version running in the Browser App, represented as a semantic version string.
+	MaxSemanticVersion SemVer `json:"maxSemanticVersion,omitempty"`
+	// The maximum (newest) agent version running in the Browser App.
+	MaxVersion int `json:"maxVersion,omitempty"`
+	// The minimum (oldest) agent version running in the Browser App, represented as a semantic version string.
+	MinSemanticVersion SemVer `json:"minSemanticVersion,omitempty"`
+	// The minimum (oldest) agent version running in the Browser App.
+	MinVersion int `json:"minVersion,omitempty"`
+}
+
+// BrowserApplicationSettings - Configuration settings for the Browser App
+type BrowserApplicationSettings struct {
+	// The current Apdex target setting
+	ApdexTarget float64 `json:"apdexTarget,omitempty"`
+}
+
+// BrowserApplicationSummaryData - Summary statistics about the Browser App.
+type BrowserApplicationSummaryData struct {
+	// The number of AJAX requests per minute
+	AjaxRequestThroughput float64 `json:"ajaxRequestThroughput,omitempty"`
+	// The average AJAX response time in seconds.
+	AjaxResponseTimeAverage Seconds `json:"ajaxResponseTimeAverage,omitempty"`
+	// The percentage of page views with a JS error.
+	JsErrorRate float64 `json:"jsErrorRate,omitempty"`
+	// The number of page loads per minute
+	PageLoadThroughput float64 `json:"pageLoadThroughput,omitempty"`
+	// The average page view time in seconds.
+	PageLoadTimeAverage float64 `json:"pageLoadTimeAverage,omitempty"`
+	// The median page view time in seconds.
+	PageLoadTimeMedian float64 `json:"pageLoadTimeMedian,omitempty"`
+	// The average SPA response time in seconds.
+	SpaResponseTimeAverage Seconds `json:"spaResponseTimeAverage,omitempty"`
+	// The median SPA response time in seconds.
+	SpaResponseTimeMedian Seconds `json:"spaResponseTimeMedian,omitempty"`
+}
+
+// DashboardEntityOutline - A Dashboard entity outline.
+type DashboardEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The date and time the dashboard was created
+	CreatedAt DateTime `json:"createdAt,omitempty"`
+	// The parent entity `guid` of the dashboard.
+	DashboardParentGUID common.EntityGUID `json:"dashboardParentGuid,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The owner information of the dashboard.
+	Owner DashboardEntityOwnerInfo `json:"owner,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The permissions of the dashboard.
+	Permissions DashboardEntityPermissions `json:"permissions,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+	// The date and time the dashboard was updated
+	UpdatedAt DateTime `json:"updatedAt,omitempty"`
+}
+
+func (x *DashboardEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *DashboardEntityOutline) ImplementsEntityOutline() {}
+
+// DashboardEntityOwnerInfo - Dashboard owner
+type DashboardEntityOwnerInfo struct {
+	// The email of the dashboard owner. Null for System Identity owners.
+	Email string `json:"email,omitempty"`
+	// Stringified principal ID. Numeric string for USER type; UUID for SYSTEM_IDENTITY type.
+	ID string `json:"id,omitempty"`
+	// The type of principal that owns this dashboard.
+	Type DashboardEntityOwnerType `json:"type,omitempty"`
+	// New Relic user ID. Null for System Identity owners.
+	UserID int `json:"userId,omitempty"`
+}
+
+// EntityCollection - A collection of user defined Entities and Entity Search queries.
+type EntityCollection struct {
+	// The account the collection is part of
+	Account accounts.AccountReference `json:"account,omitempty"`
+	// The user who created the collection
+	CreatedBy users.UserReference `json:"createdBy,omitempty"`
+	// The definition of the collection.
+	Definition EntityCollectionDefinition `json:"definition,omitempty"`
+	// The GUID of the Entity
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The result of searching for the members of the collection.
+	Members EntitySearch `json:"members,omitempty"`
+	// The name of the collection.
+	Name string `json:"name,omitempty"`
+	// The type of Collection
+	Type EntityCollectionType `json:"type,omitempty"`
+}
+
+// EntityCollectionDefinition - The definition of a collection.
+type EntityCollectionDefinition struct {
+	// A list of entity GUIDs. These entities will belong to the collection as long as their accounts are included in the scope accounts of the collection.
+	EntityGUIDs []common.EntityGUID `json:"entityGuids,omitempty"`
+	// The Entity Search query that returns the full collection of entities.
+	EntitySearchQuery string `json:"entitySearchQuery,omitempty"`
+	// The Accounts that will be used to scope the collection.
+	ScopeAccounts EntityCollectionScopeAccounts `json:"scopeAccounts,omitempty"`
+	// A list of entity search queries. The resulting entities will be limited to the scope accounts of the collection.
+	SearchQueries []string `json:"searchQueries,omitempty"`
+}
+
+// EntityCollectionScopeAccounts - The Accounts used to scope a collection.
+type EntityCollectionScopeAccounts struct {
+	// The Account IDs that make up the account scoping.
+	AccountIDs []int `json:"accountIds,omitempty"`
+}
+
+// EntityGoldenContext - An object that represent the context.
+type EntityGoldenContext struct {
+	// Account context.
+	Account int `json:"account,omitempty"`
+	// Collection guid context.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+}
+
+// EntityGoldenContextInput - Input type used to define the context for the golden metrics.
+type EntityGoldenContextInput struct {
+	// Account context.
+	Account int `json:"account,omitempty"`
+	// Collection guid context.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+}
+
+// EntityGoldenContextScopedGoldenMetrics - An object that represents the golden metrics scoped by context
+type EntityGoldenContextScopedGoldenMetrics struct {
+	// Context for the golden metric
+	Context EntityGoldenContext `json:"context"`
+	// Metrics for the domain and type
+	Metrics []EntityGoldenMetric `json:"metrics"`
+}
+
+// EntityGoldenContextScopedGoldenTags - An object that represents the golden tags scoped by context
+type EntityGoldenContextScopedGoldenTags struct {
+	// Context for the golden tags
+	Context EntityGoldenContext `json:"context"`
+	// Tags for the domain and type
+	Tags []EntityGoldenTag `json:"tags"`
+}
+
+// EntityGoldenMetric - An object that represents a golden metric.
+type EntityGoldenMetric struct {
+	// The definition of the golden metric.
+	Definition EntityGoldenMetricDefinition `json:"definition"`
+	// The synthesised metric name. i.e: newrelic.goldenmetrics.apm.application.throughput
+	MetricName string `json:"metricName"`
+	// The name of the golden metric.
+	Name string `json:"name"`
+	// The definitions of the golden metric as they are defined in the public repo https://github.com/newrelic/entity-definitions.
+	OriginalDefinitions []EntityGoldenOriginalDefinitionWithSelector `json:"originalDefinitions"`
+	// Original queries as they are defined in the public repo https://github.com/newrelic/entity-definitions.
+	OriginalQueries []EntityGoldenOriginalQueryWithSelector `json:"originalQueries"`
+	// The golden metric NRQL query.
+	Query string `json:"query"`
+	// The title of the golden metric.
+	Title string `json:"title"`
+	// The unit used to represent the golden metric.
+	Unit EntityGoldenMetricUnit `json:"unit"`
+}
+
+// EntityGoldenMetricDefinition - The definition of the metric.
+type EntityGoldenMetricDefinition struct {
+	// The field used to filter the entity in the metric. This will be added to the WHERE by default.
+	EventId string `json:"eventId"`
+	// Indicates if the eventId field references a GUID, a domainId or an entity name.
+	EventObjectId EntityGoldenEventObjectId `json:"eventObjectId"`
+	// The field to FACET by.
+	Facet string `json:"facet"`
+	// The FROM clause of the query.
+	From string `json:"from"`
+	// The SELECT clause of the query.
+	Select string `json:"select"`
+	// If a complementary WHERE clause is required to identify the entity type this field will contain it.
+	Where string `json:"where,omitempty"`
+}
+
+// EntityGoldenNRQLTimeWindowInput - Time range to apply to the golden metric NRQL query
+type EntityGoldenNRQLTimeWindowInput struct {
+	// Start time.
+	Since NRQL `json:"since,omitempty"`
+	// End time.
+	Until NRQL `json:"until,omitempty"`
+}
+
+// EntityGoldenOriginalDefinitionWithSelector - Represents a metric definition for a give metric selector value.
+type EntityGoldenOriginalDefinitionWithSelector struct {
+	// The definition of the golden metric.
+	Definition EntityGoldenMetricDefinition `json:"definition"`
+	// The value of the selector. Currently, this is the value of the instrumentation provider.
+	SelectorValue string `json:"selectorValue"`
+}
+
+// EntityGoldenOriginalQueryWithSelector - Object that represents a nrql metric with its metric selector
+type EntityGoldenOriginalQueryWithSelector struct {
+	// The golden metric NRQL query.
+	Query string `json:"query"`
+	// The value of the selector. Currently, this is the value of the instrumentation provider.
+	SelectorValue string `json:"selectorValue"`
+}
+
+// EntityGoldenTag - An object that represents a golden tag.
+type EntityGoldenTag struct {
+	// The golden tag key.
+	Key string `json:"key"`
+}
+
+// EntityManagementAPICatalogAPIContract - Interface for Api Contract entities
+type EntityManagementAPICatalogAPIContract struct {
+	// The name of the Api Contract
+	Name string `json:"name"`
+}
+
+func (x *EntityManagementAPICatalogAPIContract) ImplementsEntityManagementAPICatalogAPIContract() {}
+
+// EntityManagementAPISpecificationBlobEntity - Entity of type Spec Blob.
+type EntityManagementAPISpecificationBlobEntity struct {
+	// The blob containing the Api specification content.
+	Blob EntityManagementBlob `json:"blob"`
+	// Description of the specification content.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the specification file.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementAPISpecificationBlobEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementActor - Represents an actor.
+type EntityManagementActor struct {
+	// Id of the actor.
+	ID int `json:"id"`
+	// Type of the actor.
+	Type EntityManagementActorType `json:"type"`
+}
+
+func (x *EntityManagementActor) ImplementsEntityManagementActor() {}
+
+// EntityManagementAdditionalParameter - Key-value pair for additional configuration
+type EntityManagementAdditionalParameter struct {
+	// Parameter name
+	Key string `json:"key,omitempty"`
+	// Parameter value
+	Value string `json:"value,omitempty"`
+}
+
+// EntityManagementAgentConfigurationEntity - A configuration that can contain multiple immutable versions and can be deployed to a fleet
+type EntityManagementAgentConfigurationEntity struct {
+	// The agentType
+	AgentType string `json:"agentType"`
+	// Configuration type
+	ConfigurationType string `json:"configurationType,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The managedEntityType this configuration is intended to be deployed to
+	ManagedEntityType EntityManagementManagedEntityType `json:"managedEntityType,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique user provided name for the configuration
+	Name string `json:"name"`
+	// The operating system of the managed entity this configuration is intended to be deployed to
+	OperatingSystem EntityManagementOperatingSystem `json:"operatingSystem,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+	// The total number of versions that have been created for this configuration
+	VersionCount int `json:"versionCount,omitempty"`
+}
+
+func (x *EntityManagementAgentConfigurationEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementAgentConfigurationVersionEntity - A version of an agent configuration
+type EntityManagementAgentConfigurationVersionEntity struct {
+	// EntityGuid of the parent AgentConfiguration object
+	AgentConfiguration int `json:"agentConfiguration"`
+	// Metadata about the configuration blob
+	Blob EntityManagementBlob `json:"blob,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+	// Monotonically increasing version number
+	Version int `json:"version"`
+}
+
+func (x *EntityManagementAgentConfigurationVersionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementAgentDeployment - A set of configurations that are currently deployed
+type EntityManagementAgentDeployment struct {
+	// Deployment finish
+	CompletedAt *nrtime.EpochMilliseconds `json:"completedAt,omitempty"`
+	// Fleet Id
+	Fleet int `json:"fleet,omitempty"`
+	// Deployment Id
+	ID string `json:"id,omitempty"`
+	// Managed Entity Id
+	ManagedEntity int `json:"managedEntity,omitempty"`
+	// Deployment started
+	StartedAt *nrtime.EpochMilliseconds `json:"startedAt,omitempty"`
+	// Deployment status
+	Status string `json:"status,omitempty"`
+}
+
+// EntityManagementAgentEffectiveConfigurationEntity - The configuration that is actively being used to configure an agent
+type EntityManagementAgentEffectiveConfigurationEntity struct {
+	// Metadata about the effective configuration blob
+	Blob EntityManagementBlob `json:"blob"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementAgentEffectiveConfigurationEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementAgentEntity - A software component that collects or processes telemetry
+type EntityManagementAgentEntity struct {
+	// The agentType
+	AgentType string `json:"agentType"`
+	// Properties specific to fleet control
+	FleetControlProperties EntityManagementFleetControlProperties `json:"fleetControlProperties"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The infrastructure managers related to the agent
+	InfrastructureManagers []EntityManagementInfrastructureManager `json:"infrastructureManagers,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+	// Version of the agent
+	Version string `json:"version,omitempty"`
+}
+
+func (x *EntityManagementAgentEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementAgentToDeploy - Agent to deploy in a fleet deployment
+type EntityManagementAgentToDeploy struct {
+	// Agent type
+	AgentType string `json:"agentType"`
+	// Configuration version list for this agent
+	ConfigurationVersionList []EntityManagementDeploymentAgentConfigurationVersion `json:"configurationVersionList"`
+	// Agent version
+	Version string `json:"version"`
+}
+
+// EntityManagementAiAgentEntity - Agent configuration for agentic-platform
+type EntityManagementAiAgentEntity struct {
+	// list of worker agents available to the planner agent in a multi-agent setup, ignore this for a single agent setup
+	Agents []EntityManagementEntityInterface `json:"agents"`
+	// agent category, to identify different agents supported by the platform in both single and multi-agent setups
+	Category string `json:"category"`
+	// short description of the agent, important for the discoverability of the agent in a group chat, so make it clear and concise.
+	Description string `json:"description"`
+	// display name for the agent
+	DisplayName string `json:"displayName,omitempty"`
+	// entity's global identifier
+	ID int `json:"id"`
+	// flag to be set to true once agent validation is complete and is ready for use.
+	Initialized bool `json:"initialized,omitempty"`
+	// llm configuration for the agent which includes exact LLM name and temperature settings
+	LlmConfig EntityManagementLlmConfig `json:"llmConfig,omitempty"`
+	// list of MCP server entities to be attached to the agent, each MCP server entity allows you to include/exclude a subset of tools
+	McpServers []EntityManagementAiAgentMcpServerConfig `json:"mcpServers"`
+	// agent metadata
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// unique name of the agent entity
+	Name string `json:"name"`
+	// system instructions for the agent, this guides the behaviour of the llm, so make it elaborate but avoid noise.
+	Prompt string `json:"prompt"`
+	// creator of the agent entity, will help to distinguish extrernal agents from NR owned agents
+	Provider EntityManagementProvider `json:"provider,omitempty"`
+	// entity scope
+	Scope EntityManagementScopedReference `json:"scope"`
+	// collection of tags
+	Tags []EntityManagementTag `json:"tags"`
+	// test flag (true in case entity is experimental, default is true)
+	Test bool `json:"test,omitempty"`
+	// list of tool entities to attach to the agent
+	Tools []EntityManagementAiAgentToolConfig `json:"tools"`
+	// entity type
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementAiAgentEntity) ImplementsEntityManagementEntity() {}
+
+// special
+func (x *EntityManagementAiAgentEntity) UnmarshalJSON(b []byte) error {
+	var objMap map[string]*json.RawMessage
+	err := json.Unmarshal(b, &objMap)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range objMap {
+		if v == nil {
+			continue
+		}
+
+		switch k {
+		case "agents":
+			if v == nil {
+				continue
+			}
+			var rawMessageAgents []*json.RawMessage
+			err = json.Unmarshal(*v, &rawMessageAgents)
+			if err != nil {
+				return err
+			}
+
+			for _, m := range rawMessageAgents {
+				xxx, err := UnmarshalEntityManagementEntityInterface(*m)
+				if err != nil {
+					return err
+				}
+
+				if xxx != nil {
+					x.Agents = append(x.Agents, *xxx)
+				}
+			}
+		case "category":
+			err = json.Unmarshal(*v, &x.Category)
+			if err != nil {
+				return err
+			}
+		case "description":
+			err = json.Unmarshal(*v, &x.Description)
+			if err != nil {
+				return err
+			}
+		case "displayName":
+			err = json.Unmarshal(*v, &x.DisplayName)
+			if err != nil {
+				return err
+			}
+		case "id":
+			err = json.Unmarshal(*v, &x.ID)
+			if err != nil {
+				return err
+			}
+		case "initialized":
+			err = json.Unmarshal(*v, &x.Initialized)
+			if err != nil {
+				return err
+			}
+		case "llmConfig":
+			err = json.Unmarshal(*v, &x.LlmConfig)
+			if err != nil {
+				return err
+			}
+		case "mcpServers":
+			err = json.Unmarshal(*v, &x.McpServers)
+			if err != nil {
+				return err
+			}
+		case "metadata":
+			err = json.Unmarshal(*v, &x.Metadata)
+			if err != nil {
+				return err
+			}
+		case "name":
+			err = json.Unmarshal(*v, &x.Name)
+			if err != nil {
+				return err
+			}
+		case "prompt":
+			err = json.Unmarshal(*v, &x.Prompt)
+			if err != nil {
+				return err
+			}
+		case "provider":
+			err = json.Unmarshal(*v, &x.Provider)
+			if err != nil {
+				return err
+			}
+		case "scope":
+			err = json.Unmarshal(*v, &x.Scope)
+			if err != nil {
+				return err
+			}
+		case "tags":
+			err = json.Unmarshal(*v, &x.Tags)
+			if err != nil {
+				return err
+			}
+		case "test":
+			err = json.Unmarshal(*v, &x.Test)
+			if err != nil {
+				return err
+			}
+		case "tools":
+			err = json.Unmarshal(*v, &x.Tools)
+			if err != nil {
+				return err
+			}
+		case "type":
+			err = json.Unmarshal(*v, &x.Type)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// EntityManagementAiAgentMcpServerConfig - Configuring specific tools from an MCP server for an agent's use
+type EntityManagementAiAgentMcpServerConfig struct {
+	// list of specific tools to exclude from this MCP server
+	ExcludeTools []string `json:"excludeTools"`
+	// list of specific tools to include from this MCP server (default is empty list, which means all tools from the MCP server will be included)
+	IncludeTools []string `json:"includeTools"`
+	// reference to the MCP server entity
+	Server EntityManagementMcpServerEntity `json:"server"`
+}
+
+// EntityManagementAiAgentToolConfig - Deprecated: Configuration for an agent's use of a specific MCP server/tool
+type EntityManagementAiAgentToolConfig struct {
+	// list of specific tools to exclude from this MCP server
+	ExcludeTools []string `json:"excludeTools"`
+	// list of specific tools to include from this MCP server
+	IncludeTools []string `json:"includeTools"`
+	// reference to the MCP server/tool entity
+	Tool EntityManagementAiToolEntity `json:"tool"`
+}
+
+// EntityManagementAiCapableEntity - AI Capable Library for AI Inventory Catalog
+type EntityManagementAiCapableEntity struct {
+	// Category of the tool/library
+	Category string `json:"category"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Language of the ai tool/library
+	Language string `json:"language"`
+	// Last seen timestamp: A date and time as an ISO8601 formatted string.
+	LastSeen DateTime `json:"lastSeen"`
+	// Entity metadata
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Unique name of the agent entity
+	Name string `json:"name"`
+	// Entity scope
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags
+	Tags []EntityManagementTag `json:"tags"`
+	// Type of the tool. Eg: library or usage
+	ToolType string `json:"toolType"`
+	// Version of the ai tool/library
+	ToolVersion string `json:"toolVersion"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementAiCapableEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementAiEvaluationConfigEntity - Experimental feature for ai evaluation configuration
+type EntityManagementAiEvaluationConfigEntity struct {
+	// The entity description.
+	Description string `json:"description,omitempty"`
+	// Enable or disable Evaluations for all the entities under the scope
+	Enabled bool `json:"enabled,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Reference to the ManagedEvaluationsEntity containing the evaluation configurations to be applied
+	ManagedEvaluationsEntity EntityManagementManagedEvaluationsEntity `json:"managedEvaluationsEntity,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique user provided name for the evaluation.
+	Name string `json:"name"`
+	// Defines the fraction of incoming messages to be evaluated. Value ranges from 0.0 (none) to 1.0 (all).
+	SamplingRate float64 `json:"samplingRate,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementAiEvaluationConfigEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementAiToolEntity - Tool configuration for agentic-platform
+type EntityManagementAiToolEntity struct {
+	// short description of the tool, useful for tool discovery by an agent
+	Description string `json:"description"`
+	// entity's unique global indentifier
+	ID int `json:"id"`
+	// flag to be set to true once agent validation is complete and is ready for use.
+	Initialized bool `json:"initialized,omitempty"`
+	// tool metadata
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// unique name of the tool
+	Name string `json:"name"`
+	// tool parameters to be passed for each tool
+	Parameters []EntityManagementAiToolParameter `json:"parameters"`
+	// creator of the agent entity, will help to distinguish extrernal agents from NR owned agents
+	Provider EntityManagementProvider `json:"provider,omitempty"`
+	// entity scope
+	Scope EntityManagementScopedReference `json:"scope"`
+	// collection of tags
+	Tags []EntityManagementTag `json:"tags"`
+	// test flag (true in case entity is experimental, default is true)
+	Test bool `json:"test,omitempty"`
+	// type of tool from a list of first class citizen tools
+	ToolType EntityManagementAiToolType `json:"toolType,omitempty"`
+	// entity type
+	Type string `json:"type"`
+	// It is primarily a nerdgraph query in single line format
+	URL string `json:"url"`
+}
+
+func (x *EntityManagementAiToolEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementAiToolParameter - Tool parameters to be passed to ToolEntity
+type EntityManagementAiToolParameter struct {
+	// description of the parameter - important for the discovery of parameter by llm
+	Description string `json:"description"`
+	// name of the tool parameter
+	Name string `json:"name"`
+	// type of the parameter indicating its data-type
+	Type EntityManagementAiToolParameterType `json:"type"`
+}
+
+// EntityManagementArrayCondition - Array condition type.
+type EntityManagementArrayCondition struct {
+	// Array condition  type operator.
+	Operator EntityManagementArrayOperator `json:"operator"`
+}
+
+// EntityManagementAttribute - Attributes to represent thresholds
+type EntityManagementAttribute struct {
+	// Key for the attribute, e.g., 'queryCountThreshold', 'queryDurationThresholdMs'
+	Key string `json:"key"`
+	// It generates the current timestamp in milliseconds
+	LastUpdatedAt *nrtime.EpochMilliseconds `json:"lastUpdatedAt,omitempty"`
+	// It represents the userId of the user who has edited this
+	LastUpdatedBy EntityManagementPrincipal `json:"lastUpdatedBy,omitempty"`
+	// Value for the attribute, e.g., '1000', '5000'. The value can be a string representation of a number or any other type as needed.
+	Value string `json:"value"`
+}
+
+// EntityManagementAwsAssumeRoleConfig - Configuration for accessing an Aws account via AssumeRole
+type EntityManagementAwsAssumeRoleConfig struct {
+	// External ID to use when assuming the role
+	ExternalId EntityManagementDynamicString `json:"externalId,omitempty"`
+	// The ARN of the role to assume
+	RoleArn string `json:"roleArn"`
+}
+
+// EntityManagementAwsConnectionEntity - Connection entity type for Aws
+type EntityManagementAwsConnectionEntity struct {
+	// A single credential from the choice of AwsCredential
+	Credential EntityManagementAwsCredentials `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. True by default
+	Enabled bool `json:"enabled,omitempty"`
+	// Optional field representing an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// Default region for this connection
+	Region string `json:"region,omitempty"`
+	// The entity’s scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity’s type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementAwsConnectionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementAwsCredentials - Base Credential type for Aws
+type EntityManagementAwsCredentials struct {
+	// AssumeRole type
+	AssumeRole EntityManagementAwsAssumeRoleConfig `json:"assumeRole,omitempty"`
+}
+
+// EntityManagementAzureDevOpsConnectionEntity - Connection entity type for Azure DevOps
+type EntityManagementAzureDevOpsConnectionEntity struct {
+	// A single credential from the choice of AzureDevOpsCredential
+	Credential EntityManagementAzureDevOpsCredentials `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. True by default
+	Enabled bool `json:"enabled,omitempty"`
+	// Optional field representing an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Array of up to 2 SigningCredential to verify incoming requests, and rotate new signing credentials when needed
+	SigningCredentials []EntityManagementSigningCredential `json:"signingCredentials"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity's type.
+	Type string `json:"type"`
+	// The Azure DevOps organization URL, e.g. https://dev.azure.com/contoso
+	URL string `json:"url"`
+}
+
+func (x *EntityManagementAzureDevOpsConnectionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementAzureDevOpsCredentials - Base credentials type for Azure DevOps
+type EntityManagementAzureDevOpsCredentials struct {
+	// OAuth support via Azure AD
+	Oauth EntityManagementAzureDevOpsOAuthCredential `json:"oauth,omitempty"`
+	// A personal access token credential
+	PersonalAccessToken EntityManagementSecretReference `json:"personalAccessToken,omitempty"`
+}
+
+// EntityManagementAzureDevOpsOAuthCredential - OAuth credential type for Azure DevOps via Azure AD
+type EntityManagementAzureDevOpsOAuthCredential struct {
+	// The Azure AD application (client) ID
+	ClientId string `json:"clientId"`
+	// The Azure AD client secret
+	ClientSecret EntityManagementSecretReference `json:"clientSecret"`
+	// The OAuth refresh token for token renewal
+	RefreshToken EntityManagementSecretReference `json:"refreshToken"`
+	// The field name for the access token from the JSON response, default to access_token
+	TokenFieldName string `json:"tokenFieldName,omitempty"`
+	// The full Azure AD token URL, e.g. https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token
+	TokenURL string `json:"tokenUrl"`
+}
+
+// EntityManagementBackgroundProcessingQuery - At rest background processing types
+type EntityManagementBackgroundProcessingQuery struct {
+	// The list of scopes to be included in every query in a scheduled batch of cross account queries.
+	JoinScopes []EntityManagementScopedReference `json:"joinScopes"`
+	// The NRQL string used to specify the action you want to take and data you want to take the specified action on.
+	NRQL NRQL `json:"nrql"`
+	// The scope for the output, if applicable. If the value is null, the entity scope is used as output.
+	OutputScope EntityManagementScopedReference `json:"outputScope,omitempty"`
+	// The list of scopes to be queried, allowing a scheduled batch of cross account queries. If this value is null, the original entity scope will be used.
+	Scopes []EntityManagementScopedReference `json:"scopes"`
+}
+
+// EntityManagementBackgroundProcessingRuleEntity - At rest background processing types
+type EntityManagementBackgroundProcessingRuleEntity struct {
+	// Entity description.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The account and NRQL query definition for the rule
+	Query EntityManagementBackgroundProcessingQuery `json:"query"`
+	// Classification of the query type. This field is primarily for filtering
+	RuleType EntityManagementBackgroundProcessingType `json:"ruleType,omitempty"`
+	// The cronExpression to run the scheduled query. Minute step values, ranges and lists are not permitted.
+	Schedule EntityManagementSchedule `json:"schedule,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Describes the asynchronous at-rest process state to communicate through the API what is happening
+	State EntityManagementProcessState `json:"state,omitempty"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementBackgroundProcessingRuleEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementBackgroundProcessingSqlQuery - At rest background processing types
+type EntityManagementBackgroundProcessingSqlQuery struct {
+	// The scope for the output, if applicable. If the value is null, the entity scope is used as output.
+	OutputScope EntityManagementScopedReference `json:"outputScope,omitempty"`
+	// The target of the SQL query results, indicating the destination where the SQL results will be sent.
+	OutputTarget string `json:"outputTarget"`
+	// The list of scopes to be queried, allowing cross account queries. If this value is null, the original entity scope will be used.
+	Scopes []EntityManagementScopedReference `json:"scopes"`
+	// The SQL string used to specify the action you want to take and data you want to take the specified action on.
+	Sql string `json:"sql"`
+}
+
+// EntityManagementBackgroundSqlProcessingRuleEntity - At rest background sql processing types
+type EntityManagementBackgroundSqlProcessingRuleEntity struct {
+	// Entity description.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The account and SQL query definition for the rule
+	Query EntityManagementBackgroundProcessingSqlQuery `json:"query"`
+	// The cronExpression to run the scheduled query. Minute step values, ranges and lists are not permitted.
+	Schedule EntityManagementSchedule `json:"schedule,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Describes the asynchronous at-rest process state to communicate through the API what is happening
+	State EntityManagementProcessState `json:"state,omitempty"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementBackgroundSqlProcessingRuleEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementBlob - Metadata about a blob stored in the Blob Datastore.
+type EntityManagementBlob struct {
+	// Object that holds the details of the blob signature
+	BlobSignature EntityManagementBlobSignature `json:"blobSignature,omitempty"`
+	// Object that holds the details of the blob signature
+	BlobSignatures []EntityManagementBlobSignature `json:"blobSignatures,omitempty"`
+	// The checksum of the blob content
+	Checksum string `json:"checksum,omitempty"`
+	// The checksum algorithm used to calculate the checksum of the blob content
+	ChecksumAlgorithm string `json:"checksumAlgorithm,omitempty"`
+	// The content type of the blob
+	ContentType string `json:"contentType"`
+	// The blob identifier. Can be used to download the blob data from the Blob API
+	ID int `json:"id"`
+}
+
+// EntityManagementBlobSignature - A set of configurations for blob signature
+type EntityManagementBlobSignature struct {
+	// Boolean flag to show if a blob has security findings
+	SecurityFindings bool `json:"securityFindings,omitempty"`
+	// Signature details
+	Signature EntityManagementSignatureDetails `json:"signature"`
+	// Error encountered during signature creation
+	SignatureError []string `json:"signatureError"`
+	// Errors encountered during signature creation
+	SignatureErrors []string `json:"signatureErrors"`
+	// Signature of the blob
+	Signatures []EntityManagementSignatureDetails `json:"signatures"`
+	// Error encountered during validation
+	ValidationError []string `json:"validationError"`
+}
+
+// EntityManagementBudgetAccount - Represents an account.
+type EntityManagementBudgetAccount struct {
+	// The unique identifier of the account.
+	ID int `json:"id"`
+}
+
+// EntityManagementBudgetAlertPolicy - Represents an alert policy for the budget
+type EntityManagementBudgetAlertPolicy struct {
+	// The unique identifier of the alert policy.
+	ID int `json:"id"`
+}
+
+// EntityManagementBudgetCustomer - Represents a customer.
+type EntityManagementBudgetCustomer struct {
+	// The unique identifier of the customer.
+	ID string `json:"id"`
+}
+
+// EntityManagementBudgetEntity - Represents a New Relic Budget entity.
+type EntityManagementBudgetEntity struct {
+	// A list of alert policies associated with this budget.
+	BudgetAlertPolicies []EntityManagementBudgetAlertPolicy `json:"budgetAlertPolicies,omitempty"`
+	// A list of limits defined for this budget.
+	BudgetLimits []EntityManagementBudgetLimit `json:"budgetLimits,omitempty"`
+	// The segment being tracked by the budget.
+	BudgetSegment EntityManagementBudgetSegment `json:"budgetSegment,omitempty"`
+	// Budget Type as Ingest or compute
+	BudgetType EntityManagementBudgetType `json:"budgetType,omitempty"`
+	// The globally unique identifier of the entity.
+	ID int `json:"id"`
+	// Metadata associated with the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the entity.
+	Name string `json:"name"`
+	// True if it’s an org level budget, False otherwise.
+	OrganizationBudget bool `json:"organizationBudget,omitempty"`
+	// The scope of the entity.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// A collection of tags associated with the entity.
+	Tags []EntityManagementTag `json:"tags"`
+	// The type of the entity.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementBudgetEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementBudgetLimit - Represents a budget limit.
+type EntityManagementBudgetLimit struct {
+	// The consumption metric associated with the budget limit.
+	ConsumptionMetric EntityManagementConsumptionMetric `json:"consumptionMetric,omitempty"`
+	// Reference to where the complete budget limit definition is stored. The Budget Entity acts as an index/tracking system while the actual limit configuration data lives in the Limits Platform.
+	Reference EntityManagementReference `json:"reference,omitempty"`
+	// The value of the limit for the specified consumption metric.
+	Value int `json:"value,omitempty"`
+}
+
+// EntityManagementBudgetOrganization - Represents an organization.
+type EntityManagementBudgetOrganization struct {
+	// The unique identifier of the organization.
+	ID int `json:"id"`
+}
+
+// EntityManagementBudgetSegment - The segment being tracked by the budget.
+type EntityManagementBudgetSegment struct {
+	// Array of account IDs associated with the budget segment.
+	Accounts []EntityManagementBudgetAccount `json:"accounts,omitempty"`
+	// Customer Contract ID.
+	Customer EntityManagementBudgetCustomer `json:"customer,omitempty"`
+	// Array of organization IDs in a multi-tenant structure.
+	Organizations []EntityManagementBudgetOrganization `json:"organizations,omitempty"`
+	// Object containing user limit configuration.
+	Users EntityManagementUsers `json:"users,omitempty"`
+}
+
+// EntityManagementBudgetUser - Represents a user whose resource consumption limits are managed by the budget.
+type EntityManagementBudgetUser struct {
+	// The unique identifier of the user (userID).
+	ID int `json:"id"`
+}
+
+// EntityManagementCategoryScope - Scope for category subtype
+type EntityManagementCategoryScope struct {
+	// id based on scope
+	ID string `json:"id"`
+	// type of scope
+	Type EntityManagementCategoryScopeType `json:"type"`
+}
+
+// EntityManagementCharacterTextSplitterOptions - The CharacterTextSplitter options
+type EntityManagementCharacterTextSplitterOptions struct {
+	// Is the separator a regex
+	IsSeparatorRegex bool `json:"isSeparatorRegex"`
+	// Character to split text on
+	Separator string `json:"separator"`
+}
+
+// EntityManagementCiscoMerakiAPIKeyCredential - Api key auth credential type for Cisco Meraki
+type EntityManagementCiscoMerakiAPIKeyCredential struct {
+	// The api key to authorize API access
+	APIKey EntityManagementSecretReference `json:"apiKey"`
+}
+
+// EntityManagementCiscoMerakiConnectionEntity - Connection entity type for Cisco Meraki
+type EntityManagementCiscoMerakiConnectionEntity struct {
+	// A single credential for Cisco Meraki
+	Credential EntityManagementCiscoMerakiCredential `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. True by default
+	Enabled bool `json:"enabled,omitempty"`
+	// Meraki organization id
+	ExternalId string `json:"externalId"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// The Cisco Meraki region (e.g., India, China, Canada)
+	Region string `json:"region"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity's type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementCiscoMerakiConnectionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementCiscoMerakiCredential - Credential type for Cisco Meraki
+type EntityManagementCiscoMerakiCredential struct {
+	// Api key authentication
+	APIKey EntityManagementCiscoMerakiAPIKeyCredential `json:"apiKey,omitempty"`
+}
+
+// EntityManagementCloudProviderConfiguration - Cloud provider configuration for a federated log setup.
+type EntityManagementCloudProviderConfiguration struct {
+	// The cloud provider where this federated log setup is deployed.
+	Provider EntityManagementCloudProvider `json:"provider"`
+	// The cloud provider region where the federated log setup is deployed.
+	Region string `json:"region"`
+}
+
+// EntityManagementCollectionEntity - An entity type to represent collections of entities
+type EntityManagementCollectionEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementCollectionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementCommunicationLog - CommunicationLog represents the communication information for an incident. This includes communication details as well as the impact information for that incident.
+type EntityManagementCommunicationLog struct {
+	// The message communicated by.
+	CommunicatedBy string `json:"communicatedBy"`
+	// Mode of the communication happened.
+	CommunicationMode []EntityManagementCommunicationMode `json:"communicationMode"`
+	// The communication status.
+	CommunicationStatus EntityManagementCommunicationStatus `json:"communicationStatus"`
+	// Represents the customer impact of the incident.
+	Impact []EntityManagementCustomerImpactEntity `json:"impact"`
+	// The content of the communication log.
+	Message string `json:"message,omitempty"`
+	// The timestamp of the communication log.
+	Timestamp *nrtime.EpochMilliseconds `json:"timestamp,omitempty"`
+}
+
+// EntityManagementComponentEntity - An entity representing the component or the product available to create impact for an incident.
+type EntityManagementComponentEntity struct {
+	// The component description.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Name for the component.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementComponentEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementComputeLocationEntity - An entity representing a compute location for serverless job execution
+type EntityManagementComputeLocationEntity struct {
+	// Description for the ComputeLocation
+	Description string `json:"description"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique user provided name for the ComputeLocation, can be utilized for workload querying.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementComputeLocationEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementConfig - Collection of attributes to represent thresholds of a type
+type EntityManagementConfig struct {
+	// The list of attributes that define the thresholds for this config.
+	Attributes []EntityManagementAttribute `json:"attributes"`
+	// The name of the analyzer for which this config is applicable.
+	Name string `json:"name"`
+}
+
+// EntityManagementConfiguration - Metadata about the configuration and the configuration blob itself
+type EntityManagementConfiguration struct {
+	// The raw configuration blob supplied by the system
+	Blob EntityManagementBlob `json:"blob"`
+	// The ID of the source system entity for the configuration
+	Source int `json:"source,omitempty"`
+	// The last time the configuration was updated
+	UpdatedAt *nrtime.EpochMilliseconds `json:"updatedAt,omitempty"`
+	// Who or what last updated the configuration
+	UpdatedBy string `json:"updatedBy,omitempty"`
+}
+
+// EntityManagementConfluenceBasicAuthCredential - Basic auth credential type for Confluence
+type EntityManagementConfluenceBasicAuthCredential struct {
+	// The confluence domain (e.g., your-domain.atlassian.net)
+	Domain string `json:"domain"`
+	// The Confluence API token to authorize the API operations
+	Token EntityManagementSecretReference `json:"token"`
+	// API token expiration time
+	TokenExpirationTime *nrtime.EpochMilliseconds `json:"tokenExpirationTime,omitempty"`
+	// The Confluence user ID (the Atlassian account email) associated with the API token.
+	UserID EntityManagementSecretReference `json:"userId"`
+}
+
+// EntityManagementConfluenceConnectionEntity - Connection entity type for Confluence
+type EntityManagementConfluenceConnectionEntity struct {
+	// A single credential from the choice of ConfluenceCredential
+	Credential EntityManagementConfluenceCredentials `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. False by default.
+	Enabled bool `json:"enabled,omitempty"`
+	// Optional field representing an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Array of up to 2 SigningCredential to verify incoming requests, and rotate new signing credentials when needed
+	SigningCredentials []EntityManagementSigningCredential `json:"signingCredentials"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity's type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementConfluenceConnectionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementConfluenceCredentials - Base credentials type for Confluence
+type EntityManagementConfluenceCredentials struct {
+	// A simple basic auth credential
+	BasicAuth EntityManagementConfluenceBasicAuthCredential `json:"basicAuth,omitempty"`
+}
+
+// EntityManagementConfluenceIntegration - Bare essentials for any integration with confluence
+type EntityManagementConfluenceIntegration struct {
+	// The confluence user ID associated with this integration.
+	ConfluenceUserId string `json:"confluenceUserId"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the Confluence Rag Settings.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The secret key referencing confluence credentials in secret store.
+	SecretKey string `json:"secretKey"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+	// The confluence domain.
+	URL string `json:"url"`
+}
+
+func (x *EntityManagementConfluenceIntegration) ImplementsEntityManagementEntity() {}
+
+// EntityManagementConfluenceRagSettingsEntity - Confluence Rag Settings
+type EntityManagementConfluenceRagSettingsEntity struct {
+	// The options for character text splitter
+	CharacterTextSplitterOptions EntityManagementCharacterTextSplitterOptions `json:"characterTextSplitterOptions,omitempty"`
+	// The chunk overlap for chunking documents
+	ChunkOverlap int `json:"chunkOverlap,omitempty"`
+	// The chunk size for chunking documents
+	ChunkSize int `json:"chunkSize,omitempty"`
+	// The ID of the confluence integration entity
+	ConfluenceIntegrationId int `json:"confluenceIntegrationId"`
+	// The CQL query for selecting documents to index.
+	ConfluenceQuery string `json:"confluenceQuery"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The interval, in seconds, for how often documents are synced.
+	IntervalSeconds int `json:"intervalSeconds"`
+	// The timestamp when the connector was last run.
+	LastPullTime *nrtime.EpochMilliseconds `json:"lastPullTime,omitempty"`
+	// The options when using the markdown text splitter
+	MarkdownTextSplitterOptions EntityManagementMarkdownTextSplitterOptions `json:"markdownTextSplitterOptions,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the Confluence Rag Settings.
+	Name string `json:"name"`
+	// The timestamp for the connector's next scheduled run.
+	NextPullTime *nrtime.EpochMilliseconds `json:"nextPullTime,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The text splitter to be used
+	TextSplitterType EntityManagementTextSplitterType `json:"textSplitterType,omitempty"`
+	// The options when using a token text splitter
+	TokenTextSplitterOptions EntityManagementTokenTextSplitterOptions `json:"tokenTextSplitterOptions,omitempty"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementConfluenceRagSettingsEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementConnectionSettings - Connection settings type for all connections
+type EntityManagementConnectionSettings struct {
+	// The key or name of the setting
+	Key string `json:"key"`
+	// The value of the setting.
+	Value string `json:"value"`
+}
+
+// EntityManagementCorrelationAttribute - A configuration attribute for probabilistic matching.
+type EntityManagementCorrelationAttribute struct {
+	// Attribute name.
+	Name string `json:"name"`
+	// Attribute value.
+	Value string `json:"value"`
+}
+
+// EntityManagementCorrelationAttributeCondition - Defines an attribute matching condition between subjects.
+type EntityManagementCorrelationAttributeCondition struct {
+	// The attribute path to match (e.g., 'tags.hostname').
+	Attribute string `json:"attribute"`
+	// Optional. Reference to an org-level normalizer to apply to both attribute and value after transforms.
+	Normalize EntityManagementCorrelationNormalizerEntity `json:"normalize,omitempty"`
+	// Optional. Reference to an org-level normalizer to apply only to the attribute side. Overrides normalize for attribute.
+	NormalizeAttribute EntityManagementCorrelationNormalizerEntity `json:"normalizeAttribute,omitempty"`
+	// Optional. Reference to an org-level normalizer to apply only to the value side. Overrides normalize for value.
+	NormalizeValue EntityManagementCorrelationNormalizerEntity `json:"normalizeValue,omitempty"`
+	// The matching operator.
+	Operator EntityManagementCorrelationAttributeConditionOperator `json:"operator"`
+	// Optional. Ordered list of transform functions to apply to both attribute and value before comparison.
+	Transform []EntityManagementCorrelationTransformFunction `json:"transform"`
+	// Optional. Ordered list of transform functions to apply only to the attribute side. Overrides transform for attribute.
+	TransformAttribute []EntityManagementCorrelationTransformFunction `json:"transformAttribute"`
+	// Optional. Ordered list of transform functions to apply only to the value side. Overrides transform for value.
+	TransformValue []EntityManagementCorrelationTransformFunction `json:"transformValue"`
+	// The value to match against. Should be a reference to the other subject following the pattern {{alias.attribute}}.
+	Value string `json:"value"`
+}
+
+// EntityManagementCorrelationContext - Context metadata about a correlation link.
+type EntityManagementCorrelationContext struct {
+	// Confidence score (0.0 to 1.0) if probabilistic matching was used.
+	Confidence float64 `json:"confidence"`
+	// Additional informational messages about the correlation.
+	Messages []string `json:"messages"`
+	// The GUID of the CorrelationLinkingRule that created this link.
+	RuleId int `json:"ruleId"`
+}
+
+// EntityManagementCorrelationInternalSourceConfigEntity - CorrelationInternalSourceConfig persists the configuration required to provision
+// DAQS filters, separating the ingestion mechanism from the correlation logic.
+// This entity is internal only.
+type EntityManagementCorrelationInternalSourceConfigEntity struct {
+	// Account ID of the Rule Filter.
+	AccountID int `json:"accountId"`
+	// Alias for this subject used in criteria and linking configuration.
+	Alias string `json:"alias"`
+	// The internal ID used by the DAQS filtering system.
+	FilterId int `json:"filterId"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The NRQL query used to filter the stream.
+	NRQL NRQL `json:"nrql"`
+	// The name of this internal source configuration.
+	Name string `json:"name"`
+	// List of namespaces applicable to this filter.
+	Namespaces []string `json:"namespaces"`
+	// The Kafka topic where filtered data should be published.
+	OutputTopic string `json:"outputTopic"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The data source identifier (e.g., ai-external-incident).
+	Source string `json:"source"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementCorrelationInternalSourceConfigEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementCorrelationLinkEntity - CorrelationLink represents a directional edge between two correlation subjects.
+// When a CorrelationLinkingRule matches, it creates this relationship entity in NGEP.
+// Note: The output is stored in NGEP as an entity and not a relationship, because
+// the targets for the relationship need not be NGEP entities (can just be NRDB Events).
+type EntityManagementCorrelationLinkEntity struct {
+	// Metadata about why this link exists.
+	Context EntityManagementCorrelationContext `json:"context"`
+	// Indicates if the link is directional.
+	Directional bool `json:"directional"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The relationship type (e.g., CAUSED_BY, RELATED_TO).
+	LinkType string `json:"linkType"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this correlation link.
+	Name string `json:"name"`
+	// Audit trail if a user manually modified/rejected this link.
+	OverrideInfo []EntityManagementCorrelationOverrideInfo `json:"overrideInfo"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The 'From' correlation subject.
+	Source EntityManagementCorrelationSubjectReference `json:"source"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The 'To' correlation subject.
+	Target EntityManagementCorrelationSubjectReference `json:"target"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementCorrelationLinkEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementCorrelationLinkingConfig - Defines the output configuration for correlation results.
+type EntityManagementCorrelationLinkingConfig struct {
+	// Whether the link is directional (default: false).
+	Directional bool `json:"directional,omitempty"`
+	// The type of link/relationship to create (e.g., 'RELATED_TO', 'CAUSED_BY').
+	LinkType string `json:"linkType"`
+	// Alias of the source subject (for directional links).
+	SourceAlias string `json:"sourceAlias,omitempty"`
+	// Alias of the target subject (for directional links).
+	TargetAlias string `json:"targetAlias,omitempty"`
+}
+
+// EntityManagementCorrelationLinkingCriteria - Defines the matching criteria for correlation.
+type EntityManagementCorrelationLinkingCriteria struct {
+	// Deterministic attribute matching rules.
+	AttributeConditions []EntityManagementCorrelationAttributeCondition `json:"attributeConditions"`
+	// Probabilistic/ML-based matching configuration.
+	Probabilistic EntityManagementCorrelationProbabilisticMatchingConfig `json:"probabilistic,omitempty"`
+	// Temporal window configuration for correlation.
+	TemporalWindow EntityManagementCorrelationWindowConfig `json:"temporalWindow,omitempty"`
+	// Topology proximity threshold for correlation.
+	TopologyProximity int `json:"topologyProximity,omitempty"`
+}
+
+// EntityManagementCorrelationLinkingRuleEntity - CorrelationLinkingRule persists the logic required to drive the event correlation engine,
+// defining which events (Drivers) trigger searches for other subjects (Candidates).
+// Supports all standard CRUD operations including delete via the generic delete mutation.
+type EntityManagementCorrelationLinkingRuleEntity struct {
+	// The criteria defining how to match driver and candidates.
+	Criteria EntityManagementCorrelationLinkingCriteria `json:"criteria"`
+	// Description of what this correlation rule does.
+	Description string `json:"description,omitempty"`
+	// Whether this correlation rule is currently enabled. Considered true by default
+	Enabled bool `json:"enabled,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The output configuration defining the correlation result.
+	LinkingConfig EntityManagementCorrelationLinkingConfig `json:"linkingConfig"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this correlation rule.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Defines the Driver (trigger) and Candidates.
+	Subjects []EntityManagementCorrelationSubject `json:"subjects"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementCorrelationLinkingRuleEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementCorrelationNormalizationRule - A pattern-value mapping rule used by CorrelationNormalizerEntity.
+type EntityManagementCorrelationNormalizationRule struct {
+	// Regex pattern to match against the input value.
+	Pattern string `json:"pattern"`
+	// The normalized output value when pattern matches.
+	Value string `json:"value"`
+}
+
+// EntityManagementCorrelationNormalizerEntity - Organization-scoped normalizer for pattern-based value mappings.
+// Referenced in CorrelationAttributeCondition normalize fields.
+// Managed separately from correlation rules and reusable across rules within the organization.
+type EntityManagementCorrelationNormalizerEntity struct {
+	// If true, pattern matching ignores case. Default: true.
+	CaseInsensitive bool `json:"caseInsensitive"`
+	// Behavior when no pattern matches. Default: PASSTHROUGH.
+	Default EntityManagementCorrelationNormalizationDefault `json:"default"`
+	// Optional description of the normalizer's purpose.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Unique name within the org, used to reference in rules.
+	Name string `json:"name"`
+	// Ordered list of pattern-value mappings. First match wins.
+	Rules []EntityManagementCorrelationNormalizationRule `json:"rules"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementCorrelationNormalizerEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementCorrelationOverrideInfo - User override information for a correlation link.
+type EntityManagementCorrelationOverrideInfo struct {
+	// The action taken by the user.
+	Action EntityManagementCorrelationOverrideAction `json:"action"`
+	// Timestamp when the override was performed.
+	Timestamp *nrtime.EpochMilliseconds `json:"timestamp"`
+	// ID of the user who performed the override.
+	UserID int `json:"userId"`
+}
+
+// EntityManagementCorrelationProbabilisticMatchingConfig - Configuration for probabilistic/ML-based matching.
+type EntityManagementCorrelationProbabilisticMatchingConfig struct {
+	// The ML algorithm to use.
+	Algorithm EntityManagementCorrelationMatchingAlgorithm `json:"algorithm"`
+	// Confidence threshold (0.0 to 1.0) for accepting correlations.
+	ConfidenceThreshold float64 `json:"confidenceThreshold"`
+	// Additional configuration attributes for the algorithm.
+	Configs []EntityManagementCorrelationAttribute `json:"configs"`
+}
+
+// EntityManagementCorrelationSubject - Defines a subject (event or entity) that participates in correlation.
+type EntityManagementCorrelationSubject struct {
+	// List of account IDs to query for this subject. Account access is validated by the correlation service at runtime.
+	AccountIDs []int `json:"accountIds"`
+	// Alias for this subject used in criteria and linking configuration.
+	Alias string `json:"alias"`
+	// Lifecycle configuration for stateful subjects (optional).
+	Lifecycle EntityManagementCorrelationSubjectLifecycleConfig `json:"lifecycle,omitempty"`
+	// The NRQL query to select this subject.
+	NRQL NRQL `json:"nrql"`
+	// The type of the subject (EVENT or ENTITY).
+	Type EntityManagementCorrelationSubjectType `json:"type"`
+}
+
+// EntityManagementCorrelationSubjectLifecycleConfig - Defines the lifecycle management for stateful correlation subjects.
+type EntityManagementCorrelationSubjectLifecycleConfig struct {
+	// Values indicating the subject is in a closed state.
+	ClosedValues []string `json:"closedValues"`
+	// Field name representing the unique identifier for the subject.
+	IdentityKey string `json:"identityKey"`
+	// Values indicating the subject is in an open state.
+	OpenValues []string `json:"openValues"`
+	// Field name representing the state of the subject.
+	StateKey string `json:"stateKey"`
+}
+
+// EntityManagementCorrelationSubjectReference - Reference to a correlation subject (event or entity).
+type EntityManagementCorrelationSubjectReference struct {
+	// The account where the event resides.
+	AccountID int `json:"accountId"`
+	// The unique identifier of the event.
+	EventId string `json:"eventId"`
+	// The event's type (e.g., NR_ISSUE).
+	EventType string `json:"eventType"`
+}
+
+// EntityManagementCorrelationWindowConfig - Defines the temporal window for candidate discovery.
+type EntityManagementCorrelationWindowConfig struct {
+	// Attribute name for driver end timestamp (optional).
+	DriverEndTimestampAttribute string `json:"driverEndTimestampAttribute,omitempty"`
+	// Attribute name for driver start timestamp (optional).
+	DriverStartTimestampAttribute string `json:"driverStartTimestampAttribute,omitempty"`
+	// Lookback duration in seconds from the driver event.
+	LookbackSeconds Seconds `json:"lookbackSeconds"`
+	// Lookforward duration in seconds from the driver event.
+	LookforwardSeconds Seconds `json:"lookforwardSeconds"`
+}
+
+// EntityManagementCount - Represents the count.
+type EntityManagementCount struct {
+	// Number of repositories associated with the integration.
+	RepoCount int `json:"repoCount,omitempty"`
+	// Number of teams associated with the integration.
+	TeamCount int `json:"teamCount,omitempty"`
+}
+
+// EntityManagementCustomEvaluationEntity - Experimental feature for custom evaluations
+type EntityManagementCustomEvaluationEntity struct {
+	// Evaluation criteria definition
+	Criteria string `json:"criteria,omitempty"`
+	// The entity description.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Model identifier to use for evaluation
+	Model string `json:"model,omitempty"`
+	// A unique user provided name for the evaluation.
+	Name string `json:"name"`
+	// Parameters required for the evaluation
+	Parameters []EntityManagementEvaluationParameter `json:"parameters"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Step-by-step evaluation instructions
+	Steps []string `json:"steps"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// Threshold value for passing the evaluation (0.0 to 1.0)
+	Threshold float64 `json:"threshold,omitempty"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementCustomEvaluationEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementCustomerImpactEntity - An entity representing customer impact information for an incident. It contains impact representing an incident.
+type EntityManagementCustomerImpactEntity struct {
+	// Impact along with attributes
+	Blob EntityManagementBlob `json:"blob,omitempty"`
+	// Impacted Components per issue
+	Components []EntityManagementComponentEntity `json:"components"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Related issue id
+	IssueId int `json:"issueId,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique user provided name for the customer impact.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementCustomerImpactEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementCustomerImpactQueryEntity - An entity representing customer impact queries information for an incident.
+type EntityManagementCustomerImpactQueryEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// Impacted products.
+	Products []EntityManagementComponentEntity `json:"products"`
+	// Customer impact query to determine the impacted account ids.
+	Query string `json:"query"`
+	// Query account id required to execute the customer impact query.
+	QueryAccountId int `json:"queryAccountId"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// NRTeam responsible for the customer impact query.
+	TeamEntity EntityManagementTeamEntity `json:"teamEntity,omitempty"`
+	// @deprecated Use 'teamEntity' field instead
+	// Team name responsible for the customer impact query.
+	TeamName string `json:"teamName,omitempty"`
+	// Account IDs to be used with the total customer impact query.
+	TotalCustImpactQueryAccountIds []int `json:"totalCustImpactQueryAccountIds,omitempty"`
+	// Customer impact query to determine the total customer impact.
+	TotalCustomerImpactQuery string `json:"totalCustomerImpactQuery,omitempty"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementCustomerImpactQueryEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementDateCondition - Date condition type.
+type EntityManagementDateCondition struct {
+	// End values for the IN_RANGE operator.
+	EndValue string `json:"endValue,omitempty"`
+	// Date condition type  operator.
+	Operator EntityManagementDateOperator `json:"operator"`
+	// Start values for the IN_RANGE operator.
+	StartValue string `json:"startValue,omitempty"`
+	// Value for BEFORE and AFTER operators.
+	Value string `json:"value,omitempty"`
+}
+
+// EntityManagementDeploymentAgentConfigurationVersion - Properties of a deployed configuration version
+type EntityManagementDeploymentAgentConfigurationVersion struct {
+	// Configuration version ID
+	ID int `json:"id"`
+}
+
+// EntityManagementDiscoverySettings - Discovery related settings.
+type EntityManagementDiscoverySettings struct {
+	// If discovery is enabled for that organization or not.
+	Enabled bool `json:"enabled"`
+	// Tag keys used for discovery for the organization.
+	TagKeys []string `json:"tagKeys"`
+}
+
+// EntityManagementEntity - The Entity interface.
+type EntityManagementEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementEventBridgeCondition - Represents a single base condition comparing a field to a value.
+type EntityManagementEventBridgeCondition struct {
+	// The JSON path to the field within the event payload to evaluate.
+	Field string `json:"field"`
+	// The matching logic for the field.
+	Value EntityManagementEventBridgeConditionValue `json:"value"`
+}
+
+// EntityManagementEventBridgeConditionValue - A wrapper object that will contain exactly one of the possible condition types.
+type EntityManagementEventBridgeConditionValue struct {
+	// Array condition type.
+	Array EntityManagementArrayCondition `json:"array,omitempty"`
+	// Date condition type.
+	Date EntityManagementDateCondition `json:"date,omitempty"`
+	// A simple check for the existence of a field.
+	Exists bool `json:"exists,omitempty"`
+	// Numeric condition type.
+	Numeric EntityManagementNumericCondition `json:"numeric,omitempty"`
+	// String condition type.
+	String EntityManagementStringCondition `json:"string,omitempty"`
+}
+
+// EntityManagementEventBridgeRuleEntity - Event Bridge Rule entity type
+type EntityManagementEventBridgeRuleEntity struct {
+	// A list of conditions. All conditions in this list must be true for the rule to match (logical AND).
+	Conditions []EntityManagementEventBridgeCondition `json:"conditions"`
+	// An optional, user-defined description for the bridge rule.
+	Description string `json:"description,omitempty"`
+	// Whether this rule is enabled or not.
+	Enabled bool `json:"enabled"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A user-defined name for the bridge rule.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Defines the origin of the event this rule applies to. It specifies both the high-level event source and the specific entity name within that source.
+	SourceType EntityManagementEventBridgeSourceType `json:"sourceType"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The list of target actions to execute when an event matches the filter.
+	Targets []EntityManagementEventBridgeTarget `json:"targets"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementEventBridgeRuleEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementEventBridgeSourceType - Defines the origin of an event.
+type EntityManagementEventBridgeSourceType struct {
+	// The system from which the event originates.
+	Event EntityManagementEventBridgeEventSourceType `json:"event"`
+	// The specific name of the entity within the source system (e.g., 'WorkItem').
+	Name string `json:"name"`
+}
+
+// EntityManagementEventBridgeTarget - A target action to be executed when an event matches the rule.
+type EntityManagementEventBridgeTarget struct {
+	// A user-defined name for this target action within the rule.
+	Name string `json:"name"`
+	// The specific parameters for this target.
+	Parameters EntityManagementEventBridgeTargetParameters `json:"parameters"`
+	// The type of action this target performs. For V1, only WORKFLOW is supported.
+	Type EntityManagementEventBridgeTargetType `json:"type"`
+	// An optional condition evaluated before executing this target.
+	When string `json:"when,omitempty"`
+}
+
+// EntityManagementEventBridgeTargetParameters - A wrapper object containing parameters for one specific target type.
+type EntityManagementEventBridgeTargetParameters struct {
+	// Parameters for a WORKFLOW target. Populated only if type is WORKFLOW.
+	Workflow EntityManagementEventBridgeWorkflowTargetParameters `json:"workflow,omitempty"`
+}
+
+// EntityManagementEventBridgeWorkflowDefinitionType - Defines the workflow to execute.
+type EntityManagementEventBridgeWorkflowDefinitionType struct {
+	// Specifies the workflow to execute.
+	Name string `json:"name"`
+	// Specifies the scope at which the workflow is defined.
+	ScopeType EntityManagementEventBridgeWorkflowDefinitionScopeType `json:"scopeType,omitempty"`
+	// Specifies the version of the workflow to execute.
+	Version int `json:"version"`
+}
+
+// EntityManagementEventBridgeWorkflowInput - A simple key-value pair for workflow parameters (output).
+type EntityManagementEventBridgeWorkflowInput struct {
+	// The name of the input parameter.
+	Name string `json:"name"`
+	// The value of the input parameter.
+	Value string `json:"value"`
+}
+
+// EntityManagementEventBridgeWorkflowTargetParameters - Parameters specific to a WORKFLOW target.
+type EntityManagementEventBridgeWorkflowTargetParameters struct {
+	// Defines the workflow to execute.
+	Definition EntityManagementEventBridgeWorkflowDefinitionType `json:"definition"`
+	// A list of key-value pairs to pass as input parameters to the workflow.
+	Inputs []EntityManagementEventBridgeWorkflowInput `json:"inputs"`
+	// The scope in which the target workflow will be executed.
+	Scope EntityManagementScopedReference `json:"scope"`
+}
+
+// EntityManagementExecutionIssue - Rule execution issues
+type EntityManagementExecutionIssue struct {
+	// Machine-readable code specifying the type of error or status.
+	StatusCode EntityManagementStatusCode `json:"statusCode"`
+	// Human-readable message providing details about the error or status.
+	StatusMessage string `json:"statusMessage,omitempty"`
+}
+
+// EntityManagementExternalOwner - Owner of the repository
+type EntityManagementExternalOwner struct {
+	// External Owner ID of the repository.
+	ID string `json:"id"`
+	// Type of owner of the repository eg:- user,organisation etc.
+	Type EntityManagementExternalOwnerType `json:"type"`
+}
+
+// EntityManagementFederatedLogsPartitionEntity - Federated logs partition entity.
+type EntityManagementFederatedLogsPartitionEntity struct {
+	// Indicates if this log partition is active. When turned off, no new data will be routed to this partition, but existing data can still be queried.
+	Active bool `json:"active"`
+	// The optional retention policy for logs in this partition.
+	DataRetentionPolicy EntityManagementRetentionPolicy `json:"dataRetentionPolicy,omitempty"`
+	// The description of the log partition.
+	Description string `json:"description,omitempty"`
+	// The forwarder configuration specific to this partition.
+	ForwarderConfiguration EntityManagementPartitionForwarderConfiguration `json:"forwarderConfiguration,omitempty"`
+	// The health check status of this federated log partition. Indicates whether the partition and its dependencies are operating correctly.
+	HealthCheck EntityManagementPartitionHealthCheckStatus `json:"healthCheck,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Indicates if this log partition is the default partition.
+	IsDefault bool `json:"isDefault"`
+	// The lifecycle status of the log partition. This indicates the current stage of the entity lifecycle, which can help identify if there are any issues or if the partition is ready for use.
+	LifecycleStatus EntityManagementLifecycleStatusPartition `json:"lifecycleStatus"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the log partition. This corresponds to the partition/event type used in log queries.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The federated logs setup this partition belongs to.
+	Setup EntityManagementFederatedLogsSetupEntity `json:"setup"`
+	// Storage details for the log partition, including the associated table and data location URI.
+	Storage EntityManagementPartitionStorage `json:"storage"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementFederatedLogsPartitionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementFederatedLogsSetupEntity - Federated logs setup entity.
+type EntityManagementFederatedLogsSetupEntity struct {
+	// Indicates if this federated log setup is active. When turned off, no new data will be routed to this setup, but existing data can still be queried.
+	Active bool `json:"active"`
+	// The entity guid of the default log partition for this federated log setup. This is the partition where logs will be routed if they do not match any specific partition routing rules.
+	DefaultPartitionId int `json:"defaultPartitionId,omitempty"`
+	// The description of the federated log setup.
+	Description string `json:"description,omitempty"`
+	// The forwarder responsible for processing and routing logs for this setup.
+	Forwarder EntityManagementForwarder `json:"forwarder,omitempty"`
+	// The health check status of this federated log setup. Indicates whether the setup and its dependencies (connections, storage, etc.) are operating correctly.
+	HealthCheck EntityManagementSetupHealthCheckStatus `json:"healthCheck,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The lifecycle status of the federated log setup. This indicates the current stage of the entity lifecycle, which can help identify if there are any issues or if the setup is ready for use.
+	LifecycleStatus EntityManagementLifecycleStatusSetup `json:"lifecycleStatus"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the federated log setup.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The storage configuration for this setup, including cloud provider, bucket, database, and connections.
+	Storage EntityManagementSetupStorage `json:"storage"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementFederatedLogsSetupEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementFleetControlProperties - Properties specific to fleet control
+type EntityManagementFleetControlProperties struct {
+	// Agent deployment properties
+	AppliedDeployment EntityManagementAgentDeployment `json:"appliedDeployment,omitempty"`
+	// True is the Agent sent a disconnect message
+	DisconnectedReceived bool `json:"disconnectedReceived,omitempty"`
+	// Environment the agent is running in
+	Environment string `json:"environment,omitempty"`
+	// True if the Agent is up and healthy
+	Healthy bool `json:"healthy,omitempty"`
+	// Error message returned by the agent when it is unhealthy
+	LastError string `json:"lastError,omitempty"`
+	// Error message returned when the last remote configuration deploy is not successful
+	LastRemoteConfigError string `json:"lastRemoteConfigError,omitempty"`
+	// Status of the last remote configuration deploy
+	LastRemoteConfigStatus string `json:"lastRemoteConfigStatus,omitempty"`
+	// Timestamp indicating when the agent was started
+	StartTime *nrtime.EpochMilliseconds `json:"startTime,omitempty"`
+	// The UID of this agent
+	Uid string `json:"uid,omitempty"`
+	// Version of the agent
+	Version string `json:"version,omitempty"`
+}
+
+// EntityManagementFleetDeployment - Deprecated: A set of configurations that are currently deployed
+type EntityManagementFleetDeployment struct {
+	// A list of EntityGuid of Managed Entities selected for Canary deploy
+	CanaryManagedEntities []int `json:"canaryManagedEntities"`
+	// The number of configurations changed during this deployment
+	ConfigsChanged int `json:"configsChanged"`
+	// A list of configurations included in this deployment
+	ConfigurationVersions []int `json:"configurationVersions"`
+	// Deployment started
+	DeployedAt *nrtime.EpochMilliseconds `json:"deployedAt"`
+	// Deployment description
+	Description string `json:"description,omitempty"`
+	// The number of entities changed during this deployment
+	EntitiesChanged int `json:"entitiesChanged"`
+	// The number of managed entities changed during this deployment
+	ManagedEntitiesChanged int `json:"managedEntitiesChanged,omitempty"`
+	// The number of managed entities required to change during this deployment
+	ManagedEntitiesRequiredToChange int `json:"managedEntitiesRequiredToChange,omitempty"`
+	// Metadata containing identification of the user who created this deployment
+	Metadata EntityManagementUserMetadata `json:"metadata,omitempty"`
+	// Deployment name
+	Name string `json:"name"`
+	// Deployment status
+	Status string `json:"status,omitempty"`
+	// The number of supervised agent entities changed during this deployment
+	SupervisedAgentEntitiesChanged int `json:"supervisedAgentEntitiesChanged,omitempty"`
+	// The number of supervised agent entities required to change during this deployment
+	SupervisedAgentEntitiesRequiredToChange int `json:"supervisedAgentEntitiesRequiredToChange,omitempty"`
+}
+
+// EntityManagementFleetDeploymentEntity - A set of configurations that can be deployed to a fleet
+type EntityManagementFleetDeploymentEntity struct {
+	// Agents to deploy
+	Agents []EntityManagementAgentToDeploy `json:"agents"`
+	// A list of configurations included in this deployment
+	ConfigurationVersionList []EntityManagementDeploymentAgentConfigurationVersion `json:"configurationVersionList,omitempty"`
+	// Deprecated - Replaced by configurationVersionList
+	ConfigurationVersions []int `json:"configurationVersions"`
+	// Deployment description
+	Description string `json:"description,omitempty"`
+	// Deployment's Fleet ID
+	FleetId int `json:"fleetId"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Deployment name
+	Name string `json:"name"`
+	// Deployment phase
+	Phase EntityManagementFleetDeploymentPhase `json:"phase,omitempty"`
+	// Ring wise deployment status
+	RingsDeploymentTracker []EntityManagementRingDeploymentTracker `json:"ringsDeploymentTracker,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementFleetDeploymentEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementFleetEntity - A fleet of entities that are managed by NRAgentControl
+type EntityManagementFleetEntity struct {
+	// Object holds state of current deployment
+	CurrentDeployment EntityManagementFleetDeployment `json:"currentDeployment,omitempty"`
+	// User provided description for the fleet
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// CollectionEntity that associates rings of managed entities for Fleet
+	ManagedEntityRings EntityManagementCollectionEntity `json:"managedEntityRings,omitempty"`
+	// The type of entity the fleet will manage. e.g. HOST
+	ManagedEntityType EntityManagementManagedEntityType `json:"managedEntityType"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique user provided name for the fleet
+	Name string `json:"name"`
+	// The operating system type of the managed entities in this fleet
+	OperatingSystem EntityManagementOperatingSystem `json:"operatingSystem,omitempty"`
+	// Indicates this fleet has a specific product type
+	Product []string `json:"product"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementFleetEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementFleetRingEntity - A group of Managed Entities in a fleet to which a fleet deployment is applied
+type EntityManagementFleetRingEntity struct {
+	// Ring's Fleet ID
+	FleetId int `json:"fleetId"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// CollectionEntity associated with the ring
+	ManagedEntities EntityManagementCollectionEntity `json:"managedEntities,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementFleetRingEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementFlowEntity - An entity representing a Pathpoint flow entity containing stages, steps, and configuration stored in a blob.
+type EntityManagementFlowEntity struct {
+	// The Blob containing the pathpoint flow data.
+	Blob EntityManagementBlob `json:"blob,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementFlowEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementForwarder - The forwarder responsible for processing and routing logs.
+type EntityManagementForwarder struct {
+	// Configuration for a pipeline control forwarder. Populated when type is PIPELINE_CONTROL.
+	PipelineControl EntityManagementPipelineControlConfiguration `json:"pipelineControl,omitempty"`
+	// The type of forwarder used to process logs. Determines which configuration field is populated.
+	Type EntityManagementForwarderType `json:"type"`
+}
+
+// EntityManagementGenericEntity - A generic entity.
+type EntityManagementGenericEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementGenericEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementGitHubIntegrationEntity - An entity representing github integration information
+type EntityManagementGitHubIntegrationEntity struct {
+	// Composite count attribute encapsulating team and repo counts.
+	Count EntityManagementCount `json:"count,omitempty"`
+	// Options for retain entities with GitHub integration.
+	GitHubRetentionOptions EntityManagementGitHubRetentionOptions `json:"gitHubRetentionOptions,omitempty"`
+	// Github sync options for customer
+	GitHubSyncOptions EntityManagementGitHubSyncOptions `json:"gitHubSyncOptions,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The GitHub app installation ID.
+	InstallationId string `json:"installationId"`
+	// source of github integration installation
+	InstallationSource EntityManagementInstallationSource `json:"installationSource,omitempty"`
+	// installation status of the GitHub app
+	InstallationStatus EntityManagementInstallationStatus `json:"installationStatus,omitempty"`
+	// last sync completed timestamp
+	LastSyncCompletedAt *nrtime.EpochMilliseconds `json:"lastSyncCompletedAt,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// upcoming sync requested timestamp
+	NextSyncAt *nrtime.EpochMilliseconds `json:"nextSyncAt,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Synchronized GitHub teams for customer team selection.
+	SynchronizedGitHubTeams EntityManagementSynchronizedGitHubTeams `json:"synchronizedGitHubTeams,omitempty"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementGitHubIntegrationEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementGitHubRetentionOptions - Options for retaining entities with GitHub integration.
+type EntityManagementGitHubRetentionOptions struct {
+	// Whether to retain associated repositories
+	RetainRepositories bool `json:"retainRepositories,omitempty"`
+	// Whether to retain associated teams
+	RetainTeams bool `json:"retainTeams,omitempty"`
+}
+
+// EntityManagementGitHubSyncOptions - List of possible github sync options.
+type EntityManagementGitHubSyncOptions struct {
+	// Sync github repositories
+	SyncRepositories bool `json:"syncRepositories,omitempty"`
+	// Sync github teams
+	SyncTeams bool `json:"syncTeams,omitempty"`
+}
+
+// EntityManagementGitHubTeam - Type for GitHubTeam
+type EntityManagementGitHubTeam struct {
+	// The unique identifier of the GitHub team.
+	ID int `json:"id"`
+}
+
+// EntityManagementGitRepositoryEntity - An entity representing a Repository of a organization
+type EntityManagementGitRepositoryEntity struct {
+	// Count of closed pull requests(PR) in the repository.
+	ClosedPullRequestCount int `json:"closedPullRequestCount,omitempty"`
+	// The latest Configuration Item associated to the repository.  Contains a JSON representation of the repository configuration.
+	Configuration EntityManagementConfiguration `json:"configuration,omitempty"`
+	// The description of the repository.
+	Description string `json:"description,omitempty"`
+	// Repository Creation date at code hosting tool like github, gitlab etc
+	ExternalCreatedAt *nrtime.EpochMilliseconds `json:"externalCreatedAt,omitempty"`
+	// External Unique Identifier in Code hosting systems like github,gitlab etc.
+	ExternalId string `json:"externalId"`
+	// Last time the repository was deployed.
+	ExternalLastDeployedAt *nrtime.EpochMilliseconds `json:"externalLastDeployedAt,omitempty"`
+	// External owner of the repository.
+	ExternalOwner EntityManagementExternalOwner `json:"externalOwner,omitempty"`
+	// Repository Updation date at code hosting tool like github, gitlab etc
+	ExternalUpdatedAt *nrtime.EpochMilliseconds `json:"externalUpdatedAt,omitempty"`
+	// Number of times Repository has been forked.
+	ForkCount int `json:"forkCount,omitempty"`
+	// Source of the repository.
+	HostingPlatform EntityManagementHostingPlatform `json:"hostingPlatform,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Last release version of the repository.
+	LatestReleaseVersion string `json:"latestReleaseVersion,omitempty"`
+	// License associated with the repository
+	License EntityManagementRepositoryLicense `json:"license,omitempty"`
+	// Count of locked pull requests(PR) in the repository.
+	LockedPullRequestCount int `json:"lockedPullRequestCount,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// Count of open pull requests(PR) in the repository.
+	OpenPullRequestCount int `json:"openPullRequestCount,omitempty"`
+	// Most used language of the repository.
+	PrimaryLanguage string `json:"primaryLanguage,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+	// Source Url of the repository eg:- gitUrl.
+	URL string `json:"url"`
+}
+
+func (x *EntityManagementGitRepositoryEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementGithubAppTokenCredential - App token credential type for Github
+type EntityManagementGithubAppTokenCredential struct {
+	// The registered Github application ID, default to NewRelic Integration application
+	AppId string `json:"appId,omitempty"`
+	// The Github app installation ID.
+	InstallationId string `json:"installationId"`
+	// Default to NewRelic Integration privateKey, currently stored in Vault.
+	PrivateKeyReference EntityManagementSecretReference `json:"privateKeyReference"`
+	// The field name for the access token from the JSON response,  default to token
+	TokenFieldName string `json:"tokenFieldName,omitempty"`
+	// path to get an access token, default to app/installations/{installation-id}/access_tokens
+	TokenRelativeURL string `json:"tokenRelativeUrl,omitempty"`
+}
+
+// EntityManagementGithubConnection - Connection entity type for Github
+type EntityManagementGithubConnection struct {
+	// A single credential from the choice of GithubCredential
+	Credential EntityManagementGithubCredentials `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. True by default
+	Enabled bool `json:"enabled,omitempty"`
+	// Optional field representing an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// The entity’s scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Array of up to 2 SigningCredential to verify incoming requests, and rotate new signing credentials when needed
+	SigningCredentials []EntityManagementSigningCredential `json:"signingCredentials"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity’s type.
+	Type string `json:"type"`
+	// The Github API URL, default to https://api.github.com
+	URL string `json:"url,omitempty"`
+}
+
+func (x *EntityManagementGithubConnection) ImplementsEntityManagementEntity() {}
+
+// EntityManagementGithubCredentials - Base credentials type for Github
+type EntityManagementGithubCredentials struct {
+	// Github App token support with JWT
+	AppToken EntityManagementGithubAppTokenCredential `json:"appToken,omitempty"`
+	// A Github personal access token.
+	PersonalAccessToken EntityManagementSecretReference `json:"personalAccessToken,omitempty"`
+}
+
+// EntityManagementHealthCheckDetail - Result of an individual health check.
+type EntityManagementHealthCheckDetail struct {
+	// When this component was last checked.
+	LastUpdatedAt DateTime `json:"lastUpdatedAt"`
+	// Details about the failure, if any.
+	Message string `json:"message,omitempty"`
+	// Whether this specific check passed.
+	Status EntityManagementHealthCheckState `json:"status"`
+}
+
+// EntityManagementImpactProfileEntity - An entity representing impact profile.
+type EntityManagementImpactProfileEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique user provided name for the impact profile.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementImpactProfileEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementImpactQuery - Impact query containing NRQL query and account IDs for status page announcements.
+type EntityManagementImpactQuery struct {
+	// NRQL query string
+	NRQLQuery string `json:"nrqlQuery"`
+	// List of account IDs to query against
+	QueryAccountIds []int `json:"queryAccountIds"`
+}
+
+// EntityManagementInboxIssueCategoryEntity - Entity to represent category type configuration
+type EntityManagementInboxIssueCategoryEntity struct {
+	// Scope for this configuration
+	CategoryScope EntityManagementCategoryScope `json:"categoryScope"`
+	// New category Type. Start with capital letter.
+	CategoryType string `json:"categoryType"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// issue Type for category type. Should be pre-existed. New issue type have to be added manually in the code.
+	IssueType EntityManagementIssueType `json:"issueType"`
+	// Message attributes provided in order. Application will fall back to second then third and so on if previous attribute not found or null or empty.
+	MessageAttributes []string `json:"messageAttributes,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// Name attributes in order. Application will fall back to second then third and so on if previous attribute not found or null or empty.
+	NameAttributes []string `json:"nameAttributes"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementInboxIssueCategoryEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementIncidentAttachmentEntity - Represents a attachment entity used in incident
+type EntityManagementIncidentAttachmentEntity struct {
+	// Incident attachment Blob
+	Blob EntityManagementBlob `json:"blob"`
+	// An optional description of the attachment, generally additional context about the attachment
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementIncidentAttachmentEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementIncidentEntity - Entity of type IncidentEntity.
+type EntityManagementIncidentEntity struct {
+	// The primary entity (user or team) responsible for the WorkItem.
+	AssignedTo EntityManagementWorkItemAssignment `json:"assignedTo"`
+	// A flexible collection of key/value pair strings for storing domain-specific data.
+	Attributes []EntityManagementWorkItemAttribute `json:"attributes"`
+	// The high-level classification of the WorkItem (INCIDENT, ISSUE, VULNERABILITY, PERFORMANCE).
+	Category EntityManagementWorkItemCategory `json:"category,omitempty"`
+	// Customer Impact Description
+	CustomerImpact string `json:"customerImpact,omitempty"`
+	// Detailed explanation of the WorkItem.
+	Description string `json:"description,omitempty"`
+	// An optional Epoch timestamp indicating a potential due date (e.g., retrospective deadline).
+	DueDate *nrtime.EpochMilliseconds `json:"dueDate,omitempty"`
+	// Entities Impacted
+	EntitiesImpacted []string `json:"entitiesImpacted"`
+	// An optional, consumer-managed identifier (replaces incidentKey).
+	ExternalId string `json:"externalId,omitempty"`
+	// The entitys global unique identifier.
+	ID int `json:"id"`
+	// Primary classification of the incident (e.g., Network, Software). Max length: 64 characters.
+	IncidentCategory string `json:"incidentCategory,omitempty"`
+	// A public-facing, human-readable identifier for the incident.
+	IncidentKey string `json:"incidentKey"`
+	// The incident profile entity global unique identifier.
+	IncidentProfileId string `json:"incidentProfileId"`
+	// Secondary classification, dependent on the category. Max length: 64 characters.
+	IncidentSubcategory string `json:"incidentSubcategory,omitempty"`
+	// A list of issue links related to the incident
+	IssueLinks []string `json:"issueLinks"`
+	// An optional list of alphanumeric tags or keywords (replaces incidentTags).
+	Labels []string `json:"labels"`
+	// Key takeaways and lessons learned from the incident and its resolution.
+	LessonsLearned string `json:"lessonsLearned,omitempty"`
+	// A collection entity linking to external tickets or related documents.
+	Links EntityManagementCollectionEntity `json:"links,omitempty"`
+	// The maximum severity level reached during the incident lifecycle.
+	MaxSeverity string `json:"maxSeverity,omitempty"`
+	// A collection entity holding the stream of messages/notes (e.g., incident timeline).
+	Messages EntityManagementCollectionEntity `json:"messages,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name or title of the message.
+	Name string `json:"name"`
+	// The relative importance or urgency of the WorkItem.
+	Priority EntityManagementWorkItemPriority `json:"priority"`
+	// The end-user who reported the incident, if different from the creator.
+	ReportedBy string `json:"reportedBy,omitempty"`
+	// The category of the resolution (e.g., Code Fix, Configuration Change).
+	ResolutionCategory string `json:"resolutionCategory,omitempty"`
+	// A summary of the steps taken to resolve the incident.
+	ResolutionSummary string `json:"resolutionSummary,omitempty"`
+	// A list of references to work items that represent action items from the retrospective.
+	RetroActionItems []int `json:"retroActionItems"`
+	// A detailed summary of the root cause analysis findings.
+	RootCauseSummary string `json:"rootCauseSummary,omitempty"`
+	// Tags associated with the root cause for categorization and analysis.
+	RootCauseTags []string `json:"rootCauseTags"`
+	// The entitys scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Represents the severity level of the incident, Can be customer-configured.
+	Severity string `json:"severity"`
+	// The originating system that created the incident record. Slack, UI
+	Source EntityManagementIncidentSource `json:"source"`
+	// The workitem status. statuscan be customised for each <Domain>WorkItem independently, and can be a completely different set than the core status list
+	Status string `json:"status"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// Incident timelines
+	Timelines EntityManagementCollectionEntity `json:"timelines,omitempty"`
+	// The specific event or action that initiated the incident.
+	TriggeringEvent string `json:"triggeringEvent,omitempty"`
+	// The entitys type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementIncidentEntity) ImplementsEntityManagementEntity() {}
+
+func (x *EntityManagementIncidentEntity) ImplementsEntityManagementWorkItemV2() {}
+
+// EntityManagementIncidentLinkEntity - Entity representing an incident link.
+type EntityManagementIncidentLinkEntity struct {
+	// An optional external identifier for this link from a synced system.
+	ExternalId string `json:"externalId,omitempty"`
+	// The entitys global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name or title of the link.
+	Name string `json:"name"`
+	// The entitys scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The ID of the sync configuration that created this link.
+	SourceSyncConfigurationId int `json:"sourceSyncConfigurationId,omitempty"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entitys type.
+	Type string `json:"type"`
+	// The URL of the external resource.
+	URL string `json:"url"`
+}
+
+func (x *EntityManagementIncidentLinkEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementIncidentMessageEntity - Entity representing an incident message.
+type EntityManagementIncidentMessageEntity struct {
+	// The message content.
+	Content string `json:"content"`
+	// The encoding used for the message content.
+	ContentEncoding EntityManagementEncodingType `json:"contentEncoding"`
+	// The type of message content (e.g., TEXT, HTML, MARKDOWN).
+	ContentType EntityManagementMessageType `json:"contentType"`
+	// An optional external identifier for this message from a synced system.
+	ExternalId string `json:"externalId,omitempty"`
+	// The entitys global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name or title of the message.
+	Name string `json:"name"`
+	// The ID of the parent message if this is a reply or threaded message.
+	ParentId int `json:"parentId,omitempty"`
+	// The entitys scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The ID of the sync configuration that created this message.
+	SourceSyncConfigurationId int `json:"sourceSyncConfigurationId,omitempty"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entitys type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementIncidentMessageEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementIncidentProfileAttachmentEntity - Represents a attachment entity used in profile
+type EntityManagementIncidentProfileAttachmentEntity struct {
+	// Incident profile attachment Blob
+	Blob EntityManagementBlob `json:"blob"`
+	// An optional description of the attachment, generally additional context about the attachment
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementIncidentProfileAttachmentEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementIncidentProfileEntity - Incident profile entity
+type EntityManagementIncidentProfileEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the Incident Profile
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity's type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementIncidentProfileEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementIncidentTimelineEntity - Entity of type IncidentTimeline.
+type EntityManagementIncidentTimelineEntity struct {
+	// The content of the entry, which can include rich text formatting.
+	Content string `json:"content"`
+	// The type of entry (e.g., NOTE, PROPOSED_CHANGE, KEY_MOMENTS, STATE).
+	EntryType string `json:"entryType"`
+	// The entitys global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name or title of the message.
+	Name string `json:"name"`
+	// The entitys scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The source of the timeline entry
+	Source EntityManagementIncidentTimelineSource `json:"source"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entitys type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementIncidentTimelineEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementInfrastructureManager - Details related to an infrastructure manager
+type EntityManagementInfrastructureManager struct {
+	// The type of the manager
+	Type string `json:"type,omitempty"`
+	// The version of the manager
+	Version string `json:"version,omitempty"`
+}
+
+// EntityManagementJiraBasicAuthCredential - Basic auth credential type for Jira
+type EntityManagementJiraBasicAuthCredential struct {
+	// The Jira api token to authorize the API usage for read/create/update operations
+	APIKey EntityManagementSecretReference `json:"apiKey"`
+	// username to create the api token
+	Username EntityManagementSecretReference `json:"username"`
+}
+
+// EntityManagementJiraConnection - Connection entity type for Jira
+type EntityManagementJiraConnection struct {
+	// A single credential from the choice of JiraCredential
+	Credential EntityManagementJiraCredentials `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. True by default
+	Enabled bool `json:"enabled,omitempty"`
+	// Optional field representing an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// The entity’s scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Array of up to 2 SigningCredential to verify incoming requests, and rotate new signing credentials when needed
+	SigningCredentials []EntityManagementSigningCredential `json:"signingCredentials"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity’s type.
+	Type string `json:"type"`
+	// The Jira instance URL
+	URL string `json:"url"`
+}
+
+func (x *EntityManagementJiraConnection) ImplementsEntityManagementEntity() {}
+
+// EntityManagementJiraCredentials - Base credentials type for Jira
+type EntityManagementJiraCredentials struct {
+	// A simple api key credential
+	BasicAuth EntityManagementJiraBasicAuthCredential `json:"basicAuth,omitempty"`
+	// OAuth support
+	Oauth EntityManagementJiraOAuthCredential `json:"oauth,omitempty"`
+	// A personal access token credential
+	PersonalAccessToken EntityManagementSecretReference `json:"personalAccessToken,omitempty"`
+}
+
+// EntityManagementJiraOAuthCredential - OAuth credential type for Jira
+type EntityManagementJiraOAuthCredential struct {
+	// The client ID for the OAuth request
+	ClientId string `json:"clientId"`
+	// The client secret for the OAuth request
+	ClientSecret EntityManagementSecretReference `json:"clientSecret"`
+	// The field name for the oauth token from the JSON response, default to access_token
+	TokenFieldName string `json:"tokenFieldName,omitempty"`
+	// The Jira Atlassian URL to get an oauth token, default to https://auth.atlassian.com/oauth/token
+	TokenURL string `json:"tokenUrl,omitempty"`
+}
+
+// EntityManagementJiraSyncConfigurationV2Entity - Jira Sync Configuration entity type
+type EntityManagementJiraSyncConfigurationV2Entity struct {
+	// Direction of the sync, true for 2-way, false for 1-way from New Relic to Jira.
+	Bidirectional bool `json:"bidirectional"`
+	// A reference to a connection entity for the 3rd party ticketing system, using NGEP identifier.
+	Connection int `json:"connection"`
+	// Description of the sync configuration
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the sync is enabled or not
+	Enabled bool `json:"enabled"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The issue type of the Jira issue to be created: STORY, TASK, BUG
+	IssueType EntityManagementJiraIssueType `json:"issueType"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Sync configuration mode.
+	Mode EntityManagementSyncConfigurationMode `json:"mode"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The key of the Jira project where the issue will be created
+	ProjectKey string `json:"projectKey"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// A list of tags to match against a specific WorkItem set of tags to determine if the WorkItem should be synced.
+	Targets []EntityManagementTag `json:"targets"`
+	// The list of fields and their mapping from the WorkItem entity
+	TemplateFields []EntityManagementTemplateFieldType `json:"templateFields"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementJiraSyncConfigurationV2Entity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementJuniperMistBasicAuthCredential - Basic auth credential type for Juniper Mist
+type EntityManagementJuniperMistBasicAuthCredential struct {
+	// The API token to authorize API access
+	Token EntityManagementSecretReference `json:"token"`
+}
+
+// EntityManagementJuniperMistConnectionEntity - Connection entity type for Juniper Mist
+type EntityManagementJuniperMistConnectionEntity struct {
+	// A single credential for Juniper Mist
+	Credential EntityManagementJuniperMistCredential `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. True by default
+	Enabled bool `json:"enabled,omitempty"`
+	// Optional field representing an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// The Juniper Mist region (e.g., Global 01, Global 02, Global 03, Global 04)
+	Region string `json:"region"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Array of up to 2 SigningCredential to verify incoming requests, and rotate new signing credentials when needed
+	SigningCredentials []EntityManagementSigningCredential `json:"signingCredentials"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity's type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementJuniperMistConnectionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementJuniperMistCredential - Credential type for Juniper Mist
+type EntityManagementJuniperMistCredential struct {
+	// A simple token-based authentication
+	BasicAuth EntityManagementJuniperMistBasicAuthCredential `json:"basicAuth,omitempty"`
+}
+
+// EntityManagementLifecycleStatusPartition - Lifecycle status for a federated log partition.
+type EntityManagementLifecycleStatusPartition struct {
+	// When the lifecycle status was last updated.
+	LastUpdatedAt DateTime `json:"lastUpdatedAt"`
+	// Optional message providing additional context about the status.
+	Message string `json:"message,omitempty"`
+	// The current lifecycle state of the partition.
+	Status EntityManagementLifecycleStatePartition `json:"status"`
+}
+
+// EntityManagementLifecycleStatusSetup - Lifecycle status for a federated log setup.
+type EntityManagementLifecycleStatusSetup struct {
+	// When the lifecycle status was last updated.
+	LastUpdatedAt DateTime `json:"lastUpdatedAt"`
+	// Optional message providing additional context about the status.
+	Message string `json:"message,omitempty"`
+	// The current lifecycle state of the setup.
+	Status EntityManagementLifecycleStateSetup `json:"status"`
+}
+
+// EntityManagementLlmConfig - configurable details for the LLM
+type EntityManagementLlmConfig struct {
+	// Seed for reproducible output from LLM
+	CacheSeed string `json:"cacheSeed,omitempty"`
+	// LLM model name, for ex: gpt-4o
+	Model string `json:"model,omitempty"`
+	// LLM parameter for creative control, 0 for consistent output, 1 for more creative output
+	Temperature float64 `json:"temperature,omitempty"`
+}
+
+// EntityManagementMaintenanceWindowEntity - Represents Maintenance window entity.
+type EntityManagementMaintenanceWindowEntity struct {
+	// The type of the entities affected by maintenance window.
+	AffectedEntityType string `json:"affectedEntityType"`
+	// The description of the maintenance window.
+	Description string `json:"description,omitempty"`
+	// The duration of the maintenance window in ISO8601 duration formatted string.
+	Duration Duration `json:"duration"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The recurrence rule for the maintenance window.
+	Rrule string `json:"rrule,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The start of maintenance window in ISO8601 UTC formatted string.
+	StartTime DateTime `json:"startTime"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The timezone in which the maintenance window is scheduled.
+	Timezone string `json:"timezone"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementMaintenanceWindowEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementManagedEvaluationConfig - Configuration for a managed evaluation
+type EntityManagementManagedEvaluationConfig struct {
+	// Additional configuration parameters
+	AdditionalParameters []EntityManagementAdditionalParameter `json:"additionalParameters"`
+	// Whether the evaluation is enabled or disabled
+	Enabled bool `json:"enabled,omitempty"`
+	// The type of evaluation to perform
+	EvaluationType EntityManagementManagedEvaluationType `json:"evaluationType,omitempty"`
+	// Threshold value for the evaluation (0.0 to 1.0)
+	Threshold float64 `json:"threshold,omitempty"`
+}
+
+// EntityManagementManagedEvaluationsEntity - Experimental feature for managed evaluations
+type EntityManagementManagedEvaluationsEntity struct {
+	// The entity description.
+	Description string `json:"description,omitempty"`
+	// List of evaluation configurations for this entity
+	Evaluations []EntityManagementManagedEvaluationConfig `json:"evaluations"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique user provided name for the evaluation.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementManagedEvaluationsEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementMarkdownTextSplitterOptions - The MarkdownTextSplitter options
+type EntityManagementMarkdownTextSplitterOptions struct {
+	// Headers to split text on
+	HeadersToSplitOn []string `json:"headersToSplitOn"`
+	// Wether splitter should return each line
+	ReturnEachLine bool `json:"returnEachLine"`
+}
+
+// EntityManagementMcpServerAuth - Authentication configuration for an MCP server
+type EntityManagementMcpServerAuth struct {
+	// Bearer token value (required when type=BEARER_TOKEN)
+	BearerToken EntityManagementSecretReference `json:"bearerToken,omitempty"`
+	// Arbitrary header key (required when type=GENERIC_HEADER)
+	HeaderKey string `json:"headerKey,omitempty"`
+	// Arbitrary header value (required when type=GENERIC_HEADER)
+	HeaderValue EntityManagementSecretReference `json:"headerValue,omitempty"`
+	// Type of authentication to apply
+	Type EntityManagementMcpAuthType `json:"type"`
+}
+
+// EntityManagementMcpServerEntity - MCP Server entity for agentic-platform
+type EntityManagementMcpServerEntity struct {
+	// Authentication configuration for connecting to the MCP server
+	Auth EntityManagementMcpServerAuth `json:"auth,omitempty"`
+	// short description of the MCP server used for validation by agentic-platform
+	Description string `json:"description"`
+	// display name for the mcp server
+	DisplayName string `json:"displayName,omitempty"`
+	// Endpoint for the MCP server
+	Endpoint string `json:"endpoint"`
+	// entity's unique global indentifier
+	ID int `json:"id"`
+	// tool metadata
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// unique name of the MCP server used for validation by agentic-platform
+	Name string `json:"name"`
+	// Protocol version expected (if empty assume latest supported)
+	ProtocolVersion string `json:"protocolVersion,omitempty"`
+	// entity scope
+	Scope EntityManagementScopedReference `json:"scope"`
+	// collection of tags
+	Tags []EntityManagementTag `json:"tags"`
+	// Transport mechanism used to communicate with the server
+	Transport EntityManagementMcpTransport `json:"transport"`
+	// entity type
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementMcpServerEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementMetadata - Metadata about an entity.
+type EntityManagementMetadata struct {
+	// The entity's creation time.
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	// Actor that created this entity.
+	CreatedBy EntityManagementActorInterface `json:"createdBy,omitempty"`
+	// The entity's last update time.
+	UpdatedAt *nrtime.EpochMilliseconds `json:"updatedAt,omitempty"`
+	// Actor that updated this entity.
+	UpdatedBy EntityManagementActorInterface `json:"updatedBy,omitempty"`
+	// The entity current version. Use this value for concurrency control.
+	Version int `json:"version"`
+}
+
+// special
+func (x *EntityManagementMetadata) UnmarshalJSON(b []byte) error {
+	var objMap map[string]*json.RawMessage
+	err := json.Unmarshal(b, &objMap)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range objMap {
+		if v == nil {
+			continue
+		}
+
+		switch k {
+		case "createdAt":
+			err = json.Unmarshal(*v, &x.CreatedAt)
+			if err != nil {
+				return err
+			}
+		case "createdBy":
+			if v == nil {
+				continue
+			}
+			xxx, err := UnmarshalEntityManagementActorInterface(*v)
+			if err != nil {
+				return err
+			}
+
+			if xxx != nil {
+				x.CreatedBy = *xxx
+			}
+		case "updatedAt":
+			err = json.Unmarshal(*v, &x.UpdatedAt)
+			if err != nil {
+				return err
+			}
+		case "updatedBy":
+			if v == nil {
+				continue
+			}
+			xxx, err := UnmarshalEntityManagementActorInterface(*v)
+			if err != nil {
+				return err
+			}
+
+			if xxx != nil {
+				x.UpdatedBy = *xxx
+			}
+		case "version":
+			err = json.Unmarshal(*v, &x.Version)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// EntityManagementMeterAttribute - Meter attribute type
+type EntityManagementMeterAttribute struct {
+	// The name of the attribute
+	Name string `json:"name"`
+	// The value of the attribute
+	Values []string `json:"values"`
+}
+
+// EntityManagementMeterEntity - An entity representing a Meter used to report customer-driven usage and associated contextual data, primarily for billing.
+type EntityManagementMeterEntity struct {
+	// Collection of attributes associated with the meter.
+	Attributes []EntityManagementMeterAttribute `json:"attributes"`
+	// Human understandable 1 liner explaining the meter's purpose.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Reference to the meter type entity that defines how usage is calculated.
+	MeterType EntityManagementMeterTypeEntity `json:"meterType"`
+	// Human understandable identifier for the meter.
+	Name string `json:"name"`
+	// Reference to the owning team entity that is responsible for reporting usage with this meter.
+	OwningTeam EntityManagementTeamEntity `json:"owningTeam"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementMeterEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementMeterTypeEntity - A meter type defines a way of calculating usage and what dimensions are guaranteed to be reported with that usage.
+type EntityManagementMeterTypeEntity struct {
+	// Determines whether this meter type can be used to create meters.
+	AllowMeterCreation bool `json:"allowMeterCreation"`
+	// The names of dimensions that this meter type expects to report.
+	AttributionDimensions []string `json:"attributionDimensions"`
+	// Human understandable 1 liner explaining the meter type's purpose.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Human understandable identifier for the meter type.
+	Name string `json:"name"`
+	// Reference to the owning team entity that is responsible for this meter type.
+	OwningTeam EntityManagementTeamEntity `json:"owningTeam"`
+	// Reference to the product line entity that this meter type belongs to.
+	ProductLine EntityManagementProductLineEntity `json:"productLine"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementMeterTypeEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementNRQLMacroEntity - A reusable NRQL macro that can be substituted into NRQL queries to simplify complex or frequently-used query patterns.
+//
+// NRQL macros allow you to define query fragments that can be referenced and expanded in your queries, reducing
+// duplication and improving maintainability. For example, you might create a macro for filtering out test data,
+// calculating a specific metric, or defining commonly-used WHERE conditions.
+//
+// ## Example Macro Expression
+//
+// A macro for filtering production traffic:
+// ```
+// environment = 'production' AND appName NOT LIKE '%test%'
+// ```
+//
+// This macro could be used in WHERE clauses across multiple queries.
+//
+// For more information about NRQL, see [NRQL documentation](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language/).
+type EntityManagementNRQLMacroEntity struct {
+	// The NRQL expression that will be substituted when this macro is used in a query.
+	//
+	// This can be any valid NRQL fragment appropriate for the supported clause(s). Examples:
+	// - WHERE clause: `environment = 'production' AND appName NOT LIKE '%test%'`
+	// - SELECT clause: `average(duration) / 1000 as 'avgDurationSeconds'`
+	// - FACET clause: `appName, host`
+	Expression string `json:"expression"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// System-generated metadata about this macro entity, including creation time, last update time, and version information.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique, human-readable name for this macro. This name is used to identify and reference the macro.
+	//
+	// The name cannot be changed after creation. Choose a descriptive name that indicates the macro's purpose, such as 'filterProductionTraffic' or 'calculateApdex'.
+	Name string `json:"name"`
+	// The number of parameters used in the macro expression. Not required if the value is 0.
+	//
+	// Within the macro expression, parameters are referenced by index as $1, $2,...
+	NumParameters int `json:"numParameters,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Key-value pairs of tags. Tags are inherited from the Entity interface.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type identifier. Always returns 'NRQL_MACRO' for this entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementNRQLMacroEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementNRQLRuleEngine - NRQL engine configuration.
+type EntityManagementNRQLRuleEngine struct {
+	// The accounts to be queried.
+	Accounts []int `json:"accounts"`
+	// An optional list of accounts that are joined with 'accounts' when running the query.
+	JoinAccounts []int `json:"joinAccounts"`
+	// The query to be executed.
+	Query string `json:"query"`
+}
+
+// EntityManagementNewRelicBasicAuthCredential - Base credentials type for New Relic
+type EntityManagementNewRelicBasicAuthCredential struct {
+	// The New Relic api key to authorize the API usage for read/create/update operations
+	APIKey EntityManagementSecretReference `json:"apiKey"`
+	// Type of basic auth credential: Ingest or User
+	Type EntityManagementKeyType `json:"type"`
+}
+
+// EntityManagementNewRelicConnection - Connection entity type for New Relic
+type EntityManagementNewRelicConnection struct {
+	// A single credential from the choice of NewRelicCredential
+	Credential EntityManagementNewRelicBasicAuthCredential `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. True by default
+	Enabled bool `json:"enabled,omitempty"`
+	// Optional field representing an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// The NewRelic region
+	Region string `json:"region,omitempty"`
+	// The entity’s scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Array of up to 2 SigningCredential to verify incoming requests, and rotate new signing credentials when needed
+	SigningCredentials []EntityManagementSigningCredential `json:"signingCredentials"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity’s type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementNewRelicConnection) ImplementsEntityManagementEntity() {}
+
+// EntityManagementNotebookEntity - An entity representing a New Relic Notebook.
+type EntityManagementNotebookEntity struct {
+	// Configuration of the notebook, including the content of each of its blocks.
+	Content EntityManagementBlob `json:"content,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementNotebookEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementNotificationAttachmentEntity - Represents a attachment entity used in notifications
+type EntityManagementNotificationAttachmentEntity struct {
+	// Notification attachment Blob
+	Blob EntityManagementBlob `json:"blob"`
+	// An optional description of the attachment, generally additional context about the attachment
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementNotificationAttachmentEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementNrAiAgentEntity - This is Nr Ai Agent Entity, currently under development.
+type EntityManagementNrAiAgentEntity struct {
+	// display name of the agent
+	DisplayName string `json:"displayName"`
+	// entity's global identifier
+	ID int `json:"id"`
+	// agent metadata
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// unique name of the agent entity
+	Name string `json:"name"`
+	// entity scope
+	Scope EntityManagementScopedReference `json:"scope"`
+	// collection of tags
+	Tags []EntityManagementTag `json:"tags"`
+	// entity type
+	Type string `json:"type"`
+	// version of the AiAgent
+	Version string `json:"version"`
+}
+
+func (x *EntityManagementNrAiAgentEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementNumericCondition - Numeric condition type.
+type EntityManagementNumericCondition struct {
+	// Numeric condition type  operator.
+	Operator EntityManagementNumericOperator `json:"operator"`
+	// Value to compare against.
+	Value float64 `json:"value"`
+}
+
+// EntityManagementOperatingSystem - Operating System string enum for the host operating systems in a fleet
+type EntityManagementOperatingSystem struct {
+	// The operating system type enum
+	Type EntityManagementOperatingSystemType `json:"type"`
+}
+
+// EntityManagementOperationEntity - Entity of type OperationEntity.
+type EntityManagementOperationEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementOperationEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementOperationMetricEntity - Entity of type OperationMetricEntity.
+type EntityManagementOperationMetricEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementOperationMetricEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementPartitionForwarderConfiguration - Forwarder configuration for a partition.
+type EntityManagementPartitionForwarderConfiguration struct {
+	// Configuration for a pipeline control forwarder. Populated when type is PIPELINE_CONTROL.
+	PipelineControl EntityManagementPartitionPipelineControlConfiguration `json:"pipelineControl,omitempty"`
+	// The type of forwarder. Must match the forwarder type defined on the parent setup.
+	Type EntityManagementForwarderType `json:"type"`
+}
+
+// EntityManagementPartitionHealthCheckStatus - Health check status for a federated log partition.
+type EntityManagementPartitionHealthCheckStatus struct {
+	// End-to-end health check: logs were successfully sent, processed, stored, and queried for this partition.
+	End2endDataFlow EntityManagementHealthCheckDetail `json:"end2endDataFlow,omitempty"`
+	// When the health check status was last updated.
+	LastUpdatedAt DateTime `json:"lastUpdatedAt"`
+	// Health check for query connection (read access) credentials and accessibility for this partition.
+	QueryConnection EntityManagementHealthCheckDetail `json:"queryConnection,omitempty"`
+}
+
+// EntityManagementPartitionPipelineControlConfiguration - Configuration for a pipeline control forwarder for a partition.
+type EntityManagementPartitionPipelineControlConfiguration struct {
+	// The partition rule that determines how incoming logs are routed to this partition.
+	PartitionRule EntityManagementRule `json:"partitionRule,omitempty"`
+}
+
+// EntityManagementPartitionStorage - Storage details for a log partition. This information is used for querying and managing log data for the partition.
+type EntityManagementPartitionStorage struct {
+	// The URI location of the log partition in object storage.
+	DataLocationUri string `json:"dataLocationUri"`
+	// The table name associated with the log partition. This could refer to a data catalog table or similar structure.
+	Table string `json:"table"`
+}
+
+// EntityManagementPerformanceInboxSettingEntity - Performance inbox setting entity. This entity encompasses all the performance inbox settings.
+type EntityManagementPerformanceInboxSettingEntity struct {
+	// Collection of configs for performance inbox settings.
+	Config []EntityManagementConfig `json:"config"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The scope at which the thresholds are applied.
+	ThresholdScope EntityManagementThresholdScope `json:"thresholdScope"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementPerformanceInboxSettingEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementPipelineCloudRuleEntity - A rule applied to telemetry data to modify how it's processed in some way
+type EntityManagementPipelineCloudRuleEntity struct {
+	// Description of this pipeline cloud rule.
+	Description string `json:"description,omitempty"`
+	// The enabled boolean field used to enable or disable a Pipeline Cloud Rule (default value will be true)
+	Enabled bool `json:"enabled,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The NRQL string used to specify the action you want to take and data you want to take the specified action on.
+	NRQL NRQL `json:"nrql"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementPipelineCloudRuleEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementPipelineControlConfiguration - Configuration for a pipeline control forwarder.
+type EntityManagementPipelineControlConfiguration struct {
+	// The fleet entity used for deploying the pipeline configuration.
+	Fleet EntityManagementFleetEntity `json:"fleet"`
+	// The routing rule that determines how incoming logs are routed to this setup.
+	RoutingRule EntityManagementRule `json:"routingRule,omitempty"`
+}
+
+// EntityManagementPrincipal - A wrapper object that will contain exactly one of the possible identity types.
+type EntityManagementPrincipal struct {
+	// The principal identifier, typically userId
+	ID string `json:"id"`
+	// Enum represents type of identity.
+	Type EntityManagementPrincipalType `json:"type"`
+}
+
+// EntityManagementProcessState - At rest background processing types
+type EntityManagementProcessState struct {
+	// Message that indicates the process status
+	Message string `json:"message,omitempty"`
+	// Indicate the status of a process
+	Status EntityManagementProcessStatus `json:"status,omitempty"`
+}
+
+// EntityManagementProductLineEntity - A product line represents a grouping of related products or services within the organization.
+type EntityManagementProductLineEntity struct {
+	// Human understandable 1 liner explaining the product line's purpose.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Human understandable identifier for the product line.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementProductLineEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementProgressLevelDefinition - Defines a progress level within a scorecard.
+type EntityManagementProgressLevelDefinition struct {
+	// The level description.
+	Description string `json:"description,omitempty"`
+	// The hex code value for the color representing this level.
+	HexColorCode string `json:"hexColorCode,omitempty"`
+	// The id of the progress level this entity refers to.
+	ID int `json:"id"`
+	// The name of this level.
+	Name string `json:"name"`
+}
+
+// EntityManagementRagDocumentEntity - A RAG Document
+type EntityManagementRagDocumentEntity struct {
+	// The email addresses of authors not found in the organization
+	AuthorEmails []string `json:"authorEmails"`
+	// The blob representation of the document.
+	Blob EntityManagementBlob `json:"blob"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the document.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional source identifier that identifies where the document came from
+	SourceIdentifier string `json:"sourceIdentifier,omitempty"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementRagDocumentEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementRagToolEntity - A tool for use with NRAI
+type EntityManagementRagToolEntity struct {
+	// The description of the tool.
+	Description string `json:"description"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the tool
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementRagToolEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementReactNativeSourcemapEntity - entityType for React native sourcemaps
+type EntityManagementReactNativeSourcemapEntity struct {
+	// The version of the mobile application this source-map belongs to
+	AppVersionId string `json:"appVersionId"`
+	// The applicationId of the underlying mobile application this source-map belongs to
+	ApplicationID string `json:"applicationId"`
+	// The Blob associated to the entity.
+	Blob EntityManagementBlob `json:"blob,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The unique identifier for the JS bundle built for the mobile application this source-map belongs to
+	JsBundleId string `json:"jsBundleId"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity(sourcemap).
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementReactNativeSourcemapEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementReference - Points to where the complete budget limit definition is stored in an external system.
+type EntityManagementReference struct {
+	// The unique identifier of the budget limit within the specified location (e.g., 'coreCCU').
+	ID string `json:"id"`
+	// The system or platform where the complete budget limit is stored (e.g., 'Limits Platform').
+	Location string `json:"location"`
+}
+
+// EntityManagementRepositoryLicense - License associated with the repository
+type EntityManagementRepositoryLicense struct {
+	// License Name associated with the repository e.g:- MIT, GPL, apache2.0..
+	Name EntityManagementLicenseName `json:"name"`
+	// License Url associated with the repository
+	URL string `json:"url,omitempty"`
+}
+
+// EntityManagementRestAPIContractEntity - Entity of type RestApiContractEntity.
+type EntityManagementRestAPIContractEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of the Api Contract
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementRestAPIContractEntity) ImplementsEntityManagementAPICatalogAPIContract() {}
+
+func (x *EntityManagementRestAPIContractEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementRetentionPolicy - Retention policy for log data.
+type EntityManagementRetentionPolicy struct {
+	// The duration value for retention.
+	Duration int `json:"duration"`
+	// The time unit for the retention duration.
+	Unit EntityManagementRetentionUnit `json:"unit"`
+}
+
+// EntityManagementRingDeploymentTracker - A type for holding deployment status for a Ring
+type EntityManagementRingDeploymentTracker struct {
+	// Rollout end time
+	CompletedAt *nrtime.EpochMilliseconds `json:"completedAt,omitempty"`
+	// Ring name
+	Name string `json:"name"`
+	// Rollout start time
+	StartedAt *nrtime.EpochMilliseconds `json:"startedAt,omitempty"`
+	// Ring deployment status
+	Status string `json:"status"`
+}
+
+// EntityManagementRule - A routing rule consisting of a single OTTL expression that determines how logs are routed.
+type EntityManagementRule struct {
+	// OTTL expression for routing logs. e.g. attributes["cloud.provider"] == "aws"
+	Expression string `json:"expression"`
+}
+
+// EntityManagementRuleExecutionStatus - Rule execution status
+type EntityManagementRuleExecutionStatus struct {
+	// Checked entities count
+	CheckedEntities int `json:"checkedEntities,omitempty"`
+	// The timestamp of rule execution
+	ExecutedAt *nrtime.EpochMilliseconds `json:"executedAt,omitempty"`
+	// List detailing issues encountered during the rule execution
+	ExecutionIssues []EntityManagementExecutionIssue `json:"executionIssues,omitempty"`
+	// The status of the execution of the rule
+	ExecutionStatus EntityManagementExecutionStatus `json:"executionStatus"`
+}
+
+// EntityManagementSchedule - An attribute, that contains information about scheduler configuration
+type EntityManagementSchedule struct {
+	// An optional field stating the status of the schedule
+	Enabled bool `json:"enabled,omitempty"`
+	// An optional ISO 8601 timestamp serving as the anchor for RRULE recurrence calculation. Defaults to current time if not provided
+	FirstRunAt DateTime `json:"firstRunAt,omitempty"`
+	// An optional attribute unit is in minutes, with a minimum of 1 minute and a maximum of 1 year expressed in minutes
+	Period int `json:"period,omitempty"`
+	// An optional RFC 5545 RRULE string for complex, timezone-aware schedules (e.g., FREQ=MONTHLY;BYDAY=FR;BYSETPOS=-1). Mutually exclusive with period
+	Rrule string `json:"rrule,omitempty"`
+	// An optional attribute executes at once, with the date-time value in ISO 8601 format
+	ScheduleAt DateTime `json:"scheduleAt,omitempty"`
+	// An optional IANA timezone identifier (e.g., America/New_York) for DST-aware schedule calculations. Defaults to Etc/UTC
+	Timezone string `json:"timezone,omitempty"`
+}
+
+// EntityManagementScopedReference - An entity with scope.
+type EntityManagementScopedReference struct {
+	// The unique reference identifier of the an object within the given scope
+	ID int `json:"id"`
+	// The scope of the entity
+	Type EntityManagementEntityScope `json:"type"`
+}
+
+// EntityManagementScorecardEntity - An entity with collection of scorecard rules.
+type EntityManagementScorecardEntity struct {
+	// The scorecard description.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique user provided name for the scorecard.
+	Name string `json:"name"`
+	// Represents the different progress levels within a scorecard. A maximum of 5 progress levels are allowed.
+	ProgressLevels []EntityManagementProgressLevelDefinition `json:"progressLevels"`
+	// List of rules in the scorecard.
+	Rules EntityManagementCollectionEntity `json:"rules,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementScorecardEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementScorecardRuleEntity - An entity representing rule in scorecards.
+type EntityManagementScorecardRuleEntity struct {
+	// The rule description.
+	Description string `json:"description,omitempty"`
+	// Is rule enabled.
+	Enabled bool `json:"enabled"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The weight this rule has on the overall Scorecard Score. This number is a whole integer with valid values from 1 to 100.
+	ImpactWeight int `json:"impactWeight,omitempty"`
+	// Last execution status of the rule
+	LastExecutionStatus EntityManagementRuleExecutionStatus `json:"lastExecutionStatus,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The NRQL rule engine.
+	NRQLEngine EntityManagementNRQLRuleEngine `json:"nrqlEngine"`
+	// A unique user provided name for the rule
+	Name string `json:"name"`
+	// The id of the progress level this rule falls in. This id must match one of the existing ids in the parent Scorecard levels field.
+	ProgressLevel int `json:"progressLevel,omitempty"`
+	// The run interval in minutes. This defines how often the rule will be executed.
+	RunInterval int `json:"runInterval,omitempty"`
+	// Schedule configuration of the rule: only period configuration is currently supported.
+	Schedule EntityManagementSchedule `json:"schedule,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementScorecardRuleEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementSecretReference - Secret reference type
+type EntityManagementSecretReference struct {
+	// secret key name
+	KeyName string `json:"keyName"`
+	// namespace to store a secret
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// EntityManagementSegmentTermsEntity - Segment Terms for Mobile
+type EntityManagementSegmentTermsEntity struct {
+	// Mobile/Browser app entity id associated with the Segment Terms
+	AppEntityId string `json:"appEntityId"`
+	// Channel associated with the Segment Terms
+	Channel EntityManagementChannelType `json:"channel"`
+	// Domain associated with the Segment Terms
+	Domain string `json:"domain"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Metric Prefix associated with the Segment Terms
+	MetricPrefix string `json:"metricPrefix"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// Old Integer id for backward compatibility
+	OldId int `json:"oldId,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+	// Array of url segments as strings
+	URLSegments []string `json:"urlSegments"`
+}
+
+func (x *EntityManagementSegmentTermsEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementServerlessJobDefinitionEntity - Represents a ServerlessJobDefinition entity for the Job Primitive platform. Defines runtime properties, compute requirements, health checks and other parameters required for running serverless jobs.
+type EntityManagementServerlessJobDefinitionEntity struct {
+	// User provided description for the ServerlessJobDefinition.
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique user provided name for the ServerlessJobDefinition, can be utilized for ServerlessJobDefinition querying.
+	Name string `json:"name"`
+	// Namespace corresponding to the onboarding team for the ServerlessJobDefinition.
+	Namespace string `json:"namespace"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Secret key names associated with the ServerlessJobDefinition for secure configuration.
+	SecretKeys []string `json:"secretKeys"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementServerlessJobDefinitionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementServiceNowAPIKeyCredential - Basic auth credential type for ServiceNow
+type EntityManagementServiceNowAPIKeyCredential struct {
+	// The ServiceNow apiKey to authorize the API operations
+	APIKey EntityManagementSecretReference `json:"apiKey"`
+}
+
+// EntityManagementServiceNowConnection - Connection entity type for ServiceNow
+type EntityManagementServiceNowConnection struct {
+	// A single credential from the choice of ServiceNowCredential
+	Credential EntityManagementServiceNowCredentials `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. False by default.
+	Enabled bool `json:"enabled,omitempty"`
+	// Optional field representing an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Array of up to 2 SigningCredential to verify incoming requests, and rotate new signing credentials when needed
+	SigningCredentials []EntityManagementSigningCredential `json:"signingCredentials"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity's type.
+	Type string `json:"type"`
+	// The ServiceNow instance URL, for example https://your-instance.service-now.com
+	URL string `json:"url"`
+}
+
+func (x *EntityManagementServiceNowConnection) ImplementsEntityManagementEntity() {}
+
+// EntityManagementServiceNowCredentials - Base credentials type for ServiceNow
+type EntityManagementServiceNowCredentials struct {
+	// A simple basic auth credential
+	BasicAuth EntityManagementServiceNowAPIKeyCredential `json:"basicAuth,omitempty"`
+	// OAuth support
+	Oauth EntityManagementServiceNowOAuthCredential `json:"oauth,omitempty"`
+}
+
+// EntityManagementServiceNowOAuthCredential - OAuth credential type for ServiceNow
+type EntityManagementServiceNowOAuthCredential struct {
+	// The client ID for the OAuth request
+	ClientId string `json:"clientId"`
+	// The client secret for the OAuth request
+	ClientSecret EntityManagementSecretReference `json:"clientSecret"`
+	// The field name for the oauth token from the JSON response, default to access_token
+	TokenFieldName string `json:"tokenFieldName,omitempty"`
+	// The ServiceNow relative URL to get an oauth token, default to oauth_token.do
+	TokenRelativeURL string `json:"tokenRelativeUrl,omitempty"`
+}
+
+// EntityManagementSetupHealthCheckStatus - Health check status for a federated log setup.
+type EntityManagementSetupHealthCheckStatus struct {
+	// End-to-end health check: logs were successfully sent, processed, stored, and queried.
+	End2endDataFlow EntityManagementHealthCheckDetail `json:"end2endDataFlow,omitempty"`
+	// When the health check status was last updated.
+	LastUpdatedAt DateTime `json:"lastUpdatedAt"`
+	// Health check for query connection (read access) credentials and accessibility.
+	QueryConnection EntityManagementHealthCheckDetail `json:"queryConnection,omitempty"`
+}
+
+// EntityManagementSetupStorage - The storage configuration for a federated log setup.
+type EntityManagementSetupStorage struct {
+	// The cloud provider configuration for this federated log setup.
+	CloudProviderConfiguration EntityManagementCloudProviderConfiguration `json:"cloudProviderConfiguration"`
+	// The connection manager entity used for writing data for this federated log setup. Must match the cloudProvider type (e.g., AwsConnectionEntity for AWS, AzureConnectionEntity for Azure).
+	DataIngestConnection EntityManagementEntityInterface `json:"dataIngestConnection"`
+	// The object storage bucket where log data is stored.
+	DataLocationBucket string `json:"dataLocationBucket"`
+	// The database name associated with the federated log setup. This could refer to a data catalog database or similar structure.
+	Database string `json:"database"`
+	// The connection manager entity used by query workers for reading and accessing federated log resources. Must match the cloudProvider type (e.g., AwsConnectionEntity for AWS, AzureConnectionEntity for Azure) and typically has read-only permissions.
+	QueryConnection EntityManagementEntityInterface `json:"queryConnection"`
+}
+
+// special
+func (x *EntityManagementSetupStorage) UnmarshalJSON(b []byte) error {
+	var objMap map[string]*json.RawMessage
+	err := json.Unmarshal(b, &objMap)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range objMap {
+		if v == nil {
+			continue
+		}
+
+		switch k {
+		case "cloudProviderConfiguration":
+			err = json.Unmarshal(*v, &x.CloudProviderConfiguration)
+			if err != nil {
+				return err
+			}
+		case "dataIngestConnection":
+			if v == nil {
+				continue
+			}
+			xxx, err := UnmarshalEntityManagementEntityInterface(*v)
+			if err != nil {
+				return err
+			}
+
+			if xxx != nil {
+				x.DataIngestConnection = *xxx
+			}
+		case "dataLocationBucket":
+			err = json.Unmarshal(*v, &x.DataLocationBucket)
+			if err != nil {
+				return err
+			}
+		case "database":
+			err = json.Unmarshal(*v, &x.Database)
+			if err != nil {
+				return err
+			}
+		case "queryConnection":
+			if v == nil {
+				continue
+			}
+			xxx, err := UnmarshalEntityManagementEntityInterface(*v)
+			if err != nil {
+				return err
+			}
+
+			if xxx != nil {
+				x.QueryConnection = *xxx
+			}
+		}
+	}
+
+	return nil
+}
+
+// EntityManagementSignatureDetails - A set of signature details for a blob signature
+type EntityManagementSignatureDetails struct {
+	// The checksum of the blob
+	Checksum string `json:"checksum,omitempty"`
+	// The checksum algorithm used to calculate the checksum of the blob content
+	ChecksumAlgorithm string `json:"checksumAlgorithm,omitempty"`
+	// Id for the key used for signing
+	KeyID string `json:"keyId,omitempty"`
+	// Signature of the blob
+	Signature string `json:"signature,omitempty"`
+	// Signature algorithm specification
+	SignatureSpecification string `json:"signatureSpecification,omitempty"`
+	// Algorithm used for signing
+	SigningAlgorithm string `json:"signingAlgorithm,omitempty"`
+	// Domain associated to the private key used for signing
+	SigningDomain string `json:"signingDomain,omitempty"`
+}
+
+// EntityManagementSigningCredential - SigningCredential to verify incoming webhook request
+type EntityManagementSigningCredential struct {
+	// Signing algorithm for verifying signature
+	SigningAlgorithm EntityManagementSigningAlgorithm `json:"signingAlgorithm"`
+	// The signing key to use for verifying signature
+	SigningKeyReference EntityManagementSecretReference `json:"signingKeyReference"`
+}
+
+// EntityManagementSlackConnection - Connection entity type for Slack
+type EntityManagementSlackConnection struct {
+	// The Slack Application ID
+	AppId string `json:"appId"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. True by default
+	Enabled bool `json:"enabled,omitempty"`
+	// Optional field representing an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// The entity’s scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Array of up to 2 SigningCredential to verify incoming requests, and rotate new signing credentials when needed
+	SigningCredentials []EntityManagementSigningCredential `json:"signingCredentials"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// Slack bot token
+	Token EntityManagementSecretReference `json:"token"`
+	// The entity’s type.
+	Type string `json:"type"`
+	// Workspace name
+	Workspace string `json:"workspace"`
+}
+
+func (x *EntityManagementSlackConnection) ImplementsEntityManagementEntity() {}
+
+// EntityManagementStatusPageAnnouncementEntity - An entity representing an end of life announcement published on a status page.
+type EntityManagementStatusPageAnnouncementEntity struct {
+	// The entity category.
+	Category EntityManagementStatusPageAnnouncementCategory `json:"category"`
+	// Communications happened during the incident
+	CommunicationLogs []EntityManagementCommunicationLog `json:"communicationLogs,omitempty"`
+	// The incident description.
+	Description string `json:"description,omitempty"`
+	// Effective date time for the Announcement event
+	EffectiveDate *nrtime.EpochMilliseconds `json:"effectiveDate,omitempty"`
+	// Event URL for the announcement
+	EventURL string `json:"eventUrl,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Impact query for the announcement
+	ImpactQuery EntityManagementImpactQuery `json:"impactQuery,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Name for the event.
+	Name string `json:"name"`
+	// Valid User entities of PMs / Engineering point of contacts
+	PointOfContacts []EntityManagementUserEntity `json:"pointOfContacts"`
+	// Announcement event published date time
+	PublishedDate *nrtime.EpochMilliseconds `json:"publishedDate,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// The state of an announcement
+	State EntityManagementStatusPageAnnouncementState `json:"state"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementStatusPageAnnouncementEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementStatusPageIncidentEntity - An entity representing an incident published on a status page.
+type EntityManagementStatusPageIncidentEntity struct {
+	// Communications happened during the incident
+	CommunicationLogs []EntityManagementCommunicationLog `json:"communicationLogs"`
+	// The incident description.
+	Description string `json:"description,omitempty"`
+	// Incident end time
+	EndTime *nrtime.EpochMilliseconds `json:"endTime,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Incident Id
+	IncidentId int `json:"incidentId"`
+	// Incident title
+	IncidentTitle string `json:"incidentTitle"`
+	// Incident last updated time
+	LastUpdatedTime *nrtime.EpochMilliseconds `json:"lastUpdatedTime,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// A unique user provided name for the incident.
+	Name string `json:"name"`
+	// Incident impact region
+	Region []EntityManagementRegion `json:"region"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Incident start time
+	StartTime *nrtime.EpochMilliseconds `json:"startTime,omitempty"`
+	// The incident status.
+	Status EntityManagementIncidentStatus `json:"status"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementStatusPageIncidentEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementStringCondition - String condition type.
+type EntityManagementStringCondition struct {
+	// String condition type  operator.
+	Operator EntityManagementStringOperator `json:"operator"`
+	// Value to compare against.
+	Value string `json:"value"`
+}
+
+// EntityManagementSyncGroupRule - Rule to create teams from groups.
+type EntityManagementSyncGroupRule struct {
+	// The conditions of the rule.
+	Conditions []EntityManagementSyncGroupRuleCondition `json:"conditions"`
+}
+
+// EntityManagementSyncGroupRuleCondition - Sync group rule condition.
+type EntityManagementSyncGroupRuleCondition struct {
+	// The condition type.
+	Type EntityManagementSyncGroupRuleConditionType `json:"type"`
+	// The value to match.
+	Value string `json:"value"`
+}
+
+// EntityManagementSyncGroupsSettings - Groups sync related settings.
+type EntityManagementSyncGroupsSettings struct {
+	// If sync groups is enabled for that organization or not.
+	Enabled bool `json:"enabled"`
+	// The rules to create teams from groups.
+	Rules []EntityManagementSyncGroupRule `json:"rules"`
+}
+
+// EntityManagementSynchronizedGitHubTeams - Type for SynchronizedGitHubTeams
+type EntityManagementSynchronizedGitHubTeams struct {
+	// A list of GitHub teams selected by the customer
+	Teams []EntityManagementGitHubTeam `json:"teams"`
+}
+
+// EntityManagementSystemActor - A system actor.
+type EntityManagementSystemActor struct {
+	// Id of the actor.
+	ID int `json:"id"`
+	// Type of the actor.
+	Type EntityManagementActorType `json:"type"`
+}
+
+func (x *EntityManagementSystemActor) ImplementsEntityManagementActor() {}
+
+// EntityManagementTag - An entity tag.
+type EntityManagementTag struct {
+	// The key or name of the tag.
+	Key string `json:"key"`
+	// The list of values of the tag.
+	Values []string `json:"values"`
+}
+
+// EntityManagementTeamEntity - An entity representing a New Relic Team.
+type EntityManagementTeamEntity struct {
+	// List of aliases associated to the team.
+	Aliases []string `json:"aliases"`
+	// Further information about team.
+	Description string `json:"description,omitempty"`
+	// External Integration with another system.
+	ExternalIntegration EntityManagementTeamExternalIntegration `json:"externalIntegration,omitempty"`
+	// The hierarchy level the team belongs to.
+	HierarchyLevelId int `json:"hierarchyLevelId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// The managers or contact persons for the team.
+	Managers []int `json:"managers"`
+	// Collection that contains the list of members belonging to the team.
+	Membership EntityManagementCollectionEntity `json:"membership,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// Collection that contains the list of entities owned by the team.
+	Ownership EntityManagementCollectionEntity `json:"ownership,omitempty"`
+	// The parent team in the hierarchy.
+	ParentId int `json:"parentId,omitempty"`
+	// List of resources attached to the team.
+	Resources []EntityManagementTeamResource `json:"resources"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementTeamEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementTeamExternalIntegration - Integration with an external system.
+type EntityManagementTeamExternalIntegration struct {
+	// The id in the external system.
+	ExternalId int `json:"externalId"`
+	// The type of the Integration.
+	Type EntityManagementTeamExternalIntegrationType `json:"type,omitempty"`
+}
+
+// EntityManagementTeamResource - Any extra information attached to a Team.
+type EntityManagementTeamResource struct {
+	// Holds the content of the resource.
+	Content string `json:"content"`
+	// Main text for the resource, use the content if null.
+	Title string `json:"title,omitempty"`
+	// Type of resource, the UI might be enriched based on the value.
+	Type string `json:"type"`
+}
+
+// EntityManagementTeamsHierarchyLevelEntity - A teams hierarchy level for the organization.
+type EntityManagementTeamsHierarchyLevelEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// List of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementTeamsHierarchyLevelEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementTeamsOrganizationSettingsEntity - Teams global settings per organization.
+type EntityManagementTeamsOrganizationSettingsEntity struct {
+	// Discovery settings.
+	Discovery EntityManagementDiscoverySettings `json:"discovery,omitempty"`
+	// The order of the teams hierarchy levels for the organization.
+	HierarchyLevelOrder []int `json:"hierarchyLevelOrder"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Sync groups settings.
+	SyncGroups EntityManagementSyncGroupsSettings `json:"syncGroups,omitempty"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementTeamsOrganizationSettingsEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementTemplateFieldType - Mapping from the Work Item entity to the third party app fields
+type EntityManagementTemplateFieldType struct {
+	// Sync direction of the field: OUTBOUND, INBOUND
+	Direction EntityManagementSyncDirection `json:"direction"`
+	// The name of the external system field
+	Name string `json:"name"`
+	// Indicate if the field is required
+	Required bool `json:"required,omitempty"`
+	// Specify how to map from a Work Item using handlebar
+	Template string `json:"template,omitempty"`
+}
+
+// EntityManagementTokenTextSplitterOptions - The TokenTextSplitter options
+type EntityManagementTokenTextSplitterOptions struct {
+	// Encoding to token splitter
+	EncodingName EntityManagementEncodingName `json:"encodingName"`
+}
+
+// EntityManagementUserActor - A user actor.
+type EntityManagementUserActor struct {
+	// Id of the actor.
+	ID int `json:"id"`
+	// Type of the actor.
+	Type EntityManagementActorType `json:"type"`
+}
+
+func (x *EntityManagementUserActor) ImplementsEntityManagementActor() {}
+
+// EntityManagementUserEntity - An entity representing a New Relic User.
+type EntityManagementUserEntity struct {
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+	// User domain identifier.
+	UserID int `json:"userId"`
+}
+
+func (x *EntityManagementUserEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementUserMetadata - Deprecated: User Metadata
+type EntityManagementUserMetadata struct {
+	// The object creation time.
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	// The object last update time.
+	UpdatedAt *nrtime.EpochMilliseconds `json:"updatedAt,omitempty"`
+	// User ID that created this object.
+	UserID int `json:"userId,omitempty"`
+}
+
+// EntityManagementUsers - Object containing user limit configuration.
+type EntityManagementUsers struct {
+	// True if this is a global/default user budget, false otherwise.
+	AppliesToAll bool `json:"appliesToAll"`
+	// Array of all users whose resource consumption limits are managed by this specific Budget Entity instance.
+	Items []EntityManagementBudgetUser `json:"items"`
+}
+
+// EntityManagementWorkItemAssignment - Represents the assigned entity of a work item, typically a user
+type EntityManagementWorkItemAssignment struct {
+	// Depends on the type, for New Relic user this is a userID
+	Identifier string `json:"identifier"`
+	// Work item assignment type: NEW_RELIC_USER_ID, NEW_RELIC_TEAM_ID
+	Type EntityManagementAssignmentType `json:"type"`
+}
+
+// EntityManagementWorkItemAttribute - Work Item attribute type
+type EntityManagementWorkItemAttribute struct {
+	// The name of the attribute
+	Name string `json:"name"`
+	// The value of the attribute
+	Value string `json:"value"`
+}
+
+// EntityManagementWorkItemLinkV2 - Work Item Link interface
+type EntityManagementWorkItemLinkV2 struct {
+	// External identifier for the work item link
+	ExternalId string `json:"externalId,omitempty"`
+	// Indicates which syncConfigurationId if any created this link
+	SourceSyncConfigurationId int `json:"sourceSyncConfigurationId,omitempty"`
+	// URL of the work item link
+	URL string `json:"url"`
+}
+
+func (x *EntityManagementWorkItemLinkV2) ImplementsEntityManagementWorkItemLinkV2() {}
+
+// EntityManagementWorkItemLinkV2Entity - Work Item Link entity type
+type EntityManagementWorkItemLinkV2Entity struct {
+	// External identifier for the work item link
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Indicates which syncConfigurationId if any created this link. Creation managed internally from INBOUND sync
+	SourceSyncConfigurationId int `json:"sourceSyncConfigurationId,omitempty"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+	// URL of the work item link
+	URL string `json:"url"`
+}
+
+func (x *EntityManagementWorkItemLinkV2Entity) ImplementsEntityManagementEntity() {}
+
+func (x *EntityManagementWorkItemLinkV2Entity) ImplementsEntityManagementWorkItemLinkV2() {}
+
+// EntityManagementWorkItemMessageV2 - Work Item Message interface
+type EntityManagementWorkItemMessageV2 struct {
+	// The message content
+	Content string `json:"content"`
+	// The message encoding: UTF8(default), BASE64
+	ContentEncoding EntityManagementEncodingType `json:"contentEncoding"`
+	// The message type: TEXT(default), JSON, YAML
+	ContentType EntityManagementMessageType `json:"contentType"`
+	// Optional field representing an identifier managed by the consumer.
+	ExternalId string `json:"externalId,omitempty"`
+	// Optional id of the WorkItemMessage parent. This can be used to implement a replyTo functionality.
+	ParentId int `json:"parentId,omitempty"`
+	// Optional (internal readonly), indicate which syncConfigurationId if any created this message
+	SourceSyncConfigurationId int `json:"sourceSyncConfigurationId,omitempty"`
+}
+
+func (x *EntityManagementWorkItemMessageV2) ImplementsEntityManagementWorkItemMessageV2() {}
+
+// EntityManagementWorkItemMessageV2Entity - Work Item Message entity type
+type EntityManagementWorkItemMessageV2Entity struct {
+	// The message content
+	Content string `json:"content"`
+	// The message encoding: UTF8(default), BASE64
+	ContentEncoding EntityManagementEncodingType `json:"contentEncoding"`
+	// The message type: TEXT(default), JSON, YAML
+	ContentType EntityManagementMessageType `json:"contentType"`
+	// Optional field representing an identifier managed by the consumer. There is no unique constraint enforced since the field is optional with non unique default value (null).
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// Optional id of the WorkItemMessage parent. This can be used to implement a replyTo functionality.
+	ParentId int `json:"parentId,omitempty"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional (internal readonly), indicate which syncConfigurationId if any created this message. Creation managed internally from INBOUND sync
+	SourceSyncConfigurationId int `json:"sourceSyncConfigurationId,omitempty"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementWorkItemMessageV2Entity) ImplementsEntityManagementEntity() {}
+
+func (x *EntityManagementWorkItemMessageV2Entity) ImplementsEntityManagementWorkItemMessageV2() {}
+
+// EntityManagementWorkItemV2 - Work Item V2 interface
+type EntityManagementWorkItemV2 struct {
+	// Assigned entity of a work item
+	AssignedTo EntityManagementWorkItemAssignment `json:"assignedTo"`
+	// Collection of Work Item attributes
+	Attributes []EntityManagementWorkItemAttribute `json:"attributes"`
+	// Category of the Work Item
+	Category EntityManagementWorkItemCategory `json:"category,omitempty"`
+	// Description of the Work Item
+	Description string `json:"description,omitempty"`
+	// Optional Epoch timestamp in milliseconds to indicate a potential due date.
+	DueDate *nrtime.EpochMilliseconds `json:"dueDate,omitempty"`
+	// Represents an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// Optional list of label as alphanumeric string.
+	Labels []string `json:"labels"`
+	// Collection of Work Item Links
+	Links EntityManagementCollectionEntity `json:"links,omitempty"`
+	// Collection of Work Item messages
+	Messages EntityManagementCollectionEntity `json:"messages,omitempty"`
+	// Priority of the work item
+	Priority EntityManagementWorkItemPriority `json:"priority"`
+	// Status of the work item: OPEN, CLOSED
+	Status string `json:"status"`
+}
+
+func (x *EntityManagementWorkItemV2) ImplementsEntityManagementWorkItemV2() {}
+
+// EntityManagementWorkItemV2Entity - Work Item entity type
+type EntityManagementWorkItemV2Entity struct {
+	// Assigned entity of a work item
+	AssignedTo EntityManagementWorkItemAssignment `json:"assignedTo"`
+	// Collection of Work Item attributes
+	Attributes []EntityManagementWorkItemAttribute `json:"attributes"`
+	// Category of the Work Item. Can set a different value on Create, cannot change on Update
+	Category EntityManagementWorkItemCategory `json:"category,omitempty"`
+	// Description of the Work Item
+	Description string `json:"description,omitempty"`
+	// Optional Epoch timestamp in milliseconds to indicate a potential due date.
+	DueDate *nrtime.EpochMilliseconds `json:"dueDate,omitempty"`
+	// Represents an identifier managed by the consumer
+	ExternalId string `json:"externalId,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Optional list of label as alphanumeric string.
+	Labels []string `json:"labels"`
+	// Collection of Work Item Links
+	Links EntityManagementCollectionEntity `json:"links,omitempty"`
+	// Collection of Work Item messages
+	Messages EntityManagementCollectionEntity `json:"messages,omitempty"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of this entity.
+	Name string `json:"name"`
+	// Priority of the work item
+	Priority EntityManagementWorkItemPriority `json:"priority"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Status of the work item
+	Status string `json:"status"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementWorkItemV2Entity) ImplementsEntityManagementEntity() {}
+
+func (x *EntityManagementWorkItemV2Entity) ImplementsEntityManagementWorkItemV2() {}
+
+// EntityManagementWorkflowDefinition - Represents a workflow definition entity
+type EntityManagementWorkflowDefinition struct {
+	// An optional description of the workflow definition
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Unique name of the workflow definition
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity type.
+	Type string `json:"type"`
+	// An array of all the Versions of that definition
+	Versions []int `json:"versions"`
+}
+
+func (x *EntityManagementWorkflowDefinition) ImplementsEntityManagementEntity() {}
+
+// EntityManagementWorkflowDefinitionVersion - Represents a Workflow Definition version, uniquely identified by a combination of Workflow Definition ID and version number
+type EntityManagementWorkflowDefinitionVersion struct {
+	// The Workflow Definition ID
+	ID int `json:"id"`
+	// The Workflow Definition Version Number
+	Version int `json:"version"`
+}
+
+// EntityManagementWorkflowSchedule - Represents a workflow schedule entity
+type EntityManagementWorkflowSchedule struct {
+	// The cron expression that defines the schedule
+	CronExpression string `json:"cronExpression"`
+	// The Workflow Definition Version that this schedule is for
+	Definition EntityManagementWorkflowDefinitionVersion `json:"definition"`
+	// An optional description of the workflow schedule
+	Description string `json:"description,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// Workflow Schedule name
+	Name string `json:"name"`
+	// Overlap policy for the workflow schedule
+	OverlapPolicy EntityManagementOverlapPolicy `json:"overlapPolicy"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// An optional timezone of the workflow schedule.
+	Timezone string `json:"timezone,omitempty"`
+	// The entity type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementWorkflowSchedule) ImplementsEntityManagementEntity() {}
+
+// EntityManagementZoomAccountOAuthCredential - Account OAuth credential type for Zoom
+type EntityManagementZoomAccountOAuthCredential struct {
+	// The access token for the OAuth request
+	AccessToken EntityManagementSecretReference `json:"accessToken"`
+	// Zoom account ID associated with this credential
+	AccountID string `json:"accountId"`
+	// The client ID for the OAuth request
+	ClientId string `json:"clientId"`
+	// The client secret for the OAuth request
+	ClientSecret EntityManagementSecretReference `json:"clientSecret"`
+	// Expiration time for the access token
+	TokenExpirationTime *nrtime.EpochMilliseconds `json:"tokenExpirationTime"`
+}
+
+// EntityManagementZoomConnectionEntity - Connection entity type for Zoom
+type EntityManagementZoomConnectionEntity struct {
+	// A single credential from the choice of ZoomCredential
+	Credential EntityManagementZoomCredentials `json:"credential"`
+	// The description of that connection.
+	Description string `json:"description,omitempty"`
+	// Flag to indicate if the connection is enabled. False by default.
+	Enabled bool `json:"enabled,omitempty"`
+	// The entity's global unique identifier.
+	ID int `json:"id"`
+	// Metadata about the entity.
+	Metadata EntityManagementMetadata `json:"metadata"`
+	// The name of that connection.
+	Name string `json:"name"`
+	// The entity's scope.
+	Scope EntityManagementScopedReference `json:"scope"`
+	// Optional list of connection settings
+	Settings []EntityManagementConnectionSettings `json:"settings"`
+	// Array of up to 2 SigningCredential to verify incoming requests, and rotate new signing credentials when needed
+	SigningCredentials []EntityManagementSigningCredential `json:"signingCredentials"`
+	// Collection of tags.
+	Tags []EntityManagementTag `json:"tags"`
+	// The entity's type.
+	Type string `json:"type"`
+}
+
+func (x *EntityManagementZoomConnectionEntity) ImplementsEntityManagementEntity() {}
+
+// EntityManagementZoomCredentials - Base credentials type for Zoom
+type EntityManagementZoomCredentials struct {
+	// Account OAuth support
+	AccountOAuth EntityManagementZoomAccountOAuthCredential `json:"accountOAuth,omitempty"`
+	// User OAuth support
+	UserOAuth EntityManagementZoomUserOAuthCredential `json:"userOAuth,omitempty"`
+}
+
+// EntityManagementZoomUserOAuthCredential - User OAuth credential type for Zoom
+type EntityManagementZoomUserOAuthCredential struct {
+	// The access token for the OAuth request
+	AccessToken EntityManagementSecretReference `json:"accessToken"`
+	// Expiration time for the access token
+	AccessTokenExpirationTime *nrtime.EpochMilliseconds `json:"accessTokenExpirationTime"`
+	// The client ID for the OAuth request
+	ClientId string `json:"clientId"`
+	// The client secret for the OAuth request
+	ClientSecret EntityManagementSecretReference `json:"clientSecret"`
+	// The refresh token for the OAuth request
+	RefreshToken EntityManagementSecretReference `json:"refreshToken"`
+	// Zoom user ID associated with this credential
+	UserID string `json:"userId"`
+}
+
+// EntityOutline - The `EntityOutline` interface object allows fetching basic entity data for many entities at a time.
+//
+// To understand more about entities and entity types, look at [our docs](https://docs.newrelic.com/docs/what-are-new-relic-entities).
+type EntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *EntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *EntityOutline) ImplementsEntityOutline() {}
+
+// EntitySearch - A data structure that contains the detailed response of an entity search.
+//
+// The direct search result is available through `results`. Information about the
+// query itself is available through `query`, `types`, and `count`.
+type EntitySearch struct {
+	// The number of entities returned by the entity search.
+	Count int `json:"count,omitempty"`
+	// A count of the Entity Search results faceted by a chosen set of criteria.
+	//
+	// Note: Unlike a NRQL facet, the facet results do not include entities where the facet value does not exist. Additionally, entities can be tagged with multiple tag values for one tag key. For these reasons, depending on the facet values chosen, the `counts` field will not always equal the `entitySearch.count` field.
+	Counts []EntitySearchCounts `json:"counts,omitempty"`
+	// The entity search query string that was generated by the `query` argument or the `queryBuilder` argument.
+	Query string `json:"query,omitempty"`
+	// The paginated results of the entity search.
+	Results EntitySearchResult `json:"results,omitempty"`
+	// The entity types returned by the entity search.
+	Types []EntitySearchTypes `json:"types,omitempty"`
+}
+
+// EntitySearchCounts - The groupings and counts of entities returned for the specified criteria.
+type EntitySearchCounts struct {
+	// The number of entities that match the specified criteria.
+	Count int `json:"count,omitempty"`
+	// The group of entities returned for the specified criteria.
+	Facet AttributeMap `json:"facet,omitempty"`
+}
+
+// EntitySearchResult - A section of the entity search results. If there is a `nextCursor` present, there are more results available.
+type EntitySearchResult struct {
+	// The entities contained in this section of the entity search results.
+	//
+	// For information on New Relic entities, visit [our docs](https://docs.newrelic.com/docs/what-are-new-relic-entities).
+	//
+	// To see some query examples of entity information,
+	// visit [our entity GraphQL API docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities).
+	Entities []EntityOutlineInterface `json:"entities,omitempty"`
+	// The next cursor for fetching additional paginated entity search results.
+	NextCursor string `json:"nextCursor,omitempty"`
+}
+
+// special
+func (x *EntitySearchResult) UnmarshalJSON(b []byte) error {
+	var objMap map[string]*json.RawMessage
+	err := json.Unmarshal(b, &objMap)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range objMap {
+		if v == nil {
+			continue
+		}
+
+		switch k {
+		case "entities":
+			if v == nil {
+				continue
+			}
+			var rawMessageEntities []*json.RawMessage
+			err = json.Unmarshal(*v, &rawMessageEntities)
+			if err != nil {
+				return err
+			}
+
+			for _, m := range rawMessageEntities {
+				xxx, err := UnmarshalEntityOutlineInterface(*m)
+				if err != nil {
+					return err
+				}
+
+				if xxx != nil {
+					x.Entities = append(x.Entities, *xxx)
+				}
+			}
+		case "nextCursor":
+			err = json.Unmarshal(*v, &x.NextCursor)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// EntitySearchTypes - A detailed entity search response object type.
+type EntitySearchTypes struct {
+	// The number of results with this type.
+	Count int `json:"count,omitempty"`
+	// The domain of the search result group.
+	Domain string `json:"domain,omitempty"`
+	// The combined domain & type of the search result group.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The type of the search result group.
+	Type string `json:"type,omitempty"`
+}
+
+// EntityTag - A tag that has been applied to an entity.
+type EntityTag struct {
+	// The tag's key
+	Key string `json:"key,omitempty"`
+	// A list of the tag values
+	Values []string `json:"values,omitempty"`
+}
+
+// ExternalEntityOutline - An External entity outline.
+type ExternalEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *ExternalEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *ExternalEntityOutline) ImplementsEntityOutline() {}
+
+// GenericEntityOutline - A generic entity outline.
+type GenericEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *GenericEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *GenericEntityOutline) ImplementsEntityOutline() {}
+
+// GenericInfrastructureEntityOutline - An Infrastructure entity outline.
+type GenericInfrastructureEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	//
+	IntegrationTypeCode string `json:"integrationTypeCode,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *GenericInfrastructureEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *GenericInfrastructureEntityOutline) ImplementsEntityOutline() {}
+
+func (x *GenericInfrastructureEntityOutline) ImplementsInfrastructureIntegrationEntityOutline() {}
+
+// InfrastructureAwsLambdaFunctionEntityOutline - An AWS Lambda Function entity outline.
+type InfrastructureAwsLambdaFunctionEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	//
+	IntegrationTypeCode string `json:"integrationTypeCode,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	//
+	Runtime string `json:"runtime,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *InfrastructureAwsLambdaFunctionEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *InfrastructureAwsLambdaFunctionEntityOutline) ImplementsEntityOutline() {}
+
+func (x *InfrastructureAwsLambdaFunctionEntityOutline) ImplementsInfrastructureIntegrationEntityOutline() {
+}
+
+// InfrastructureHostEntityOutline - An Infrastructure Host entity outline.
+type InfrastructureHostEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	//
+	HostSummary InfrastructureHostSummaryData `json:"hostSummary,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *InfrastructureHostEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *InfrastructureHostEntityOutline) ImplementsEntityOutline() {}
+
+// InfrastructureHostSummaryData - Summary statistics about the Infra Host.
+type InfrastructureHostSummaryData struct {
+	// Total CPU utilization as a percentage.
+	CpuUtilizationPercent float64 `json:"cpuUtilizationPercent,omitempty"`
+	// The cumulative disk fullness percentage.
+	DiskUsedPercent float64 `json:"diskUsedPercent,omitempty"`
+	// Total memory utilization as a percentage.
+	MemoryUsedPercent float64 `json:"memoryUsedPercent,omitempty"`
+	// The number of bytes per second received during the sampling period.
+	NetworkReceiveRate float64 `json:"networkReceiveRate,omitempty"`
+	// The number of bytes sent per second during the sampling period.
+	NetworkTransmitRate float64 `json:"networkTransmitRate,omitempty"`
+	// Number of services running on the host.
+	ServicesCount int `json:"servicesCount,omitempty"`
+}
+
+// InfrastructureIntegrationEntityOutline -
+type InfrastructureIntegrationEntityOutline struct {
+	//
+	IntegrationTypeCode string `json:"integrationTypeCode,omitempty"`
+}
+
+func (x *InfrastructureIntegrationEntityOutline) ImplementsInfrastructureIntegrationEntityOutline() {}
+
+// KeyTransactionEntityOutline - A Key Transaction entity outline.
+type KeyTransactionEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *KeyTransactionEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *KeyTransactionEntityOutline) ImplementsEntityOutline() {}
+
+// MobileAppSummaryData - Mobile application summary data
+type MobileAppSummaryData struct {
+	// The number of times the app has been launched.
+	AppLaunchCount int `json:"appLaunchCount,omitempty"`
+	// The number of crashes.
+	CrashCount int `json:"crashCount,omitempty"`
+	// Crash rate is percentage of crashes per sessions.
+	CrashRate float64 `json:"crashRate,omitempty"`
+	// Error rate is the percentage of http errors per successful requests.
+	HttpErrorRate float64 `json:"httpErrorRate,omitempty"`
+	// The number of http requests.
+	HttpRequestCount int `json:"httpRequestCount,omitempty"`
+	// The rate of http requests per minute.
+	HttpRequestRate float64 `json:"httpRequestRate,omitempty"`
+	// The average response time for all http calls.
+	HttpResponseTimeAverage Seconds `json:"httpResponseTimeAverage,omitempty"`
+	// The number of mobile sessions.
+	MobileSessionCount int `json:"mobileSessionCount,omitempty"`
+	// Network failure rate is the percentage of network failures per successful requests.
+	NetworkFailureRate float64 `json:"networkFailureRate,omitempty"`
+	// The number of users affected by crashes.
+	UsersAffectedCount int `json:"usersAffectedCount,omitempty"`
+}
+
+// MobileApplicationEntityOutline - A Mobile Application entity outline.
+type MobileApplicationEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The ID of the Mobile App.
+	ApplicationID int `json:"applicationId,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// Summary statistics about the Mobile App.
+	MobileSummary MobileAppSummaryData `json:"mobileSummary,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *MobileApplicationEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *MobileApplicationEntityOutline) ImplementsEntityOutline() {}
+
+// NerdStorageCollectionMember -
+type NerdStorageCollectionMember struct {
+	// The NerdStorage document.
+	Document NerdStorageDocument `json:"document,omitempty"`
+	// The documentId.
+	ID string `json:"id,omitempty"`
+}
+
+// SecureCredentialEntityOutline - A secure credential entity outline.
+type SecureCredentialEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The description of the entity.
+	Description string `json:"description,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The domain-specific identifier for the entity.
+	SecureCredentialId int `json:"secureCredentialId,omitempty"`
+	// Summary statistics for the Synthetic Monitor Secure Credential.
+	SecureCredentialSummary SecureCredentialSummaryData `json:"secureCredentialSummary,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+	// The time at which the entity was last updated.
+	UpdatedAt *nrtime.EpochMilliseconds `json:"updatedAt,omitempty"`
+}
+
+func (x *SecureCredentialEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *SecureCredentialEntityOutline) ImplementsEntityOutline() {}
+
+// SecureCredentialSummaryData - Summary statistics for the Synthetic Monitor Secure Credential.
+type SecureCredentialSummaryData struct {
+	// The number of monitors that contain this secure credential and failed their last check.
+	FailingMonitorCount int `json:"failingMonitorCount,omitempty"`
+	// The number of monitors that contain this secure credential.
+	MonitorCount int `json:"monitorCount,omitempty"`
+}
+
+// ServiceLevelDefinition - The service level defined for a specific entity.
+type ServiceLevelDefinition struct {
+	// The SLIs attached to the entity.
+	Indicators []ServiceLevelIndicator `json:"indicators"`
+}
+
+// ServiceLevelEvents - The events that define the SLI.
+type ServiceLevelEvents struct {
+	// The New Relic account to fetch the events from.
+	Account accounts.AccountReference `json:"account,omitempty"`
+	// The definition of bad events.
+	BadEvents ServiceLevelEventsQuery `json:"badEvents,omitempty"`
+	// The definition of good events.
+	GoodEvents ServiceLevelEventsQuery `json:"goodEvents,omitempty"`
+	// The definition of valid events.
+	ValidEvents ServiceLevelEventsQuery `json:"validEvents"`
+}
+
+// ServiceLevelEventsQuery - The query that represents the events to fetch.
+type ServiceLevelEventsQuery struct {
+	// The NRQL FACET clause to group results by.
+	Facets []string `json:"facets"`
+	// The NRDB event to fetch the data from.
+	From NRQL `json:"from"`
+	// The NRQL SELECT clause to aggregate events.
+	Select ServiceLevelEventsQuerySelect `json:"select,omitempty"`
+	// The NRQL condition to filter the events.
+	Where NRQL `json:"where,omitempty"`
+}
+
+// ServiceLevelEventsQuerySelect - The resulting NRQL SELECT clause to aggregate events.
+type ServiceLevelEventsQuerySelect struct {
+	// The attribute used in the selected function.
+	Attribute string `json:"attribute,omitempty"`
+	// The function to use in the SELECT clause.
+	Function ServiceLevelEventsQuerySelectFunction `json:"function"`
+	// The threshold used in the selected function.
+	Threshold float64 `json:"threshold,omitempty"`
+}
+
+// ServiceLevelIndicator - The definition of the SLI.
+type ServiceLevelIndicator struct {
+	// The date when the SLI was created represented in the number of milliseconds since the Unix epoch.
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt"`
+	// The user who created the SLI.
+	CreatedBy users.UserReference `json:"createdBy,omitempty"`
+	// The description of the SLI.
+	Description string `json:"description,omitempty"`
+	// The entity which the SLI is attached to.
+	EntityGUID common.EntityGUID `json:"entityGuid"`
+	// The events that define the SLI.
+	Events ServiceLevelEvents `json:"events"`
+	// The unique entity identifier of the SLI.
+	GUID common.EntityGUID `json:"guid"`
+	// The unique identifier of the SLI.
+	ID int `json:"id"`
+	// The name of the SLI.
+	Name string `json:"name"`
+	// A list of objective definitions.
+	Objectives []ServiceLevelObjective `json:"objectives"`
+	// The resulting NRQL queries that help consume the metrics of the SLI.
+	ResultQueries ServiceLevelIndicatorResultQueries `json:"resultQueries,omitempty"`
+	// [DEPRECATED] The slug is deprecated and it will be removed from the schema as soon as possible.
+	Slug string `json:"slug"`
+	// The date when the SLI was last updated represented in the number of milliseconds since the Unix epoch.
+	UpdatedAt *nrtime.EpochMilliseconds `json:"updatedAt,omitempty"`
+	// The user who last update the SLI.
+	UpdatedBy users.UserReference `json:"updatedBy,omitempty"`
+}
+
+// ServiceLevelIndicatorResultQueries - The resulting NRQL queries that help consume the metrics of the SLI.
+type ServiceLevelIndicatorResultQueries struct {
+	// The NRQL query that measures the good events.
+	GoodEvents ServiceLevelResultQuery `json:"goodEvents"`
+	// The NRQL query that measures the value of the SLI.
+	Indicator ServiceLevelResultQuery `json:"indicator"`
+	// The NRQL query that measures the valid events.
+	ValidEvents ServiceLevelResultQuery `json:"validEvents"`
+}
+
+// ServiceLevelObjective - An objective definition.
+type ServiceLevelObjective struct {
+	// The description of the SLO.
+	Description string `json:"description,omitempty"`
+	// The name of the SLO.
+	Name string `json:"name,omitempty"`
+	// The resulting NRQL queries that help consume the metrics of the SLO.
+	ResultQueries ServiceLevelObjectiveResultQueries `json:"resultQueries,omitempty"`
+	// The target percentage of the SLO.
+	Target float64 `json:"target"`
+	// The time window configuration of the SLO.
+	TimeWindow ServiceLevelObjectiveTimeWindow `json:"timeWindow"`
+}
+
+// ServiceLevelObjectiveResultQueries - The resulting NRQL queries that help consume the metrics of the SLO.
+type ServiceLevelObjectiveResultQueries struct {
+	// The NRQL query that measures the attainment of the SLO target.
+	Attainment ServiceLevelResultQuery `json:"attainment"`
+}
+
+// ServiceLevelObjectiveRollingTimeWindow - The rolling time window configuration of the SLO.
+type ServiceLevelObjectiveRollingTimeWindow struct {
+	// The count of time units.
+	Count int `json:"count"`
+	// The time unit.
+	Unit ServiceLevelObjectiveRollingTimeWindowUnit `json:"unit"`
+}
+
+// ServiceLevelObjectiveTimeWindow - The time window configuration of the SLO.
+type ServiceLevelObjectiveTimeWindow struct {
+	// The rolling time window configuration of the SLO.
+	Rolling ServiceLevelObjectiveRollingTimeWindow `json:"rolling,omitempty"`
+}
+
+// ServiceLevelResultQuery - A resulting query.
+type ServiceLevelResultQuery struct {
+	// A NRQL query.
+	NRQL NRQL `json:"nrql"`
+}
+
+// SyntheticMonitorEntityOutline - A Synthetic Monitor entity outline.
+type SyntheticMonitorEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The Synthetic Monitor ID
+	MonitorId int `json:"monitorId,omitempty"`
+	// Summary statistics for the Synthetic Monitor.
+	MonitorSummary SyntheticMonitorSummaryData `json:"monitorSummary,omitempty"`
+	// The Synthetic Monitor type
+	MonitorType SyntheticMonitorType `json:"monitorType,omitempty"`
+	// The URL being monitored by a `SIMPLE` or `BROWSER` monitor type.
+	MonitoredURL string `json:"monitoredUrl,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The duration in minutes between Synthetic Monitor runs.
+	Period Minutes `json:"period,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *SyntheticMonitorEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *SyntheticMonitorEntityOutline) ImplementsEntityOutline() {}
+
+// SyntheticMonitorSummaryData - Summary statistics for the Synthetic Monitor.
+type SyntheticMonitorSummaryData struct {
+	// The number of locations that are currently failing.
+	LocationsFailing int `json:"locationsFailing,omitempty"`
+	// The number of locations that are currently running.
+	LocationsRunning int `json:"locationsRunning,omitempty"`
+	//
+	Status SyntheticMonitorStatus `json:"status,omitempty"`
+	// The percentage of successful synthetic monitor checks in the last 24 hours.
+	SuccessRate float64 `json:"successRate,omitempty"`
+}
+
+// TeamEntityOutline - A Team entity outline.
+type TeamEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *TeamEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *TeamEntityOutline) ImplementsEntityOutline() {}
+
+// ThirdPartyServiceEntityOutline - A third party service entity outline.
+type ThirdPartyServiceEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *ThirdPartyServiceEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *ThirdPartyServiceEntityOutline) ImplementsEntityOutline() {}
+
+// TimeWindowInput - Represents a time window input.
+type TimeWindowInput struct {
+	// The end time of the time window the number of milliseconds since the Unix epoch.
+	EndTime *nrtime.EpochMilliseconds `json:"endTime"`
+	// The start time of the time window the number of milliseconds since the Unix epoch.
+	StartTime *nrtime.EpochMilliseconds `json:"startTime"`
+}
+
+// UnavailableEntityOutline - An entity outline that is unavailable.
+type UnavailableEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+}
+
+func (x *UnavailableEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *UnavailableEntityOutline) ImplementsEntityOutline() {}
 
 // WorkloadAccountStitchedFields -
 type WorkloadAccountStitchedFields struct {
 	// [DEPRECATED] Retrieves a workload.
 	Collection WorkloadCollection `json:"collection,omitempty"`
 	// [DEPRECATED] Status and breakdown preview.
-	StatusBreakdownPreview WorkloadWorkloadStatus `json:"statusBreakdownPreview"`
+	StatusBreakdownPreview WorkloadWorkloadStatus `json:"statusBreakdownPreview,omitempty"`
+}
+
+// WorkloadAlertPolicyInput - An input object used to represent an alert policy status configuration. If not provided, a status configuration will be created by default.
+type WorkloadAlertPolicyInput struct {
+	// Whether the alert policy status configuration is enabled or not.
+	Enabled bool `json:"enabled"`
+}
+
+// WorkloadAlertPolicyStatus - The alert policy status configuration
+type WorkloadAlertPolicyStatus struct {
+	// Whether the alert policy status configuration is enabled or not.
+	Enabled bool `json:"enabled"`
 }
 
 // WorkloadAutomaticStatus - The automatic status configuration.
@@ -204,13 +7604,17 @@ type WorkloadAutomaticStatusInput struct {
 // WorkloadCollection - A user defined group of entities.
 type WorkloadCollection struct {
 	// The account the workload belongs to.
-	Account accounts.AccountReference `json:"account"`
+	Account accounts.AccountReference `json:"account,omitempty"`
 	// The moment when the object was created, represented in milliseconds since the Unix epoch.
 	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt"`
 	// The user who created the workload.
 	CreatedBy users.UserReference `json:"createdBy,omitempty"`
+	// The principal ID of the user or system identity who created the workload.
+	CreatedByPrincipalId string `json:"createdByPrincipalId,omitempty"`
 	// Relevant information about the workload.
 	Description string `json:"description,omitempty"`
+	// A list of dynamic flows used to retrieve entities based on different focal transactions. The resulting entities will be limited to the scope accounts of the collection.
+	DynamicFlows []WorkloadDynamicFlow `json:"dynamicFlows"`
 	// A list of entity GUIDs. These entities will belong to the collection as long as their accounts are included in the scope accounts of the collection.
 	Entities []WorkloadEntityRef `json:"entities"`
 	// A list of entity search queries. The resulting entities will be limited to the scope accounts of the collection.
@@ -235,12 +7639,16 @@ type WorkloadCollection struct {
 	UpdatedAt *nrtime.EpochMilliseconds `json:"updatedAt,omitempty"`
 	// The user who last updated the workload.
 	UpdatedBy users.UserReference `json:"updatedBy,omitempty"`
+	// The principal ID of the user or system identity who last updated the workload.
+	UpdatedByPrincipalId string `json:"updatedByPrincipalId,omitempty"`
 }
 
 // WorkloadCreateInput - The input object used to represent the workload to be created.
 type WorkloadCreateInput struct {
 	// Relevant information about the workload.
 	Description string `json:"description,omitempty"`
+	// A list of dynamic flows used to retrieve entities based on different focal transactions.
+	DynamicFlows []WorkloadDynamicFlowInput `json:"dynamicFlows,omitempty"`
 	// A list of entity GUIDs composing the workload.
 	EntityGUIDs []common.EntityGUID `json:"entityGuids"`
 	// A list of entity search queries used to retrieve the entities that compose the workload.
@@ -258,6 +7666,78 @@ type WorkloadDuplicateInput struct {
 	// The name of the workload duplicate. If the name isn't specified, the name + ' copy' of the source workload is used to compose the new name.
 	Name string `json:"name,omitempty"`
 }
+
+// WorkloadDynamicFlow - A dynamic flow used to dynamically retrieve a group of entities.
+type WorkloadDynamicFlow struct {
+	// The unique entity identifier of the entity in New Relic to which the focal transaction belongs to.
+	EntityGUID common.EntityGUID `json:"entityGuid"`
+	// The unique identifier of the dynamic flow.
+	ID int `json:"id"`
+	// The focal transaction's name.
+	TransactionName string `json:"transactionName"`
+}
+
+// WorkloadDynamicFlowInput - The input type for dynamic flow inputs.
+type WorkloadDynamicFlowInput struct {
+	// The unique entity identifier of the entity in New Relic to which the focal transaction belongs to.
+	EntityGUID common.EntityGUID `json:"entityGuid"`
+	// The unique identifier of the dynamic flow input. If not provided, a new dynamic flow is created.
+	ID int `json:"id,omitempty"`
+	// For criteriaType=TRANSACTION: The focal transaction's name.
+	TransactionName string `json:"transactionName"`
+}
+
+// WorkloadEntityOutline - A workload entity outline.
+type WorkloadEntityOutline struct {
+	//
+	Account AccountOutline `json:"account,omitempty"`
+	// The New Relic account ID associated with this entity.
+	AccountID int `json:"accountId,omitempty"`
+	// The current alerting severity of the entity.
+	AlertSeverity EntityAlertSeverity `json:"alertSeverity,omitempty"`
+	// When the workload was created.
+	CreatedAt *nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	// The user that created the workload.
+	CreatedByUser users.UserReference `json:"createdByUser,omitempty"`
+	// The entity's domain
+	Domain string `json:"domain,omitempty"`
+	// A value representing the combination of the entity's domain and type.
+	EntityType EntityType `json:"entityType,omitempty"`
+	// The date of last time the entity has updated any of its fields.
+	FirstIndexedAt *nrtime.EpochMilliseconds `json:"firstIndexedAt,omitempty"`
+	// A unique entity identifier.
+	GUID common.EntityGUID `json:"guid,omitempty"`
+	// The list of golden metrics for a specific entity
+	GoldenMetrics EntityGoldenContextScopedGoldenMetrics `json:"goldenMetrics,omitempty"`
+	// The list of golden tags for a specific entityType.
+	GoldenTags EntityGoldenContextScopedGoldenTags `json:"goldenTags,omitempty"`
+	// The time the entity was indexed.
+	IndexedAt *nrtime.EpochMilliseconds `json:"indexedAt,omitempty"`
+	// The last time the entity's reporting status changed.
+	LastReportingChangeAt *nrtime.EpochMilliseconds `json:"lastReportingChangeAt,omitempty"`
+	// The name of this entity.
+	Name string `json:"name,omitempty"`
+	// The url to the entity.
+	Permalink string `json:"permalink,omitempty"`
+	// The reporting status of the entity. If New Relic is successfully collecting data from your application, this will be true.
+	Reporting bool `json:"reporting,omitempty"`
+	// The service level defined for the entity.
+	ServiceLevel ServiceLevelDefinition `json:"serviceLevel,omitempty"`
+	// The tags applied to the entity.
+	//
+	// For details on tags, as well as query and mutation examples, visit [our docs](https://docs.newrelic.com/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+	Tags []EntityTag `json:"tags,omitempty"`
+	// The entity's type
+	Type string `json:"type,omitempty"`
+	// When the workload was last updated.
+	UpdatedAt *nrtime.EpochMilliseconds `json:"updatedAt,omitempty"`
+	// Status of the workload.
+	WorkloadStatus WorkloadStatus `json:"workloadStatus,omitempty"`
+}
+
+func (x *WorkloadEntityOutline) ImplementsAlertableEntityOutline() {}
+
+func (x *WorkloadEntityOutline) ImplementsEntityOutline() {}
 
 // WorkloadEntityRef - A reference to a New Relic entity.
 type WorkloadEntityRef struct {
@@ -459,6 +7939,8 @@ type WorkloadStatus struct {
 
 // WorkloadStatusConfig - The configuration that defines how the status of the workload is calculated.
 type WorkloadStatusConfig struct {
+	// An input object used to represent an alert policy configuration.
+	AlertPolicy WorkloadAlertPolicyStatus `json:"alertPolicy,omitempty"`
 	// An automatic status configuration.
 	Automatic WorkloadAutomaticStatus `json:"automatic,omitempty"`
 	// A list of static status configurations.
@@ -467,6 +7949,8 @@ type WorkloadStatusConfig struct {
 
 // WorkloadStatusConfigInput - The input object used to provide the configuration that defines how the status of the workload is calculated.
 type WorkloadStatusConfigInput struct {
+	// An input object used to represent an alert policy configuration.
+	AlertPolicy *WorkloadAlertPolicyInput `json:"alertPolicy,omitempty"`
 	// An input object used to represent an automatic status configuration.
 	Automatic *WorkloadAutomaticStatusInput `json:"automatic,omitempty"`
 	// A list of static status configurations. You can only configure one static status for a workload.
@@ -505,6 +7989,8 @@ type WorkloadUpdateCollectionEntitySearchQueryInput struct {
 type WorkloadUpdateInput struct {
 	// Relevant information about the workload.
 	Description string `json:"description,omitempty"`
+	// A list of dynamic flows used to retrieve entities based on different focal transactions.
+	DynamicFlows []WorkloadDynamicFlowInput `json:"dynamicFlows,omitempty"`
 	// A list of entity GUIDs composing the workload.
 	EntityGUIDs []common.EntityGUID `json:"entityGuids"`
 	// A list of entity search queries used to retrieve the groups of entities that compose the workload.
@@ -545,6 +8031,8 @@ type WorkloadUpdateStaticStatusInput struct {
 
 // WorkloadUpdateStatusConfigInput - The input object used to provide the configuration that defines how the status of the workload is calculated.
 type WorkloadUpdateStatusConfigInput struct {
+	// An input object used to represent an alert policy configuration.
+	AlertPolicy *WorkloadAlertPolicyInput `json:"alertPolicy,omitempty"`
 	// An input object used to represent an automatic status configuration.
 	Automatic *WorkloadUpdateAutomaticStatusInput `json:"automatic,omitempty"`
 	// A list of static status configurations. You can only configure one static status for a workload.
@@ -635,9 +8123,15 @@ type AttributeMap string
 // DateTime - The `DateTime` scalar represents a date and time. The `DateTime` appears as an ISO8601 formatted string.
 type DateTime string
 
+// Duration - The `Duration` scalar represents a period of time. A `Duration` appears as an ISO8601 formatted duration string.
+type Duration string
+
+// EntityManagementDynamicString - A string meant to be generated at runtime by a function in the form of a directive.
+type EntityManagementDynamicString string
+
 // Float - The `Float` scalar type represents signed double-precision fractional
 // values as specified by
-// [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
+// [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754).
 type Float string
 
 // ID - The `ID` scalar type represents a unique identifier, often used to
@@ -660,6 +8154,1771 @@ type NerdStorageDocument string
 
 // Seconds - The `Seconds` scalar represents a duration in seconds
 type Seconds string
+
+// SemVer - The `SemVer` scalar represents a version designation conforming to the SemVer specification.
+type SemVer string
+
+// AlertableEntityOutline -
+type AlertableEntityOutlineInterface interface {
+	ImplementsAlertableEntityOutline()
+}
+
+// UnmarshalAlertableEntityOutlineInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
+func UnmarshalAlertableEntityOutlineInterface(b []byte) (*AlertableEntityOutlineInterface, error) {
+	var err error
+
+	var rawMessageAlertableEntityOutline map[string]*json.RawMessage
+	err = json.Unmarshal(b, &rawMessageAlertableEntityOutline)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageAlertableEntityOutline) < 1 {
+		return nil, nil
+	}
+
+	var typeName string
+
+	if rawTypeName, ok := rawMessageAlertableEntityOutline["__typename"]; ok {
+		err = json.Unmarshal(*rawTypeName, &typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		switch typeName {
+		case "ApmApplicationEntityOutline":
+			var interfaceType ApmApplicationEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "ApmDatabaseInstanceEntityOutline":
+			var interfaceType ApmDatabaseInstanceEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "ApmExternalServiceEntityOutline":
+			var interfaceType ApmExternalServiceEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "BrowserApplicationEntityOutline":
+			var interfaceType BrowserApplicationEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "DashboardEntityOutline":
+			var interfaceType DashboardEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "ExternalEntityOutline":
+			var interfaceType ExternalEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "GenericEntityOutline":
+			var interfaceType GenericEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "GenericInfrastructureEntityOutline":
+			var interfaceType GenericInfrastructureEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "InfrastructureAwsLambdaFunctionEntityOutline":
+			var interfaceType InfrastructureAwsLambdaFunctionEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "InfrastructureHostEntityOutline":
+			var interfaceType InfrastructureHostEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "KeyTransactionEntityOutline":
+			var interfaceType KeyTransactionEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "MobileApplicationEntityOutline":
+			var interfaceType MobileApplicationEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "SecureCredentialEntityOutline":
+			var interfaceType SecureCredentialEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "SyntheticMonitorEntityOutline":
+			var interfaceType SyntheticMonitorEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "TeamEntityOutline":
+			var interfaceType TeamEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "ThirdPartyServiceEntityOutline":
+			var interfaceType ThirdPartyServiceEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "UnavailableEntityOutline":
+			var interfaceType UnavailableEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "WorkloadEntityOutline":
+			var interfaceType WorkloadEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx AlertableEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		}
+	} else {
+		keys := []string{}
+		for k := range rawMessageAlertableEntityOutline {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("interface AlertableEntityOutline did not include a __typename field for inspection: %s", keys)
+	}
+
+	return nil, fmt.Errorf("interface AlertableEntityOutline was not matched against all PossibleTypes: %s", typeName)
+}
+
+// ApmBrowserApplicationEntityOutline - The `ApmBrowserApplicationEntityOutline` interface provides detailed information for the Browser App injected by an APM Application.
+type ApmBrowserApplicationEntityOutlineInterface interface {
+	ImplementsApmBrowserApplicationEntityOutline()
+}
+
+// UnmarshalApmBrowserApplicationEntityOutlineInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
+func UnmarshalApmBrowserApplicationEntityOutlineInterface(b []byte) (*ApmBrowserApplicationEntityOutlineInterface, error) {
+	var err error
+
+	var rawMessageApmBrowserApplicationEntityOutline map[string]*json.RawMessage
+	err = json.Unmarshal(b, &rawMessageApmBrowserApplicationEntityOutline)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageApmBrowserApplicationEntityOutline) < 1 {
+		return nil, nil
+	}
+
+	var typeName string
+
+	if rawTypeName, ok := rawMessageApmBrowserApplicationEntityOutline["__typename"]; ok {
+		err = json.Unmarshal(*rawTypeName, &typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		switch typeName {
+		case "ApmApplicationEntityOutline":
+			var interfaceType ApmApplicationEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx ApmBrowserApplicationEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		}
+	} else {
+		keys := []string{}
+		for k := range rawMessageApmBrowserApplicationEntityOutline {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("interface ApmBrowserApplicationEntityOutline did not include a __typename field for inspection: %s", keys)
+	}
+
+	return nil, fmt.Errorf("interface ApmBrowserApplicationEntityOutline was not matched against all PossibleTypes: %s", typeName)
+}
+
+// EntityManagementAPICatalogAPIContract - Interface for Api Contract entities
+type EntityManagementAPICatalogAPIContractInterface interface {
+	ImplementsEntityManagementAPICatalogAPIContract()
+}
+
+// UnmarshalEntityManagementAPICatalogAPIContractInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
+func UnmarshalEntityManagementAPICatalogAPIContractInterface(b []byte) (*EntityManagementAPICatalogAPIContractInterface, error) {
+	var err error
+
+	var rawMessageEntityManagementAPICatalogAPIContract map[string]*json.RawMessage
+	err = json.Unmarshal(b, &rawMessageEntityManagementAPICatalogAPIContract)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageEntityManagementAPICatalogAPIContract) < 1 {
+		return nil, nil
+	}
+
+	var typeName string
+
+	if rawTypeName, ok := rawMessageEntityManagementAPICatalogAPIContract["__typename"]; ok {
+		err = json.Unmarshal(*rawTypeName, &typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		switch typeName {
+		case "EntityManagementRestApiContractEntity":
+			var interfaceType EntityManagementRestAPIContractEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementAPICatalogAPIContractInterface = &interfaceType
+
+			return &xxx, nil
+		}
+	} else {
+		keys := []string{}
+		for k := range rawMessageEntityManagementAPICatalogAPIContract {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("interface EntityManagementAPICatalogAPIContract did not include a __typename field for inspection: %s", keys)
+	}
+
+	return nil, fmt.Errorf("interface EntityManagementAPICatalogAPIContract was not matched against all PossibleTypes: %s", typeName)
+}
+
+// EntityManagementActor - Represents an actor.
+type EntityManagementActorInterface interface {
+	ImplementsEntityManagementActor()
+}
+
+// UnmarshalEntityManagementActorInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
+func UnmarshalEntityManagementActorInterface(b []byte) (*EntityManagementActorInterface, error) {
+	var err error
+
+	var rawMessageEntityManagementActor map[string]*json.RawMessage
+	err = json.Unmarshal(b, &rawMessageEntityManagementActor)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageEntityManagementActor) < 1 {
+		return nil, nil
+	}
+
+	var typeName string
+
+	if rawTypeName, ok := rawMessageEntityManagementActor["__typename"]; ok {
+		err = json.Unmarshal(*rawTypeName, &typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		switch typeName {
+		case "EntityManagementSystemActor":
+			var interfaceType EntityManagementSystemActor
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementActorInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementUserActor":
+			var interfaceType EntityManagementUserActor
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementActorInterface = &interfaceType
+
+			return &xxx, nil
+		}
+	} else {
+		keys := []string{}
+		for k := range rawMessageEntityManagementActor {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("interface EntityManagementActor did not include a __typename field for inspection: %s", keys)
+	}
+
+	return nil, fmt.Errorf("interface EntityManagementActor was not matched against all PossibleTypes: %s", typeName)
+}
+
+// EntityManagementEntity - The Entity interface.
+type EntityManagementEntityInterface interface {
+	ImplementsEntityManagementEntity()
+}
+
+// UnmarshalEntityManagementEntityInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
+func UnmarshalEntityManagementEntityInterface(b []byte) (*EntityManagementEntityInterface, error) {
+	var err error
+
+	var rawMessageEntityManagementEntity map[string]*json.RawMessage
+	err = json.Unmarshal(b, &rawMessageEntityManagementEntity)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageEntityManagementEntity) < 1 {
+		return nil, nil
+	}
+
+	var typeName string
+
+	if rawTypeName, ok := rawMessageEntityManagementEntity["__typename"]; ok {
+		err = json.Unmarshal(*rawTypeName, &typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		switch typeName {
+		case "EntityManagementAgentConfigurationEntity":
+			var interfaceType EntityManagementAgentConfigurationEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementAgentConfigurationVersionEntity":
+			var interfaceType EntityManagementAgentConfigurationVersionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementAgentEffectiveConfigurationEntity":
+			var interfaceType EntityManagementAgentEffectiveConfigurationEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementAgentEntity":
+			var interfaceType EntityManagementAgentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementAiAgentEntity":
+			var interfaceType EntityManagementAiAgentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementAiCapableEntity":
+			var interfaceType EntityManagementAiCapableEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementAiEvaluationConfigEntity":
+			var interfaceType EntityManagementAiEvaluationConfigEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementAiToolEntity":
+			var interfaceType EntityManagementAiToolEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementApiSpecificationBlobEntity":
+			var interfaceType EntityManagementAPISpecificationBlobEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementAwsConnectionEntity":
+			var interfaceType EntityManagementAwsConnectionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementAzureDevOpsConnectionEntity":
+			var interfaceType EntityManagementAzureDevOpsConnectionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementBackgroundProcessingRuleEntity":
+			var interfaceType EntityManagementBackgroundProcessingRuleEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementBackgroundSqlProcessingRuleEntity":
+			var interfaceType EntityManagementBackgroundSqlProcessingRuleEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementBudgetEntity":
+			var interfaceType EntityManagementBudgetEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementCiscoMerakiConnectionEntity":
+			var interfaceType EntityManagementCiscoMerakiConnectionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementCollectionEntity":
+			var interfaceType EntityManagementCollectionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementComponentEntity":
+			var interfaceType EntityManagementComponentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementComputeLocationEntity":
+			var interfaceType EntityManagementComputeLocationEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementConfluenceConnectionEntity":
+			var interfaceType EntityManagementConfluenceConnectionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementConfluenceIntegration":
+			var interfaceType EntityManagementConfluenceIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementConfluenceRagSettingsEntity":
+			var interfaceType EntityManagementConfluenceRagSettingsEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementCorrelationInternalSourceConfigEntity":
+			var interfaceType EntityManagementCorrelationInternalSourceConfigEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementCorrelationLinkEntity":
+			var interfaceType EntityManagementCorrelationLinkEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementCorrelationLinkingRuleEntity":
+			var interfaceType EntityManagementCorrelationLinkingRuleEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementCorrelationNormalizerEntity":
+			var interfaceType EntityManagementCorrelationNormalizerEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementCustomEvaluationEntity":
+			var interfaceType EntityManagementCustomEvaluationEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementCustomerImpactEntity":
+			var interfaceType EntityManagementCustomerImpactEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementCustomerImpactQueryEntity":
+			var interfaceType EntityManagementCustomerImpactQueryEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementEventBridgeRuleEntity":
+			var interfaceType EntityManagementEventBridgeRuleEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementFederatedLogsPartitionEntity":
+			var interfaceType EntityManagementFederatedLogsPartitionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementFederatedLogsSetupEntity":
+			var interfaceType EntityManagementFederatedLogsSetupEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementFleetDeploymentEntity":
+			var interfaceType EntityManagementFleetDeploymentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementFleetEntity":
+			var interfaceType EntityManagementFleetEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementFleetRingEntity":
+			var interfaceType EntityManagementFleetRingEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementFlowEntity":
+			var interfaceType EntityManagementFlowEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementGenericEntity":
+			var interfaceType EntityManagementGenericEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementGitHubIntegrationEntity":
+			var interfaceType EntityManagementGitHubIntegrationEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementGitRepositoryEntity":
+			var interfaceType EntityManagementGitRepositoryEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementGithubConnection":
+			var interfaceType EntityManagementGithubConnection
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementImpactProfileEntity":
+			var interfaceType EntityManagementImpactProfileEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementInboxIssueCategoryEntity":
+			var interfaceType EntityManagementInboxIssueCategoryEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementIncidentAttachmentEntity":
+			var interfaceType EntityManagementIncidentAttachmentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementIncidentEntity":
+			var interfaceType EntityManagementIncidentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementIncidentLinkEntity":
+			var interfaceType EntityManagementIncidentLinkEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementIncidentMessageEntity":
+			var interfaceType EntityManagementIncidentMessageEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementIncidentProfileAttachmentEntity":
+			var interfaceType EntityManagementIncidentProfileAttachmentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementIncidentProfileEntity":
+			var interfaceType EntityManagementIncidentProfileEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementIncidentTimelineEntity":
+			var interfaceType EntityManagementIncidentTimelineEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementJiraConnection":
+			var interfaceType EntityManagementJiraConnection
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementJiraSyncConfigurationV2Entity":
+			var interfaceType EntityManagementJiraSyncConfigurationV2Entity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementJuniperMistConnectionEntity":
+			var interfaceType EntityManagementJuniperMistConnectionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementMaintenanceWindowEntity":
+			var interfaceType EntityManagementMaintenanceWindowEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementManagedEvaluationsEntity":
+			var interfaceType EntityManagementManagedEvaluationsEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementMcpServerEntity":
+			var interfaceType EntityManagementMcpServerEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementMeterEntity":
+			var interfaceType EntityManagementMeterEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementMeterTypeEntity":
+			var interfaceType EntityManagementMeterTypeEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementNewRelicConnection":
+			var interfaceType EntityManagementNewRelicConnection
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementNotebookEntity":
+			var interfaceType EntityManagementNotebookEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementNotificationAttachmentEntity":
+			var interfaceType EntityManagementNotificationAttachmentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementNrAiAgentEntity":
+			var interfaceType EntityManagementNrAiAgentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementNrqlMacroEntity":
+			var interfaceType EntityManagementNRQLMacroEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementOperationEntity":
+			var interfaceType EntityManagementOperationEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementOperationMetricEntity":
+			var interfaceType EntityManagementOperationMetricEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementPerformanceInboxSettingEntity":
+			var interfaceType EntityManagementPerformanceInboxSettingEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementPipelineCloudRuleEntity":
+			var interfaceType EntityManagementPipelineCloudRuleEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementProductLineEntity":
+			var interfaceType EntityManagementProductLineEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementRagDocumentEntity":
+			var interfaceType EntityManagementRagDocumentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementRagToolEntity":
+			var interfaceType EntityManagementRagToolEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementReactNativeSourcemapEntity":
+			var interfaceType EntityManagementReactNativeSourcemapEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementRestApiContractEntity":
+			var interfaceType EntityManagementRestAPIContractEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementScorecardEntity":
+			var interfaceType EntityManagementScorecardEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementScorecardRuleEntity":
+			var interfaceType EntityManagementScorecardRuleEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementSegmentTermsEntity":
+			var interfaceType EntityManagementSegmentTermsEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementServerlessJobDefinitionEntity":
+			var interfaceType EntityManagementServerlessJobDefinitionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementServiceNowConnection":
+			var interfaceType EntityManagementServiceNowConnection
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementSlackConnection":
+			var interfaceType EntityManagementSlackConnection
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementStatusPageAnnouncementEntity":
+			var interfaceType EntityManagementStatusPageAnnouncementEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementStatusPageIncidentEntity":
+			var interfaceType EntityManagementStatusPageIncidentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementTeamEntity":
+			var interfaceType EntityManagementTeamEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementTeamsHierarchyLevelEntity":
+			var interfaceType EntityManagementTeamsHierarchyLevelEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementTeamsOrganizationSettingsEntity":
+			var interfaceType EntityManagementTeamsOrganizationSettingsEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementUserEntity":
+			var interfaceType EntityManagementUserEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementWorkItemLinkV2Entity":
+			var interfaceType EntityManagementWorkItemLinkV2Entity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementWorkItemMessageV2Entity":
+			var interfaceType EntityManagementWorkItemMessageV2Entity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementWorkItemV2Entity":
+			var interfaceType EntityManagementWorkItemV2Entity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementWorkflowDefinition":
+			var interfaceType EntityManagementWorkflowDefinition
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementWorkflowSchedule":
+			var interfaceType EntityManagementWorkflowSchedule
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementZoomConnectionEntity":
+			var interfaceType EntityManagementZoomConnectionEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementEntityInterface = &interfaceType
+
+			return &xxx, nil
+		}
+	} else {
+		keys := []string{}
+		for k := range rawMessageEntityManagementEntity {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("interface EntityManagementEntity did not include a __typename field for inspection: %s", keys)
+	}
+
+	return nil, fmt.Errorf("interface EntityManagementEntity was not matched against all PossibleTypes: %s", typeName)
+}
+
+// EntityManagementWorkItemLinkV2 - Work Item Link interface
+type EntityManagementWorkItemLinkV2Interface interface {
+	ImplementsEntityManagementWorkItemLinkV2()
+}
+
+// UnmarshalEntityManagementWorkItemLinkV2Interface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
+func UnmarshalEntityManagementWorkItemLinkV2Interface(b []byte) (*EntityManagementWorkItemLinkV2Interface, error) {
+	var err error
+
+	var rawMessageEntityManagementWorkItemLinkV2 map[string]*json.RawMessage
+	err = json.Unmarshal(b, &rawMessageEntityManagementWorkItemLinkV2)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageEntityManagementWorkItemLinkV2) < 1 {
+		return nil, nil
+	}
+
+	var typeName string
+
+	if rawTypeName, ok := rawMessageEntityManagementWorkItemLinkV2["__typename"]; ok {
+		err = json.Unmarshal(*rawTypeName, &typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		switch typeName {
+		case "EntityManagementWorkItemLinkV2Entity":
+			var interfaceType EntityManagementWorkItemLinkV2Entity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementWorkItemLinkV2Interface = &interfaceType
+
+			return &xxx, nil
+		}
+	} else {
+		keys := []string{}
+		for k := range rawMessageEntityManagementWorkItemLinkV2 {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("interface EntityManagementWorkItemLinkV2 did not include a __typename field for inspection: %s", keys)
+	}
+
+	return nil, fmt.Errorf("interface EntityManagementWorkItemLinkV2 was not matched against all PossibleTypes: %s", typeName)
+}
+
+// EntityManagementWorkItemMessageV2 - Work Item Message interface
+type EntityManagementWorkItemMessageV2Interface interface {
+	ImplementsEntityManagementWorkItemMessageV2()
+}
+
+// UnmarshalEntityManagementWorkItemMessageV2Interface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
+func UnmarshalEntityManagementWorkItemMessageV2Interface(b []byte) (*EntityManagementWorkItemMessageV2Interface, error) {
+	var err error
+
+	var rawMessageEntityManagementWorkItemMessageV2 map[string]*json.RawMessage
+	err = json.Unmarshal(b, &rawMessageEntityManagementWorkItemMessageV2)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageEntityManagementWorkItemMessageV2) < 1 {
+		return nil, nil
+	}
+
+	var typeName string
+
+	if rawTypeName, ok := rawMessageEntityManagementWorkItemMessageV2["__typename"]; ok {
+		err = json.Unmarshal(*rawTypeName, &typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		switch typeName {
+		case "EntityManagementWorkItemMessageV2Entity":
+			var interfaceType EntityManagementWorkItemMessageV2Entity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementWorkItemMessageV2Interface = &interfaceType
+
+			return &xxx, nil
+		}
+	} else {
+		keys := []string{}
+		for k := range rawMessageEntityManagementWorkItemMessageV2 {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("interface EntityManagementWorkItemMessageV2 did not include a __typename field for inspection: %s", keys)
+	}
+
+	return nil, fmt.Errorf("interface EntityManagementWorkItemMessageV2 was not matched against all PossibleTypes: %s", typeName)
+}
+
+// EntityManagementWorkItemV2 - Work Item V2 interface
+type EntityManagementWorkItemV2Interface interface {
+	ImplementsEntityManagementWorkItemV2()
+}
+
+// UnmarshalEntityManagementWorkItemV2Interface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
+func UnmarshalEntityManagementWorkItemV2Interface(b []byte) (*EntityManagementWorkItemV2Interface, error) {
+	var err error
+
+	var rawMessageEntityManagementWorkItemV2 map[string]*json.RawMessage
+	err = json.Unmarshal(b, &rawMessageEntityManagementWorkItemV2)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageEntityManagementWorkItemV2) < 1 {
+		return nil, nil
+	}
+
+	var typeName string
+
+	if rawTypeName, ok := rawMessageEntityManagementWorkItemV2["__typename"]; ok {
+		err = json.Unmarshal(*rawTypeName, &typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		switch typeName {
+		case "EntityManagementIncidentEntity":
+			var interfaceType EntityManagementIncidentEntity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementWorkItemV2Interface = &interfaceType
+
+			return &xxx, nil
+		case "EntityManagementWorkItemV2Entity":
+			var interfaceType EntityManagementWorkItemV2Entity
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityManagementWorkItemV2Interface = &interfaceType
+
+			return &xxx, nil
+		}
+	} else {
+		keys := []string{}
+		for k := range rawMessageEntityManagementWorkItemV2 {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("interface EntityManagementWorkItemV2 did not include a __typename field for inspection: %s", keys)
+	}
+
+	return nil, fmt.Errorf("interface EntityManagementWorkItemV2 was not matched against all PossibleTypes: %s", typeName)
+}
+
+// EntityOutline - The `EntityOutline` interface object allows fetching basic entity data for many entities at a time.
+//
+// To understand more about entities and entity types, look at [our docs](https://docs.newrelic.com/docs/what-are-new-relic-entities).
+type EntityOutlineInterface interface {
+	ImplementsEntityOutline()
+}
+
+// UnmarshalEntityOutlineInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
+func UnmarshalEntityOutlineInterface(b []byte) (*EntityOutlineInterface, error) {
+	var err error
+
+	var rawMessageEntityOutline map[string]*json.RawMessage
+	err = json.Unmarshal(b, &rawMessageEntityOutline)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageEntityOutline) < 1 {
+		return nil, nil
+	}
+
+	var typeName string
+
+	if rawTypeName, ok := rawMessageEntityOutline["__typename"]; ok {
+		err = json.Unmarshal(*rawTypeName, &typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		switch typeName {
+		case "ApmApplicationEntityOutline":
+			var interfaceType ApmApplicationEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "ApmDatabaseInstanceEntityOutline":
+			var interfaceType ApmDatabaseInstanceEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "ApmExternalServiceEntityOutline":
+			var interfaceType ApmExternalServiceEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "BrowserApplicationEntityOutline":
+			var interfaceType BrowserApplicationEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "DashboardEntityOutline":
+			var interfaceType DashboardEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "ExternalEntityOutline":
+			var interfaceType ExternalEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "GenericEntityOutline":
+			var interfaceType GenericEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "GenericInfrastructureEntityOutline":
+			var interfaceType GenericInfrastructureEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "InfrastructureAwsLambdaFunctionEntityOutline":
+			var interfaceType InfrastructureAwsLambdaFunctionEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "InfrastructureHostEntityOutline":
+			var interfaceType InfrastructureHostEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "KeyTransactionEntityOutline":
+			var interfaceType KeyTransactionEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "MobileApplicationEntityOutline":
+			var interfaceType MobileApplicationEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "SecureCredentialEntityOutline":
+			var interfaceType SecureCredentialEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "SyntheticMonitorEntityOutline":
+			var interfaceType SyntheticMonitorEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "TeamEntityOutline":
+			var interfaceType TeamEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "ThirdPartyServiceEntityOutline":
+			var interfaceType ThirdPartyServiceEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "UnavailableEntityOutline":
+			var interfaceType UnavailableEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "WorkloadEntityOutline":
+			var interfaceType WorkloadEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx EntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		}
+	} else {
+		keys := []string{}
+		for k := range rawMessageEntityOutline {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("interface EntityOutline did not include a __typename field for inspection: %s", keys)
+	}
+
+	return nil, fmt.Errorf("interface EntityOutline was not matched against all PossibleTypes: %s", typeName)
+}
+
+// InfrastructureIntegrationEntityOutline -
+type InfrastructureIntegrationEntityOutlineInterface interface {
+	ImplementsInfrastructureIntegrationEntityOutline()
+}
+
+// UnmarshalInfrastructureIntegrationEntityOutlineInterface unmarshals the interface into the correct type
+// based on __typename provided by GraphQL
+func UnmarshalInfrastructureIntegrationEntityOutlineInterface(b []byte) (*InfrastructureIntegrationEntityOutlineInterface, error) {
+	var err error
+
+	var rawMessageInfrastructureIntegrationEntityOutline map[string]*json.RawMessage
+	err = json.Unmarshal(b, &rawMessageInfrastructureIntegrationEntityOutline)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to unmarshal
+	if len(rawMessageInfrastructureIntegrationEntityOutline) < 1 {
+		return nil, nil
+	}
+
+	var typeName string
+
+	if rawTypeName, ok := rawMessageInfrastructureIntegrationEntityOutline["__typename"]; ok {
+		err = json.Unmarshal(*rawTypeName, &typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		switch typeName {
+		case "GenericInfrastructureEntityOutline":
+			var interfaceType GenericInfrastructureEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx InfrastructureIntegrationEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		case "InfrastructureAwsLambdaFunctionEntityOutline":
+			var interfaceType InfrastructureAwsLambdaFunctionEntityOutline
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx InfrastructureIntegrationEntityOutlineInterface = &interfaceType
+
+			return &xxx, nil
+		}
+	} else {
+		keys := []string{}
+		for k := range rawMessageInfrastructureIntegrationEntityOutline {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("interface InfrastructureIntegrationEntityOutline did not include a __typename field for inspection: %s", keys)
+	}
+
+	return nil, fmt.Errorf("interface InfrastructureIntegrationEntityOutline was not matched against all PossibleTypes: %s", typeName)
+}
 
 // WorkloadStatusResult - The details of a status that was involved in the calculation of the workload status.
 type WorkloadStatusResultInterface interface {

--- a/pkg/workloads/workloads_api.go
+++ b/pkg/workloads/workloads_api.go
@@ -60,7 +60,13 @@ const WorkloadCreateMutation = `mutation(
 		id
 		name
 	}
+	createdByPrincipalId
 	description
+	dynamicFlows {
+		entityGuid
+		id
+		transactionName
+	}
 	entities {
 		guid
 	}
@@ -113,6 +119,9 @@ const WorkloadCreateMutation = `mutation(
 		value
 	}
 	statusConfig {
+		alertPolicy {
+			enabled
+		}
 		automatic {
 			enabled
 			remainingEntitiesRule {
@@ -162,6 +171,7 @@ const WorkloadCreateMutation = `mutation(
 		id
 		name
 	}
+	updatedByPrincipalId
 } }`
 
 // Deletes an existing workload.
@@ -211,7 +221,13 @@ const WorkloadDeleteMutation = `mutation(
 		id
 		name
 	}
+	createdByPrincipalId
 	description
+	dynamicFlows {
+		entityGuid
+		id
+		transactionName
+	}
 	entities {
 		guid
 	}
@@ -264,6 +280,9 @@ const WorkloadDeleteMutation = `mutation(
 		value
 	}
 	statusConfig {
+		alertPolicy {
+			enabled
+		}
 		automatic {
 			enabled
 			remainingEntitiesRule {
@@ -313,6 +332,7 @@ const WorkloadDeleteMutation = `mutation(
 		id
 		name
 	}
+	updatedByPrincipalId
 } }`
 
 // Duplicates an existing workload.
@@ -374,7 +394,13 @@ const WorkloadDuplicateMutation = `mutation(
 		id
 		name
 	}
+	createdByPrincipalId
 	description
+	dynamicFlows {
+		entityGuid
+		id
+		transactionName
+	}
 	entities {
 		guid
 	}
@@ -427,6 +453,9 @@ const WorkloadDuplicateMutation = `mutation(
 		value
 	}
 	statusConfig {
+		alertPolicy {
+			enabled
+		}
 		automatic {
 			enabled
 			remainingEntitiesRule {
@@ -476,6 +505,7 @@ const WorkloadDuplicateMutation = `mutation(
 		id
 		name
 	}
+	updatedByPrincipalId
 } }`
 
 // Updates an existing workload.
@@ -531,7 +561,13 @@ const WorkloadUpdateMutation = `mutation(
 		id
 		name
 	}
+	createdByPrincipalId
 	description
+	dynamicFlows {
+		entityGuid
+		id
+		transactionName
+	}
 	entities {
 		guid
 	}
@@ -584,6 +620,9 @@ const WorkloadUpdateMutation = `mutation(
 		value
 	}
 	statusConfig {
+		alertPolicy {
+			enabled
+		}
 		automatic {
 			enabled
 			remainingEntitiesRule {
@@ -633,6 +672,7 @@ const WorkloadUpdateMutation = `mutation(
 		id
 		name
 	}
+	updatedByPrincipalId
 } }`
 
 // [DEPRECATED] Retrieves a workload.
@@ -683,7 +723,13 @@ const getCollectionQuery = `query(
 		id
 		name
 	}
+	createdByPrincipalId
 	description
+	dynamicFlows {
+		entityGuid
+		id
+		transactionName
+	}
 	entities {
 		guid
 	}
@@ -736,6 +782,9 @@ const getCollectionQuery = `query(
 		value
 	}
 	statusConfig {
+		alertPolicy {
+			enabled
+		}
 		automatic {
 			enabled
 			remainingEntitiesRule {
@@ -785,4 +834,5 @@ const getCollectionQuery = `query(
 		id
 		name
 	}
+	updatedByPrincipalId
 } } } } }`

--- a/pkg/workloads/workloads_api_integration_test.go
+++ b/pkg/workloads/workloads_api_integration_test.go
@@ -198,6 +198,134 @@ func TestIntegrationWorkloadGet(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestIntegrationWorkloadCreate_IntelligentWorkload(t *testing.T) {
+	t.Parallel()
+
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	testEntityGUID := common.EntityGUID(mock.IntegrationTestApplicationEntityGUIDNew)
+
+	testTransactionName, err := mock.GetTestTransactionName()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	client := newIntegrationTestClient(t)
+
+	name := "newrelic-client-go-test-intelligent-workload-" + mock.RandSeq(5)
+	workload := WorkloadCreateInput{
+		Name: name,
+		ScopeAccounts: &WorkloadScopeAccountsInput{
+			AccountIDs: []int{testAccountID},
+		},
+		DynamicFlows: []WorkloadDynamicFlowInput{
+			{
+				EntityGUID:      common.EntityGUID(testEntityGUID),
+				TransactionName: testTransactionName,
+			},
+		},
+		StatusConfig: &WorkloadStatusConfigInput{
+			AlertPolicy: &WorkloadAlertPolicyInput{
+				Enabled: true,
+			},
+		},
+	}
+
+	created, err := client.WorkloadCreate(testAccountID, workload)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	assert.Equal(t, name, created.Name)
+	assert.NotEmpty(t, created.GUID)
+	assert.Equal(t, testAccountID, created.Account.ID)
+	assert.Equal(t, 1, len(created.DynamicFlows))
+	assert.Equal(t, common.EntityGUID(testEntityGUID), created.DynamicFlows[0].EntityGUID)
+	assert.Equal(t, testTransactionName, created.DynamicFlows[0].TransactionName)
+	assert.True(t, created.StatusConfig.AlertPolicy.Enabled)
+
+	// Wait for indexing to catch up
+	time.Sleep(30 * time.Second)
+
+	// Cleanup
+	_, err = client.WorkloadDelete(common.EntityGUID(created.GUID))
+	require.NoError(t, err)
+}
+
+func TestIntegrationWorkloadUpdate_IntelligentWorkload(t *testing.T) {
+	t.Parallel()
+
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	testEntityGUID := common.EntityGUID(mock.IntegrationTestApplicationEntityGUIDNew)
+
+	testTransactionName, err := mock.GetTestTransactionName()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	client := newIntegrationTestClient(t)
+
+	name := "newrelic-client-go-test-intelligent-workload-" + mock.RandSeq(5)
+	workload := WorkloadCreateInput{
+		Name: name,
+		ScopeAccounts: &WorkloadScopeAccountsInput{
+			AccountIDs: []int{testAccountID},
+		},
+		DynamicFlows: []WorkloadDynamicFlowInput{
+			{
+				EntityGUID:      common.EntityGUID(testEntityGUID),
+				TransactionName: testTransactionName,
+			},
+		},
+		StatusConfig: &WorkloadStatusConfigInput{
+			AlertPolicy: &WorkloadAlertPolicyInput{
+				Enabled: true,
+			},
+		},
+	}
+
+	created, err := client.WorkloadCreate(testAccountID, workload)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	require.NotEmpty(t, created.GUID)
+
+	// Wait for indexing to catch up
+	time.Sleep(30 * time.Second)
+
+	// Update: rename and disable alert policy
+	updatedName := name + "-updated"
+	updated, err := client.WorkloadUpdate(created.GUID, WorkloadUpdateInput{
+		Name: updatedName,
+		DynamicFlows: []WorkloadDynamicFlowInput{
+			{
+				EntityGUID:      common.EntityGUID(testEntityGUID),
+				TransactionName: testTransactionName,
+			},
+		},
+		StatusConfig: &WorkloadUpdateStatusConfigInput{
+			AlertPolicy: &WorkloadAlertPolicyInput{
+				Enabled: false,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	assert.Equal(t, updatedName, updated.Name)
+	assert.Equal(t, 1, len(updated.DynamicFlows))
+	assert.False(t, updated.StatusConfig.AlertPolicy.Enabled)
+
+	// Cleanup
+	_, err = client.WorkloadDelete(common.EntityGUID(updated.GUID))
+	assert.NoError(t, err)
+}
+
 func newIntegrationTestClient(t *testing.T) Workloads {
 	cfg := mock.NewIntegrationTestConfig(t)
 	client := New(cfg)


### PR DESCRIPTION
Adds support for intelligent workloads in the workloads package, enabling callers to create and update workloads anchored to a transaction entry point via dynamic flows. New Relic auto-discovers related entities using Transaction 360 distributed tracing. If dynamicFlows is set alongside entityGuids or entitySearchQueries, dynamicFlows takes precedence, others will be ignored, and an intelligent workload is created.

  Changes

  .tutone.yml
  - Added WorkloadDynamicFlowInput, WorkloadUpdateDynamicFlowInput, WorkloadAlertPolicyInput, and WorkloadUpdateAlertPolicyInput to the workloads types: section so Tutone generates the correct structs from the NerdGraph schema

  types.go (Tutone-generated)
  - Added WorkloadDynamicFlow and WorkloadDynamicFlowInput structs (entityGuid, id, transactionName)
  - Added WorkloadAlertPolicyInput and WorkloadAlertPolicyStatus structs (enabled)
  - Added DynamicFlows []WorkloadDynamicFlowInput field to WorkloadCreateInput, WorkloadUpdateInput, and WorkloadCollection
  - Added AlertPolicy field to WorkloadStatusConfig, WorkloadStatusConfigInput, and WorkloadUpdateStatusConfigInput

  workloads_api.go (Tutone-generated)
  - Added dynamicFlows { entityGuid, id, transactionName } to all 5 GraphQL strings (WorkloadCreateMutation, WorkloadDeleteMutation, WorkloadDuplicateMutation, WorkloadUpdateMutation, getCollectionQuery)
  - Added alertPolicy { enabled } inside the statusConfig block in all 5 GraphQL strings

  pkg/testhelpers/helpers.go
  - Added GetTestEntityGUID() — reads NEW_RELIC_TEST_ENTITY_GUID env var
  - Added GetTestTransactionName() — reads NEW_RELIC_TEST_TRANSACTION_NAME env var
  - Added private getEnvString() helper

  Tests

  Integration Tests
  - TestIntegrationWorkloadCreate_IntelligentWorkload — creates an intelligent workload with DynamicFlows and AlertPolicy enabled, asserts all fields, cleans up
  - TestIntegrationWorkloadUpdate_IntelligentWorkload — creates an intelligent workload, updates name and disables AlertPolicy, asserts updated fields, cleans up

  Example
  - Example_intelligentWorkload() — demonstrates full create/update/delete lifecycle with DynamicFlows and StatusConfig.AlertPolicy

  Notes

  - types.go and workloads_api.go were regenerated via make generate-tutone after updating .tutone.yml with the 4 new types. Only the workloads package files are changed; all other packages were reverted.
  - A companion PR has been raised on https://github.com/newrelic/terraform-provider-newrelic adding dynamic_flows and status_config_alert_policy support to the newrelic_workload resource, which depends on this PR.