### PR TITLE
feat(cloud): add CloudOciTrustType for OCI RPST support (NR-562518)

### DIFF
--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -5650,10 +5650,27 @@ type CloudOciLinkAccountInput struct {
 	OciDomainURL string `json:"ociDomainUrl"`
 	// The home region of the tenancy.
 	OciHomeRegion string `json:"ociHomeRegion"`
+	// Optional value propagated as the ext_resource_tag claim on the RPST. Customers use this for tag-based resource scoping in their IAM policies. Ignored for UPST.
+	ResourceTag string `json:"resourceTag,omitempty"`
 	// The OCI tenant identifier.
 	TenantId string `json:"tenantId"`
+	// The OCI WIF trust type. Defaults to UPST for backward compatibility.
+	TrustType CloudOciTrustType `json:"trustType,omitempty"`
 	// The user secret OCID.
 	UserVaultOcid string `json:"userVaultOcid"`
+}
+
+// CloudOciTrustType - OCI WIF trust type. UPST impersonates a service user; RPST uses claim-based ephemeral principals.
+type CloudOciTrustType string
+
+var CloudOciTrustTypeTypes = struct {
+	// Resource Principal Session Token — exchange grants an ephemeral identityfederateddomainapp principal. Customer IAM policies authorize via JWT claims (ext_account_id, ext_tenancy_id, ext_resource_tag) instead of a service-user group, enabling multi-account scoping and bypassing OCI's per-policy statement limit.
+	RPST CloudOciTrustType
+	// User Principal Session Token — exchange grants impersonation of a dedicated OCI service user. Default for backward compatibility with existing integrations.
+	UPST CloudOciTrustType
+}{
+	RPST: "RPST",
+	UPST: "UPST",
 }
 
 // CloudOciLogsIntegration - Fetch Metadata and Tags for OCI Logs integrations Integration


### PR DESCRIPTION
## Summary

Adds opt-in **RPST (Resource Principal Session Token)** authentication alongside the existing UPST flow on the OCI cloud integration. Backward-compatible additive change — existing UPST callers see no behavior difference; RPST is opted into by setting `trustType` on `cloudLinkAccount`.

## Changes (pkg/cloud/types.go, +17 lines, single file)

- **`CloudOciTrustType` enum** with `UPST` and `RPST` values
- **`CloudOciLinkAccountInput.TrustType`** — optional, omitempty (UPST default)
- **`CloudOciLinkAccountInput.ResourceTag`** — optional, propagated as the `ext_resource_tag` claim on the RPST for tag-based IAM scoping; ignored for UPST

`OciUpdateAccountInput` intentionally does NOT receive these fields — trust type cannot be changed after creation; the corresponding terraform-provider resource enforces this via `ForceNew`.

## Why hand-curated diff (not a full regen)

The cloud package is shared across many teams. Running `tutone --packages=cloud --refetch` produces a 1500+ line diff that catches up multiple unrelated teams' upstream schema changes. Following the established repo pattern (e.g. PRs #1334 `add CloudOciLogsIntegration types`, #1300 `AWS SecurityHub integration`, #1344 `azure autodiscovery integration`), I've kept this PR scoped to just our team's additions matching tutone-generated output exactly. Verified by running `tutone --packages=cloud --refetch` against staging NerdGraph and confirming the new types are byte-identical to what's in this PR.

## Upstream chain

- ✅ api-v2 schema change merged + deployed to staging + production
- ✅ nerd-graph stitching PR merged + deployed to staging + production
- ⏳ This PR (newrelic-client-go) — gates the next one
- ⏳ terraform-provider-newrelic PR #3101 — needs a client-go release with these types

## NR Ticket

NR-562518

## Test plan

- [x] `make compile` — passes locally
- [x] `make test-unit` — passes locally
- [x] Verified hand-edited types match tutone output: ran `tutone --packages=cloud --refetch` against staging, confirmed `CloudOciTrustType`, `TrustType`, `ResourceTag` definitions are byte-identical
- [x] End-to-end staging E2E with terraform-provider-newrelic + this client-go: linked account `69088` registered with `trustType=RPST` against api-v2 staging, polling validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)