### PR TITLE
test(federated-logs): fix unit test signatures and mock JSON shape

### DIFF
--- a/pkg/federatedlogs/federatedlogs_unit_test.go
+++ b/pkg/federatedlogs/federatedlogs_unit_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testAccountID = 123456
+
 var (
 	testSetupID            = "ZmVkLWxvZ3Mtc2V0dXAtMTIzNDU2Nzg5MA"
 	testPartitionID        = "ZmVkLWxvZ3MtcGFydGl0aW9uLTEyMzQ1Njc4OTA"
@@ -161,8 +163,9 @@ var (
 	{
 		"data": {
 			"actor": {
-				"federatedLogs": {
-					"setup": {
+				"account": {
+					"federatedLogs": {
+						"setup": {
 						"id": "ZmVkLWxvZ3Mtc2V0dXAtMTIzNDU2Nzg5MA",
 						"name": "Test Setup",
 						"description": "Test federated logs setup",
@@ -185,14 +188,16 @@ var (
 				}
 			}
 		}
-	}`
+	}
+}`
 
 	testGetPartitionResponseJSON = `
 	{
 		"data": {
 			"actor": {
-				"federatedLogs": {
-					"partition": {
+				"account": {
+					"federatedLogs": {
+						"partition": {
 						"id": "ZmVkLWxvZ3MtcGFydGl0aW9uLTEyMzQ1Njc4OTA",
 						"name": "Test Partition",
 						"description": "Test federated logs partition",
@@ -227,7 +232,8 @@ var (
 				}
 			}
 		}
-	}`
+	}
+}`
 )
 
 func TestUnitFederatedLogs_CreateSetup(t *testing.T) {
@@ -255,7 +261,7 @@ func TestUnitFederatedLogs_CreateSetup(t *testing.T) {
 		},
 	}
 
-	result, err := client.FederatedLogsCreateSetup(input)
+	result, err := client.FederatedLogsCreateSetup(testAccountID, input)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -276,7 +282,7 @@ func TestUnitFederatedLogs_UpdateSetup(t *testing.T) {
 		Description: "Test federated logs setup - updated",
 	}
 
-	result, err := client.FederatedLogsUpdateSetup(testSetupID, updateInput)
+	result, err := client.FederatedLogsUpdateSetup(testAccountID, testSetupID, updateInput)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -299,7 +305,7 @@ func TestUnitFederatedLogs_CreatePartition(t *testing.T) {
 		},
 	}
 
-	result, err := client.FederatedLogsCreatePartition(input, testSetupID)
+	result, err := client.FederatedLogsCreatePartition(testAccountID, input, testSetupID)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -319,7 +325,7 @@ func TestUnitFederatedLogs_UpdatePartition(t *testing.T) {
 		Description: "Test federated logs partition - updated",
 	}
 
-	result, err := client.FederatedLogsUpdatePartition(testPartitionID, updateInput)
+	result, err := client.FederatedLogsUpdatePartition(testAccountID, testPartitionID, updateInput)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -333,7 +339,7 @@ func TestUnitFederatedLogs_GetSetup(t *testing.T) {
 	t.Parallel()
 	client := newMockResponse(t, testGetSetupResponseJSON, http.StatusOK)
 
-	result, err := client.GetSetup(testSetupID)
+	result, err := client.GetSetup(testAccountID, testSetupID)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -346,7 +352,7 @@ func TestUnitFederatedLogs_GetPartition(t *testing.T) {
 	t.Parallel()
 	client := newMockResponse(t, testGetPartitionResponseJSON, http.StatusOK)
 
-	result, err := client.GetPartition(testPartitionID)
+	result, err := client.GetPartition(testAccountID, testPartitionID)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -359,7 +365,7 @@ func TestUnitFederatedLogs_GetSetup_Error(t *testing.T) {
 	t.Parallel()
 	client := newMockResponse(t, `{"errors": [{"message": "Not Found"}]}`, http.StatusNotFound)
 
-	result, err := client.GetSetup("non-existent-id")
+	result, err := client.GetSetup(testAccountID, "non-existent-id")
 
 	require.Error(t, err)
 	require.Nil(t, result)
@@ -369,7 +375,7 @@ func TestUnitFederatedLogs_CreateSetup_Error(t *testing.T) {
 	t.Parallel()
 	client := newMockResponse(t, `{"errors": [{"message": "Internal Server Error"}]}`, http.StatusInternalServerError)
 
-	result, err := client.FederatedLogsCreateSetup(FederatedLogsCreateSetupInput{Name: "x"})
+	result, err := client.FederatedLogsCreateSetup(testAccountID, FederatedLogsCreateSetupInput{Name: "x"})
 
 	require.Error(t, err)
 	require.Nil(t, result)


### PR DESCRIPTION
## What

Re-enables and repairs the `pkg/federatedlogs` unit tests that #1425 had to disable to unblock CI.

## Changes

`pkg/federatedlogs/federatedlogs_unit_test.go`:

1. **Signature fix.** The federatedlogs API methods now take a leading `accountID int`, which the unit tests had not been updated to pass. Added a `testAccountID` const and threaded it through every call site:
   - `FederatedLogsCreateSetup`
   - `FederatedLogsUpdateSetup`
   - `FederatedLogsCreatePartition`
   - `FederatedLogsUpdatePartition`
   - `GetSetup` (both call sites)
   - `GetPartition`

2. **Mock JSON shape fix.** `testGetSetupResponseJSON` and `testGetPartitionResponseJSON` were missing the `actor.account` wrapper. The queries are account-scoped (`actor { account(id: \$accountID) { federatedLogs { ... } } }`), so without the `account` level, JSON unmarshalling silently dropped the payload and the tests asserted on empty IDs.

## Why

#1425 disabled `federatedlogs_unit_test.go` via a placeholder build tag to keep `-tags unit` green for unrelated PRs. This PR restores the `unit` build tag and gets the tests passing for real.

## Test plan

- [x] `go test -count=1 -tags=unit -run 'TestUnitFederatedLogs' -v ./pkg/federatedlogs/...` — all 8 tests pass
- [x] `go test -count=1 -tags=unit ./pkg/federatedlogs/...` — package green
- [ ] CI green on this PR (`test-unit`)

## Note

Does **not** re-enable the integration tests (`TestIntegrationFederatedLogs_Setup`, `TestIntegrationFederatedLogs_Partition`) — those remain skipped from #1425 until the fleet-test account is granted `federatedLogsCreateSetup` access.

## Stack / order

- #1425 (skip — merge first)
- this PR (restore unit tests + fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)