### PR TITLE
feat(entities): add cursor pagination for entity search

### DIFF
--- a/pkg/entities/entities_api_.go
+++ b/pkg/entities/entities_api_.go
@@ -2,6 +2,8 @@ package entities
 
 import (
 	"context"
+	"fmt"
+	"strings"
 )
 
 // Search for entities using a custom query.
@@ -162,3 +164,151 @@ const getEntitySearchByQuery = `query(
 		type
 	}
 } } }`
+
+// GetEntitySearchByQueryWithCursor is like GetEntitySearchByQuery but paginates
+// via the results cursor returned in prior responses. Pass an empty cursor on
+// the first call, then feed each subsequent call the value from the previous
+// response's Results.NextCursor. When NextCursor is empty, pagination is done.
+//
+// See GetEntitySearchByQuery for details on the query, options, and sortBy
+// arguments.
+func (a *Entities) GetEntitySearchByQueryWithCursor(
+	options EntitySearchOptions,
+	query string,
+	sortBy []EntitySearchSortCriteria,
+	cursor string,
+) (*EntitySearch, error) {
+	return a.GetEntitySearchByQueryWithCursorWithContext(context.Background(),
+		options,
+		query,
+		sortBy,
+		cursor,
+	)
+}
+
+// GetEntitySearchByQueryWithCursorWithContext is like
+// GetEntitySearchByQueryWithCursor but accepts a context.Context.
+func (a *Entities) GetEntitySearchByQueryWithCursorWithContext(
+	ctx context.Context,
+	options EntitySearchOptions,
+	query string,
+	sortBy []EntitySearchSortCriteria,
+	cursor string,
+) (*EntitySearch, error) {
+
+	resp := entitySearchResponse{}
+	vars := map[string]interface{}{
+		"options": options,
+		"query":   query,
+		"sortBy":  sortBy,
+		"cursor":  nilIfEmpty(cursor),
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, getEntitySearchByQueryWithCursor, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.Actor.EntitySearch, nil
+}
+
+// GetEntitySearchWithCursor is like GetEntitySearch but paginates via the
+// results cursor returned in prior responses. Pass an empty cursor on the
+// first call, then feed each subsequent call the value from the previous
+// response's Results.NextCursor. When NextCursor is empty, pagination is done.
+//
+// See GetEntitySearch for details on the other arguments.
+func (a *Entities) GetEntitySearchWithCursor(
+	options EntitySearchOptions,
+	query string,
+	queryBuilder EntitySearchQueryBuilder,
+	sortBy []EntitySearchSortCriteria,
+	sortByWithDirection []SortCriterionWithDirection,
+	cursor string,
+) (*EntitySearch, error) {
+	return a.GetEntitySearchWithCursorWithContext(context.Background(),
+		options,
+		query,
+		queryBuilder,
+		sortBy,
+		sortByWithDirection,
+		cursor,
+	)
+}
+
+// GetEntitySearchWithCursorWithContext is like GetEntitySearchWithCursor but
+// accepts a context.Context.
+func (a *Entities) GetEntitySearchWithCursorWithContext(
+	ctx context.Context,
+	options EntitySearchOptions,
+	query string,
+	queryBuilder EntitySearchQueryBuilder,
+	sortBy []EntitySearchSortCriteria,
+	sortByWithDirection []SortCriterionWithDirection,
+	cursor string,
+) (*EntitySearch, error) {
+
+	resp := entitySearchResponse{}
+	vars := map[string]interface{}{
+		"options":             options,
+		"query":               query,
+		"queryBuilder":        queryBuilder,
+		"sortBy":              sortBy,
+		"sortByWithDirection": sortByWithDirection,
+		"cursor":              nilIfEmpty(cursor),
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, getEntitySearchWithCursor, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.Actor.EntitySearch, nil
+}
+
+// The two *WithCursor query strings are derived from the existing non-cursor
+// queries by injecting a `$cursor: String` variable and passing it into the
+// `results(cursor: $cursor)` sub-field. Keeping them derived avoids duplicating
+// the hundreds of lines of entity selection sets already maintained in the
+// generated file. If a regeneration ever changes the anchor patterns below,
+// addCursorArg panics at package init so the drift is caught in CI rather than
+// silently returning un-paginated data at runtime.
+var (
+	getEntitySearchByQueryWithCursor = addCursorArg(getEntitySearchByQuery)
+	getEntitySearchWithCursor        = addCursorArg(getEntitySearchQuery)
+)
+
+// addCursorArg rewrites an entitySearch query to accept a `$cursor: String`
+// variable and forwards it to the `results` sub-field. See the block comment
+// above for context.
+func addCursorArg(query string) string {
+	const (
+		// The two anchors appear exactly once in each entitySearch query const
+		// (getEntitySearchByQuery in this file, and getEntitySearchQuery in
+		// entities_api.go). If tutone regeneration reshapes either query, the
+		// checks below fail fast at package init.
+		varAnchor    = ") { actor { entitySearch("
+		resultAnchor = "\n\tresults {\n"
+		varInsert    = "\t$cursor: String,\n"
+		resultInsert = "\n\tresults(cursor: $cursor) {\n"
+	)
+
+	if strings.Count(query, varAnchor) != 1 {
+		panic(fmt.Sprintf("entities: cannot add cursor argument, %q anchor not found exactly once", varAnchor))
+	}
+	if strings.Count(query, resultAnchor) != 1 {
+		panic(fmt.Sprintf("entities: cannot add cursor argument, %q anchor not found exactly once", resultAnchor))
+	}
+
+	query = strings.Replace(query, varAnchor, varInsert+varAnchor, 1)
+	query = strings.Replace(query, resultAnchor, resultInsert, 1)
+	return query
+}
+
+// nilIfEmpty returns a *string that is nil when s is empty, otherwise pointing
+// at s. NerdGraph treats a nil (null) cursor as "start from the beginning";
+// passing an empty string would send `cursor: ""` which some resolvers reject.
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/pkg/entities/entity_integration_test.go
+++ b/pkg/entities/entity_integration_test.go
@@ -280,3 +280,53 @@ func newIntegrationTestClient(t *testing.T) Entities {
 
 	return New(tc)
 }
+
+// TestIntegrationSearchEntitiesByQueryWithCursor exercises cursor-driven
+// pagination end-to-end against a real account. It proves both branches of
+// the fix: an empty cursor returns the first page, and a cursor from that
+// response fetches a distinct second page.
+func TestIntegrationSearchEntitiesByQueryWithCursor(t *testing.T) {
+	t.Parallel()
+
+	client := newIntegrationTestClient(t)
+
+	// Very broad query so most test accounts return more than one page's
+	// worth of entities and NextCursor is populated.
+	query := "reporting = 'true'"
+
+	page1, err := client.GetEntitySearchByQueryWithCursor(EntitySearchOptions{}, query, nil, "")
+	require.NoError(t, err)
+	require.Greater(t, len(page1.Results.Entities), 0)
+
+	if page1.Results.NextCursor == "" {
+		t.Skip("test account has fewer entities than one page; cursor round-trip cannot be exercised")
+	}
+
+	page2, err := client.GetEntitySearchByQueryWithCursor(EntitySearchOptions{}, query, nil, page1.Results.NextCursor)
+	require.NoError(t, err)
+	require.Greater(t, len(page2.Results.Entities), 0)
+	require.NotEqual(t, page1.Results.Entities[0].GetGUID(), page2.Results.Entities[0].GetGUID(), "cursor did not advance to a new entity")
+}
+
+// TestIntegrationSearchEntitiesWithCursor is the queryBuilder counterpart to
+// TestIntegrationSearchEntitiesByQueryWithCursor.
+func TestIntegrationSearchEntitiesWithCursor(t *testing.T) {
+	t.Parallel()
+
+	client := newIntegrationTestClient(t)
+
+	qb := EntitySearchQueryBuilder{Reporting: true}
+
+	page1, err := client.GetEntitySearchWithCursor(EntitySearchOptions{}, "", qb, nil, nil, "")
+	require.NoError(t, err)
+	require.Greater(t, len(page1.Results.Entities), 0)
+
+	if page1.Results.NextCursor == "" {
+		t.Skip("test account has fewer entities than one page; cursor round-trip cannot be exercised")
+	}
+
+	page2, err := client.GetEntitySearchWithCursor(EntitySearchOptions{}, "", qb, nil, nil, page1.Results.NextCursor)
+	require.NoError(t, err)
+	require.Greater(t, len(page2.Results.Entities), 0)
+	require.NotEqual(t, page1.Results.Entities[0].GetGUID(), page2.Results.Entities[0].GetGUID(), "cursor did not advance to a new entity")
+}

--- a/pkg/entities/entity_test.go
+++ b/pkg/entities/entity_test.go
@@ -6,7 +6,10 @@ package entities
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -265,4 +268,137 @@ func TestGetEntityWithContext_LargeViolationId(t *testing.T) {
 	require.True(t, ok, "expected *SyntheticMonitorEntity, got %T", *entity)
 	require.Len(t, synthEntity.RecentAlertViolations, 1)
 	require.Equal(t, EntityAlertViolationInt(violationID), synthEntity.RecentAlertViolations[0].ViolationId)
+}
+
+// TestAddCursorArg_QueryStrings verifies the derived *WithCursor query strings
+// declare the $cursor variable and forward it into results(cursor: $cursor).
+// If tutone regeneration reshapes either source query, the addCursorArg helper
+// panics at package init; this test additionally guards the resulting text.
+func TestAddCursorArg_QueryStrings(t *testing.T) {
+	t.Parallel()
+
+	for name, q := range map[string]string{
+		"getEntitySearchByQueryWithCursor": getEntitySearchByQueryWithCursor,
+		"getEntitySearchWithCursor":        getEntitySearchWithCursor,
+	} {
+		require.Contains(t, q, "$cursor: String,", "%s missing $cursor variable declaration", name)
+		require.Contains(t, q, "results(cursor: $cursor) {", "%s does not forward cursor to results()", name)
+		// The pre-existing top-level `results {` must be replaced, not duplicated.
+		require.NotContains(t, q, "\n\tresults {\n", "%s still contains un-cursor'd results { block", name)
+	}
+}
+
+// captureRequestServer is a testing mock that captures each inbound GraphQL
+// request body and returns a canned response. It's local to this file because
+// the shared testhelpers.NewMockServer discards the request body.
+type captureRequestServer struct {
+	*httptest.Server
+	requests [][]byte
+}
+
+func newCaptureRequestServer(t *testing.T, response string) *captureRequestServer {
+	t.Helper()
+	crs := &captureRequestServer{}
+	crs.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		crs.requests = append(crs.requests, body)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write([]byte(response))
+		require.NoError(t, err)
+	}))
+	return crs
+}
+
+const entitySearchCursorResponse = `{
+	"data": {
+		"actor": {
+			"entitySearch": {
+				"count": 2,
+				"query": "domain = 'APM'",
+				"results": {
+					"entities": [
+						{
+							"__typename": "ApmApplicationEntityOutline",
+							"guid": "MTIzfEFQTXxBUFBMSUNBVElPTnwxMTE=",
+							"name": "app-1"
+						},
+						{
+							"__typename": "ApmApplicationEntityOutline",
+							"guid": "MTIzfEFQTXxBUFBMSUNBVElPTnwyMjI=",
+							"name": "app-2"
+						}
+					],
+					"nextCursor": "PAGE-2-CURSOR"
+				}
+			}
+		}
+	}
+}`
+
+// TestGetEntitySearchByQueryWithCursor reproduces Scott's Slack question:
+// prior to this method the caller had no way to pass a nextCursor value back
+// in for pagination. This test asserts (1) the returned NextCursor is parsed,
+// (2) an empty cursor is sent as `null`, and (3) a non-empty cursor is
+// forwarded on the wire.
+func TestGetEntitySearchByQueryWithCursor(t *testing.T) {
+	t.Parallel()
+
+	crs := newCaptureRequestServer(t, entitySearchCursorResponse)
+	defer crs.Close()
+
+	client := New(mock.NewTestConfig(t, crs.Server))
+
+	// First page — empty cursor should serialize to `null`.
+	got, err := client.GetEntitySearchByQueryWithCursor(
+		EntitySearchOptions{}, "domain = 'APM'", nil, "",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "PAGE-2-CURSOR", got.Results.NextCursor)
+
+	// Second page — feed the cursor back in.
+	_, err = client.GetEntitySearchByQueryWithCursor(
+		EntitySearchOptions{}, "domain = 'APM'", nil, "PAGE-2-CURSOR",
+	)
+	require.NoError(t, err)
+
+	require.Len(t, crs.requests, 2)
+	require.Contains(t, string(crs.requests[0]), `"cursor":null`, "empty cursor should be sent as null")
+	require.Contains(t, string(crs.requests[1]), `"cursor":"PAGE-2-CURSOR"`, "cursor value should round-trip")
+
+	// Sanity: the outbound query must declare and forward $cursor.
+	for _, body := range crs.requests {
+		require.True(t, strings.Contains(string(body), "$cursor: String"), "outbound query missing $cursor declaration")
+		require.True(t, strings.Contains(string(body), "results(cursor: $cursor)"), "outbound query does not forward cursor to results()")
+	}
+}
+
+// TestGetEntitySearchWithCursor mirrors TestGetEntitySearchByQueryWithCursor
+// for the queryBuilder variant.
+func TestGetEntitySearchWithCursor(t *testing.T) {
+	t.Parallel()
+
+	crs := newCaptureRequestServer(t, entitySearchCursorResponse)
+	defer crs.Close()
+
+	client := New(mock.NewTestConfig(t, crs.Server))
+
+	qb := EntitySearchQueryBuilder{Domain: EntitySearchQueryBuilderDomainTypes.APM}
+
+	got, err := client.GetEntitySearchWithCursor(
+		EntitySearchOptions{}, "", qb, nil, nil, "",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "PAGE-2-CURSOR", got.Results.NextCursor)
+
+	_, err = client.GetEntitySearchWithCursor(
+		EntitySearchOptions{}, "", qb, nil, nil, "PAGE-2-CURSOR",
+	)
+	require.NoError(t, err)
+
+	require.Len(t, crs.requests, 2)
+	require.Contains(t, string(crs.requests[0]), `"cursor":null`)
+	require.Contains(t, string(crs.requests[1]), `"cursor":"PAGE-2-CURSOR"`)
 }


### PR DESCRIPTION
EntitySearch responses include a nextCursor but the existing methods had no way to feed it back in, so callers could only ever see the first page. Adds GetEntitySearchByQueryWithCursor and GetEntitySearchWithCursor (with WithContext variants) that accept a cursor argument alongside the existing parameters; the derived query strings inject $cursor: String and forward it into results(cursor: $cursor).

