### PR TITLE
fix(http): redact license key and response headers in trace logs

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -325,8 +325,8 @@ func logNice(body string) string {
 func redactedHeaders(header http.Header) http.Header {
 	h := http.Header{}
 	for k, values := range header {
-		switch k {
-		case "Api-Key", "X-Api-Key", "X-Insert-Key":
+		switch http.CanonicalHeaderKey(k) {
+		case "Api-Key", "X-Api-Key", "X-Insert-Key", "X-License-Key":
 			h[k] = []string{"[REDACTED]"}
 		default:
 			h[k] = values
@@ -454,7 +454,7 @@ func (c *Client) innerDo(req *Request, errorValue ErrorResponse, i int) (*http.R
 		return resp, body, false, readErr
 	}
 
-	logHeaders, err = json.Marshal(resp.Header)
+	logHeaders, err = json.Marshal(redactedHeaders(resp.Header))
 	if err != nil {
 		return resp, body, false, err
 	}

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -512,3 +512,29 @@ func TestPaymentRequiredError(t *testing.T) {
 
 	assert.IsType(t, &errors.PaymentRequiredError{}, err)
 }
+
+func TestRedactedHeaders(t *testing.T) {
+	t.Parallel()
+
+	h := http.Header{}
+	// Sensitive auth headers set by the authorizers in auth.go.
+	h.Set("Api-Key", mock.PersonalAPIKey)
+	h.Set("X-Api-Key", "adminAPIKey")
+	h.Set("X-Insert-Key", "insightsInsertKey")
+	h.Set("X-License-Key", mock.LicenseKey)
+	// Non-sensitive headers must be preserved.
+	h.Set("Content-Type", "application/json")
+	h.Set("X-Account-ID", "12345")
+
+	redacted := redactedHeaders(h)
+
+	for _, key := range []string{"Api-Key", "X-Api-Key", "X-Insert-Key", "X-License-Key"} {
+		assert.Equal(t, "[REDACTED]", redacted.Get(key), "expected %s to be redacted", key)
+	}
+
+	assert.Equal(t, "application/json", redacted.Get("Content-Type"))
+	assert.Equal(t, "12345", redacted.Get("X-Account-ID"))
+
+	// The original header map must not be mutated.
+	assert.Equal(t, mock.LicenseKey, h.Get("X-License-Key"))
+}


### PR DESCRIPTION
## Summary

Remediates CodeQL `go/clear-text-logging` (high severity) on `newrelic-client-go` — [NR-560190](https://new-relic.atlassian.net/browse/NR-560190). Sensitive auth headers were flowing into Trace-level log calls in `internal/http/client.go`. A prior fix ([#1418](https://github.com/newrelic/newrelic-client-go/pull/1418)) introduced `redactedHeaders` and applied it to the request path, but two gaps remained — both closed here. **Scope is confined to `internal/http/`**; no public API or behavior outside Trace logging changes.

## Alerts addressed

| Alert | Rule | Severity | Location | Root cause |
|---|---|---|---|---|
| [#5](https://github.com/newrelic/newrelic-client-go/security/code-scanning/5) | `go/clear-text-logging` | HIGH | `internal/http/client.go` (response header log) | Response headers logged un-redacted |
| [#4](https://github.com/newrelic/newrelic-client-go/security/code-scanning/4) | `go/clear-text-logging` | HIGH | `internal/http/client.go` (response header log) | Response headers logged un-redacted |
| [#3](https://github.com/newrelic/newrelic-client-go/security/code-scanning/3) | `go/clear-text-logging` | HIGH | `internal/http/client.go` (response header log) | Response headers logged un-redacted |
| [#1](https://github.com/newrelic/newrelic-client-go/security/code-scanning/1) | `go/clear-text-logging` | HIGH | `pkg/logging/logrus_logger.go` (Trace sink) | Sensitive header value reaching the log sink |

## Gaps fixed

1. **`X-License-Key` was never redacted.** The client sets four sensitive auth headers (`internal/http/auth.go`): `Api-Key`, `X-Api-Key`, `X-Insert-Key`, and `X-License-Key`. `redactedHeaders` only covered the first three, so `LicenseKeyAuthorizer`'s license key leaked to Trace logs. This gap predated #1418.
2. **Response headers were logged un-redacted.** `innerDo` logged `json.Marshal(resp.Header)` directly, unlike the request path — defense-in-depth for any server/proxy that echoes auth headers, and it closes the CodeQL taint path from `resp.Header` → log sink.

## Changes

- **`internal/http/client.go`**
  - Add `X-License-Key` to the `redactedHeaders` redaction set.
  - Match header names via `http.CanonicalHeaderKey(k)` so redaction cannot be bypassed by non-canonical casing.
  - Redact response headers (`redactedHeaders(resp.Header)`) before the `request completed` Trace log.
- **`internal/http/client_test.go`**
  - Add `TestRedactedHeaders`: asserts all four sensitive headers become `[REDACTED]`, non-sensitive headers (`Content-Type`, `X-Account-ID`) pass through, and the input map is not mutated. Uses the shared `pkg/testhelpers` constants (`mock.PersonalAPIKey`, `mock.LicenseKey`) to match existing test conventions.

## Verification (all green locally)

- `go build ./internal/http/...` — OK
- `go vet -tags unit ./internal/http/` — OK
- `go test -tags unit -run TestRedactedHeaders -v ./internal/http/` — PASS
- `go test -tags unit ./internal/http/` — full package suite, 0 failures


[NR-560190]: https://new-relic.atlassian.net/browse/NR-560190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ