### PR TITLE
fix(alerts): add description and titleTemplate to compound conditions

### DIFF
--- a/pkg/alerts/compound_conditions.go
+++ b/pkg/alerts/compound_conditions.go
@@ -18,6 +18,8 @@ type CompoundCondition struct {
 	ThresholdDuration     int                  `json:"thresholdDuration,omitempty"`
 	TriggerExpression     string               `json:"triggerExpression,omitempty"`
 	EntityGuid            string               `json:"entityGuid,omitempty"`
+	Description           string               `json:"description,omitempty"`
+	TitleTemplate         string               `json:"titleTemplate,omitempty"`
 }
 
 // ComponentCondition represents a component condition within a compound condition.
@@ -35,6 +37,8 @@ type CompoundConditionCreateInput struct {
 	RunbookURL            *string                   `json:"runbookUrl"`
 	ThresholdDuration     *int                      `json:"thresholdDuration"`
 	TriggerExpression     string                    `json:"triggerExpression"`
+	Description           *string                   `json:"description,omitempty"`
+	TitleTemplate         *string                   `json:"titleTemplate,omitempty"`
 }
 
 // CompoundConditionUpdateInput represents the input for updating a compound condition.
@@ -47,6 +51,8 @@ type CompoundConditionUpdateInput struct {
 	RunbookURL            *string                   `json:"runbookUrl"`
 	ThresholdDuration     *int                      `json:"thresholdDuration"`
 	TriggerExpression     *string                   `json:"triggerExpression"`
+	Description           *string                   `json:"description,omitempty"`
+	TitleTemplate         *string                   `json:"titleTemplate,omitempty"`
 }
 
 // ComponentConditionInput represents the input for a component condition within a compound condition.
@@ -272,6 +278,7 @@ const (
 			id
 			alias
 		}
+		description
 		enabled
 		entityGuid
 		facetMatchingBehavior
@@ -279,6 +286,7 @@ const (
 		policyId
 		runbookUrl
 		thresholdDuration
+		titleTemplate
 		triggerExpression
 	`
 

--- a/pkg/alerts/compound_conditions_integration_test.go
+++ b/pkg/alerts/compound_conditions_integration_test.go
@@ -485,6 +485,128 @@ func TestIntegrationCompoundConditions_UpdatePolicyID(t *testing.T) {
 	}()
 }
 
+func TestIntegrationCompoundConditions_TitleTemplateAndDescription(t *testing.T) {
+	t.Skip("Skipping due to titleTemplate and description being behind the DCON/compound_title_template_and_description_apis feature flag until generally available.")
+	t.Parallel()
+
+	testAccountID, err := mock.GetTestAccountID()
+	if err != nil {
+		t.Skipf("%s", err)
+	}
+
+	var (
+		randStr       = mock.RandSeq(5)
+		conditionName = fmt.Sprintf("test-compound-condition-%s", randStr)
+	)
+
+	client := newIntegrationTestClient(t)
+
+	testPolicy := AlertsPolicyInput{
+		IncidentPreference: AlertsIncidentPreferenceTypes.PER_POLICY,
+		Name:               fmt.Sprintf("test-alert-policy-%s", randStr),
+	}
+	policy, err := client.CreatePolicyMutation(testAccountID, testPolicy)
+	require.NoError(t, err)
+
+	defer func() {
+		_, err := client.DeletePolicyMutation(testAccountID, policy.ID)
+		if err != nil {
+			t.Logf("error cleaning up alert policy %s (%s): %s", policy.ID, policy.Name, err)
+		}
+	}()
+
+	nrqlConditionInput1 := NrqlConditionCreateInput{
+		NrqlConditionCreateBase: NrqlConditionCreateBase{
+			Enabled: true,
+			Name:    fmt.Sprintf("test-nrql-condition-1-%s", randStr),
+			Nrql:    NrqlConditionCreateQuery{Query: "SELECT count(*) FROM Transaction"},
+			Terms: []NrqlConditionTerm{
+				{
+					Threshold:            floatPtr(1.0),
+					ThresholdOccurrences: ThresholdOccurrences.AtLeastOnce,
+					ThresholdDuration:    600,
+					Operator:             AlertsNRQLConditionTermsOperatorTypes.ABOVE,
+					Priority:             NrqlConditionPriorities.Critical,
+				},
+			},
+			ViolationTimeLimitSeconds: 3600,
+		},
+	}
+	nrqlCondition1, err := client.CreateNrqlConditionStaticMutation(testAccountID, policy.ID, nrqlConditionInput1)
+	require.NoError(t, err)
+
+	nrqlConditionInput2 := NrqlConditionCreateInput{
+		NrqlConditionCreateBase: NrqlConditionCreateBase{
+			Enabled: true,
+			Name:    fmt.Sprintf("test-nrql-condition-2-%s", randStr),
+			Nrql:    NrqlConditionCreateQuery{Query: "SELECT average(duration) FROM Transaction"},
+			Terms: []NrqlConditionTerm{
+				{
+					Threshold:            floatPtr(500.0),
+					ThresholdOccurrences: ThresholdOccurrences.AtLeastOnce,
+					ThresholdDuration:    600,
+					Operator:             AlertsNRQLConditionTermsOperatorTypes.ABOVE,
+					Priority:             NrqlConditionPriorities.Critical,
+				},
+			},
+			ViolationTimeLimitSeconds: 3600,
+		},
+	}
+	nrqlCondition2, err := client.CreateNrqlConditionStaticMutation(testAccountID, policy.ID, nrqlConditionInput2)
+	require.NoError(t, err)
+
+	description := "Test description for compound condition"
+	titleTemplate := fmt.Sprintf("{{compoundCondition.name}} triggered - %s", randStr)
+
+	createInput := CompoundConditionCreateInput{
+		Name:              conditionName,
+		Enabled:           true,
+		TriggerExpression: "A AND B",
+		ThresholdDuration: intPtr(300),
+		ComponentConditions: []ComponentConditionInput{
+			{ID: nrqlCondition1.ID, Alias: "A"},
+			{ID: nrqlCondition2.ID, Alias: "B"},
+		},
+		Description:   &description,
+		TitleTemplate: &titleTemplate,
+	}
+
+	created, err := client.CreateCompoundCondition(testAccountID, policy.ID, createInput)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	require.Equal(t, description, created.Description)
+	require.Equal(t, titleTemplate, created.TitleTemplate)
+
+	createdID := created.ID
+	fetchedList, err := client.SearchCompoundConditions(testAccountID, &AlertsCompoundConditionFilterInput{
+		Id: &AlertsCompoundConditionIDFilter{Eq: &createdID},
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, fetchedList, 1)
+	require.NotEmpty(t, fetchedList[0].Description)
+	require.NotEmpty(t, fetchedList[0].TitleTemplate)
+
+	updatedDescription := "Updated description"
+	updatedTitleTemplate := fmt.Sprintf("{{compoundCondition.name}} updated - %s", randStr)
+	updateInput := CompoundConditionUpdateInput{
+		Name:              stringPtr(conditionName),
+		Enabled:           boolPtr(true),
+		TriggerExpression: stringPtr("A AND B"),
+		PolicyID:          stringPtr(policy.ID),
+		ComponentConditions: []ComponentConditionInput{
+			{ID: nrqlCondition1.ID, Alias: "A"},
+			{ID: nrqlCondition2.ID, Alias: "B"},
+		},
+		Description:   &updatedDescription,
+		TitleTemplate: &updatedTitleTemplate,
+	}
+
+	updated, err := client.UpdateCompoundCondition(testAccountID, created.ID, updateInput)
+	require.NoError(t, err)
+	require.Equal(t, updatedDescription, updated.Description)
+	require.Equal(t, updatedTitleTemplate, updated.TitleTemplate)
+}
+
 // Helper functions to create pointers
 func floatPtr(f float64) *float64 {
 	return &f

--- a/pkg/alerts/compound_conditions_test.go
+++ b/pkg/alerts/compound_conditions_test.go
@@ -30,6 +30,8 @@ var (
 									"thresholdDuration": 60,
 									"triggerExpression": "a and b",
 									"entityGuid": "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
+									"description": "Test description",
+									"titleTemplate": "{{compoundCondition.name}} triggered",
 									"componentConditions": [
 										{
 											"id": "1",
@@ -57,6 +59,8 @@ var (
 				"thresholdDuration": 60,
 				"triggerExpression": "a and b",
 				"entityGuid": "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
+				"description": "Test description",
+				"titleTemplate": "{{compoundCondition.name}} triggered",
 				"componentConditions": [
 					{
 						"id": "1",
@@ -79,6 +83,8 @@ var (
 				"thresholdDuration": 60,
 				"triggerExpression": "a or b",
 				"entityGuid": "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
+				"description": "Updated description",
+				"titleTemplate": "{{compoundCondition.name}} updated",
 				"componentConditions": [
 					{
 						"id": "1",
@@ -130,6 +136,8 @@ func TestSearchCompoundConditions(t *testing.T) {
 			ThresholdDuration:     60,
 			TriggerExpression:     "a and b",
 			EntityGuid:            "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
+			Description:           "Test description",
+			TitleTemplate:         "{{compoundCondition.name}} triggered",
 			ComponentConditions: []ComponentCondition{
 				{
 					ID:    "1",
@@ -175,6 +183,8 @@ func TestCreateCompoundCondition(t *testing.T) {
 		ThresholdDuration:     60,
 		TriggerExpression:     "a and b",
 		EntityGuid:            "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
+		Description:           "Test description",
+		TitleTemplate:         "{{compoundCondition.name}} triggered",
 		ComponentConditions: []ComponentCondition{
 			{
 				ID:    "1",
@@ -224,6 +234,8 @@ func TestUpdateCompoundCondition(t *testing.T) {
 		ThresholdDuration:     60,
 		TriggerExpression:     "a or b",
 		EntityGuid:            "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
+		Description:           "Updated description",
+		TitleTemplate:         "{{compoundCondition.name}} updated",
 		ComponentConditions: []ComponentCondition{
 			{
 				ID:    "1",


### PR DESCRIPTION
## Issue Link

[NR-583583](https://new-relic.atlassian.net/browse/NR-583583)

## Goals

Add `Description` and `TitleTemplate` fields to the compound condition Go client structs and GraphQL query constants, to match the new fields being added to the NerdGraph schema in [alerts_graphql_service PR #765](https://source.datanerd.us/Alerting/alerts_graphql_service/pull/765).

## Changes

- Added `Description` and `TitleTemplate` to `CompoundCondition`, `CompoundConditionCreateInput`, and `CompoundConditionUpdateInput`
- Added `description` and `titleTemplate` to `graphqlCompoundConditionStructFields` query constant
- Updated unit test JSON fixtures and expected structs to include both fields
- Added `TestIntegrationCompoundConditions_TitleTemplateAndDescription` (skipped behind `DCON/compound_title_template_and_description_apis` flag until GA)

## Testing

- Unit tests: passing
- Integration test: skipped pending feature flag GA (remove `t.Skip` when flag is removed)

## Dependencies

Requires the AGQL PR to be merged and stitched into NerdGraph before integration tests can run.

- AGQL PR: https://source.datanerd.us/Alerting/alerts_graphql_service/pull/765
- Jira: NR-583583
- Next: Terraform provider PR will follow once this is released

[NR-583583]: https://new-relic.atlassian.net/browse/NR-583583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ