### PR TITLE
feat(logconfigurations): re-import schema

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -1057,6 +1057,10 @@ packages:
             max_query_field_depth: 2
           - name: parsingRules
             max_query_field_depth: 2
+          - name: liveArchiveConfigurations
+            max_query_field_depth: 2
+          - name: pipelineConfiguration
+            max_query_field_depth: 2
     mutations:
       - name: logConfigurationsCreateObfuscationExpression
         max_query_field_depth: 3
@@ -1081,6 +1085,10 @@ packages:
       - name: logConfigurationsUpdateParsingRule
         max_query_field_depth: 2
       - name: logConfigurationsDeleteParsingRule
+        max_query_field_depth: 2
+      - name: logConfigurationsUpdateLiveArchiveConfiguration
+        max_query_field_depth: 2
+      - name: logConfigurationsUpsertPipelineConfiguration
         max_query_field_depth: 2
     types:
       - name: LogConfigurationsDataPartitionRuleMatchingCriteriaInput

--- a/pkg/logconfigurations/logconfigurations_api.go
+++ b/pkg/logconfigurations/logconfigurations_api.go
@@ -295,6 +295,7 @@ const LogConfigurationsCreateParsingRuleMutation = `mutation(
 		id
 		lucene
 		nrql
+		source
 		updatedAt
 		updatedBy {
 			email
@@ -631,6 +632,81 @@ const LogConfigurationsUpdateDataPartitionRuleMutation = `mutation(
 	}
 } }`
 
+// Update the Live Archive configuration of an event type.
+func (a *Logconfigurations) LogConfigurationsUpdateLiveArchiveConfiguration(
+	accountID int,
+	enabled bool,
+	eventType string,
+	retentionPolicy LogConfigurationsLiveArchiveRetentionPolicyType,
+) (*LogConfigurationsLiveArchiveConfiguration, error) {
+	return a.LogConfigurationsUpdateLiveArchiveConfigurationWithContext(context.Background(),
+		accountID,
+		enabled,
+		eventType,
+		retentionPolicy,
+	)
+}
+
+// Update the Live Archive configuration of an event type.
+func (a *Logconfigurations) LogConfigurationsUpdateLiveArchiveConfigurationWithContext(
+	ctx context.Context,
+	accountID int,
+	enabled bool,
+	eventType string,
+	retentionPolicy LogConfigurationsLiveArchiveRetentionPolicyType,
+) (*LogConfigurationsLiveArchiveConfiguration, error) {
+
+	resp := LogConfigurationsUpdateLiveArchiveConfigurationQueryResponse{}
+	vars := map[string]interface{}{
+		"accountId":       accountID,
+		"enabled":         enabled,
+		"eventType":       eventType,
+		"retentionPolicy": retentionPolicy,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, LogConfigurationsUpdateLiveArchiveConfigurationMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.LogConfigurationsLiveArchiveConfiguration, nil
+}
+
+type LogConfigurationsUpdateLiveArchiveConfigurationQueryResponse struct {
+	LogConfigurationsLiveArchiveConfiguration LogConfigurationsLiveArchiveConfiguration `json:"LogConfigurationsUpdateLiveArchiveConfiguration"`
+}
+
+const LogConfigurationsUpdateLiveArchiveConfigurationMutation = `mutation(
+	$accountId: Int!,
+	$enabled: Boolean!,
+	$eventType: String!,
+	$retentionPolicy: LogConfigurationsLiveArchiveRetentionPolicyType!,
+) { logConfigurationsUpdateLiveArchiveConfiguration(
+	accountId: $accountId,
+	enabled: $enabled,
+	eventType: $eventType,
+	retentionPolicy: $retentionPolicy,
+) {
+	accountId
+	createdAt
+	createdBy {
+		email
+		gravatar
+		id
+		name
+	}
+	enabled
+	eventType
+	id
+	retentionPolicy
+	updatedAt
+	updatedBy {
+		email
+		gravatar
+		id
+		name
+	}
+} }`
+
 // Update an existing data partition rule.
 func (a *Logconfigurations) LogConfigurationsUpdateObfuscationExpression(
 	accountID int,
@@ -849,6 +925,70 @@ const LogConfigurationsUpdateParsingRuleMutation = `mutation(
 		id
 		lucene
 		nrql
+		source
+		updatedAt
+		updatedBy {
+			email
+			gravatar
+			id
+			name
+		}
+	}
+} }`
+
+// Upsert pipeline configuration for an account.
+func (a *Logconfigurations) LogConfigurationsUpsertPipelineConfiguration(
+	accountID int,
+	pipelineConfiguration LogConfigurationsPipelineConfigurationInput,
+) (*LogConfigurationsUpsertPipelineConfigurationResponse, error) {
+	return a.LogConfigurationsUpsertPipelineConfigurationWithContext(context.Background(),
+		accountID,
+		pipelineConfiguration,
+	)
+}
+
+// Upsert pipeline configuration for an account.
+func (a *Logconfigurations) LogConfigurationsUpsertPipelineConfigurationWithContext(
+	ctx context.Context,
+	accountID int,
+	pipelineConfiguration LogConfigurationsPipelineConfigurationInput,
+) (*LogConfigurationsUpsertPipelineConfigurationResponse, error) {
+
+	resp := LogConfigurationsUpsertPipelineConfigurationQueryResponse{}
+	vars := map[string]interface{}{
+		"accountId":             accountID,
+		"pipelineConfiguration": pipelineConfiguration,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, LogConfigurationsUpsertPipelineConfigurationMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.LogConfigurationsUpsertPipelineConfigurationResponse, nil
+}
+
+type LogConfigurationsUpsertPipelineConfigurationQueryResponse struct {
+	LogConfigurationsUpsertPipelineConfigurationResponse LogConfigurationsUpsertPipelineConfigurationResponse `json:"LogConfigurationsUpsertPipelineConfiguration"`
+}
+
+const LogConfigurationsUpsertPipelineConfigurationMutation = `mutation(
+	$accountId: Int!,
+	$pipelineConfiguration: LogConfigurationsPipelineConfigurationInput!,
+) { logConfigurationsUpsertPipelineConfiguration(
+	accountId: $accountId,
+	pipelineConfiguration: $pipelineConfiguration,
+) {
+	pipelineConfiguration {
+		accountId
+		accountLevelNativeJsonEnabled
+		enrichmentDisabled
+		jsonParsingDisabled
+		obfuscationDisabled
+		parsingDisabled
+		patternsEnabled
+		pluginAttributesCleanupEnabled
+		recursiveJsonParsingDisabled
+		transformationDisabled
 		updatedAt
 		updatedBy {
 			email
@@ -912,6 +1052,61 @@ const getDataPartitionRulesQuery = `query(
 	nrql
 	retentionPolicy
 	targetDataPartition
+	updatedAt
+	updatedBy {
+		email
+		gravatar
+		id
+		name
+	}
+} } } } }`
+
+// Look up for all Live Archive configurations for a given account.
+func (a *Logconfigurations) GetLiveArchiveConfigurations(
+	accountID int,
+) (*[]LogConfigurationsLiveArchiveConfiguration, error) {
+	return a.GetLiveArchiveConfigurationsWithContext(context.Background(),
+		accountID,
+	)
+}
+
+// Look up for all Live Archive configurations for a given account.
+func (a *Logconfigurations) GetLiveArchiveConfigurationsWithContext(
+	ctx context.Context,
+	accountID int,
+) (*[]LogConfigurationsLiveArchiveConfiguration, error) {
+
+	resp := liveArchiveConfigurationsResponse{}
+	vars := map[string]interface{}{
+		"accountID": accountID,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, getLiveArchiveConfigurationsQuery, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	if len(resp.Actor.Account.LogConfigurations.LiveArchiveConfigurations) == 0 {
+		return nil, errors.NewNotFound("")
+	}
+
+	return &resp.Actor.Account.LogConfigurations.LiveArchiveConfigurations, nil
+}
+
+const getLiveArchiveConfigurationsQuery = `query(
+	$accountID: Int!,
+) { actor { account(id: $accountID) { logConfigurations { liveArchiveConfigurations {
+	accountId
+	createdAt
+	createdBy {
+		email
+		gravatar
+		id
+		name
+	}
+	enabled
+	eventType
+	id
+	retentionPolicy
 	updatedAt
 	updatedBy {
 		email
@@ -1104,6 +1299,56 @@ const getParsingRulesQuery = `query(
 	id
 	lucene
 	nrql
+	source
+	updatedAt
+	updatedBy {
+		email
+		gravatar
+		id
+		name
+	}
+} } } } }`
+
+// Look up pipeline configuration for a given account.
+func (a *Logconfigurations) GetPipelineConfiguration(
+	accountID int,
+) (*LogConfigurationsPipelineConfiguration, error) {
+	return a.GetPipelineConfigurationWithContext(context.Background(),
+		accountID,
+	)
+}
+
+// Look up pipeline configuration for a given account.
+func (a *Logconfigurations) GetPipelineConfigurationWithContext(
+	ctx context.Context,
+	accountID int,
+) (*LogConfigurationsPipelineConfiguration, error) {
+
+	resp := pipelineConfigurationResponse{}
+	vars := map[string]interface{}{
+		"accountID": accountID,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, getPipelineConfigurationQuery, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.Actor.Account.LogConfigurations.PipelineConfiguration, nil
+}
+
+const getPipelineConfigurationQuery = `query(
+	$accountID: Int!,
+) { actor { account(id: $accountID) { logConfigurations { pipelineConfiguration {
+	accountId
+	accountLevelNativeJsonEnabled
+	enrichmentDisabled
+	jsonParsingDisabled
+	obfuscationDisabled
+	parsingDisabled
+	patternsEnabled
+	pluginAttributesCleanupEnabled
+	recursiveJsonParsingDisabled
+	transformationDisabled
 	updatedAt
 	updatedBy {
 		email

--- a/pkg/logconfigurations/types.go
+++ b/pkg/logconfigurations/types.go
@@ -63,15 +63,34 @@ var LogConfigurationsDataPartitionRuleMutationErrorTypeTypes = struct {
 type LogConfigurationsDataPartitionRuleRetentionPolicyType string
 
 var LogConfigurationsDataPartitionRuleRetentionPolicyTypeTypes = struct {
+	// Archive retention policy for data partitions routed to archived namespaces (e.g. Logging:Archive).
+	ARCHIVE LogConfigurationsDataPartitionRuleRetentionPolicyType
 	// The alternative data retention policy, 30 days of data retention since the log data is ingested.
 	SECONDARY LogConfigurationsDataPartitionRuleRetentionPolicyType
 	// The maximum retention period associated with the account. This is determined by the customer’s subscription/contract with New Relic.
 	STANDARD LogConfigurationsDataPartitionRuleRetentionPolicyType
 }{
+	// Archive retention policy for data partitions routed to archived namespaces (e.g. Logging:Archive).
+	ARCHIVE: "ARCHIVE",
 	// The alternative data retention policy, 30 days of data retention since the log data is ingested.
 	SECONDARY: "SECONDARY",
 	// The maximum retention period associated with the account. This is determined by the customer’s subscription/contract with New Relic.
 	STANDARD: "STANDARD",
+}
+
+// LogConfigurationsLiveArchiveRetentionPolicyType - Live Archive retention policies.
+type LogConfigurationsLiveArchiveRetentionPolicyType string
+
+var LogConfigurationsLiveArchiveRetentionPolicyTypeTypes = struct {
+	// Live Archive disabled
+	NONE LogConfigurationsLiveArchiveRetentionPolicyType
+	// Live Archive enabled with configured retention policy
+	STANDARD_ARCHIVE LogConfigurationsLiveArchiveRetentionPolicyType
+}{
+	// Live Archive disabled
+	NONE: "NONE",
+	// Live Archive enabled with configured retention policy
+	STANDARD_ARCHIVE: "STANDARD_ARCHIVE",
 }
 
 // LogConfigurationsObfuscationMethod - Methods for replacing obfuscated values.
@@ -112,6 +131,27 @@ var LogConfigurationsParsingRuleMutationErrorTypeTypes = struct {
 	NOT_FOUND: "NOT_FOUND",
 }
 
+// LogConfigurationsParsingRuleSource - Source of the parsing rule.
+// NO_CODE: Rule was generated from the No Code UI.
+// WRITE_YOUR_OWN: Rule was created from the Old UI.
+type LogConfigurationsParsingRuleSource string
+
+var LogConfigurationsParsingRuleSourceTypes = struct {
+	// Rule created from the NO CODE UI
+	NO_CODE LogConfigurationsParsingRuleSource
+	// Rule created from new UI but using Write your own screen.
+	NO_CODE_WRITE_YOUR_OWN LogConfigurationsParsingRuleSource
+	// Rule created from existing/OLD UI.
+	WRITE_YOUR_OWN LogConfigurationsParsingRuleSource
+}{
+	// Rule created from the NO CODE UI
+	NO_CODE: "NO_CODE",
+	// Rule created from new UI but using Write your own screen.
+	NO_CODE_WRITE_YOUR_OWN: "NO_CODE_WRITE_YOUR_OWN",
+	// Rule created from existing/OLD UI.
+	WRITE_YOUR_OWN: "WRITE_YOUR_OWN",
+}
+
 // Account - The `Account` object provides general data about the account, as well as
 // being the entry point into more detailed data about a single account.
 //
@@ -138,12 +178,16 @@ type Actor struct {
 type LogConfigurationsAccountStitchedFields struct {
 	// Look up for all data partition rules for a given account.
 	DataPartitionRules []LogConfigurationsDataPartitionRule `json:"dataPartitionRules"`
+	// Look up for all Live Archive configurations for a given account.
+	LiveArchiveConfigurations []LogConfigurationsLiveArchiveConfiguration `json:"liveArchiveConfigurations"`
 	// Look up for all obfuscation expressions for a given account
 	ObfuscationExpressions []LogConfigurationsObfuscationExpression `json:"obfuscationExpressions"`
 	// Look up for all obfuscation rules for a given account.
 	ObfuscationRules []LogConfigurationsObfuscationRule `json:"obfuscationRules"`
 	// Look up for all parsing rules for a given account.
 	ParsingRules []*LogConfigurationsParsingRule `json:"parsingRules"`
+	// Look up pipeline configuration for a given account.
+	PipelineConfiguration LogConfigurationsPipelineConfiguration `json:"pipelineConfiguration,omitempty"`
 	// Test a Grok pattern against a list of log lines.
 	TestGrok []LogConfigurationsGrokTestResult `json:"testGrok"`
 }
@@ -308,6 +352,28 @@ type LogConfigurationsGrokTestResult struct {
 	Matched bool `json:"matched"`
 }
 
+// LogConfigurationsLiveArchiveConfiguration - Live Archive configuration for an event type.
+type LogConfigurationsLiveArchiveConfiguration struct {
+	// Account Id
+	AccountID int `json:"accountId"`
+	// Identifies the date and time when the configuration was created.
+	CreatedAt nrtime.DateTime `json:"createdAt"`
+	// Identifies the user who has created the configuration.
+	CreatedBy UserReference `json:"createdBy,omitempty"`
+	// Indicates if the Live Archive configuration is enabled
+	Enabled bool `json:"enabled"`
+	// EventType name that will be configured.
+	EventType string `json:"eventType"`
+	// Configuration Id
+	ID string `json:"id"`
+	// Retention policy for the EventType.
+	RetentionPolicy LogConfigurationsLiveArchiveRetentionPolicyType `json:"retentionPolicy"`
+	// Identifies the date and time when the configuration was last updated.
+	UpdatedAt nrtime.DateTime `json:"updatedAt,omitempty"`
+	// Identifies the user who has last updated the configuration.
+	UpdatedBy UserReference `json:"updatedBy,omitempty"`
+}
+
 // LogConfigurationsObfuscationAction - Application of an obfuscation expression with specific a replacement method.
 type LogConfigurationsObfuscationAction struct {
 	// Log record attributes to apply this expression to. An empty list applies the action to all the attributes.
@@ -386,6 +452,8 @@ type LogConfigurationsParsingRule struct {
 	Lucene string `json:"lucene"`
 	// The NRQL to match events to the parsing rule.
 	NRQL NRQL `json:"nrql"`
+	// Source of the parsing rule.
+	Source LogConfigurationsParsingRuleSource `json:"source"`
 	// Identifies the date and time when the rule was last updated.
 	UpdatedAt nrtime.DateTime `json:"updatedAt,omitempty"`
 	// Identifies the user who has last updated the rule.
@@ -406,6 +474,8 @@ type LogConfigurationsParsingRuleConfiguration struct {
 	Lucene string `json:"lucene"`
 	// The NRQL to match events to the parsing rule.
 	NRQL NRQL `json:"nrql"`
+	// Source of the parsing rule. Defaults to WRITE_YOUR_OWN.
+	Source LogConfigurationsParsingRuleSource `json:"source,omitempty"`
 }
 
 // LogConfigurationsParsingRuleMutationError - Expected errors as a result of mutating a parsing rule.
@@ -416,14 +486,62 @@ type LogConfigurationsParsingRuleMutationError struct {
 	Type LogConfigurationsParsingRuleMutationErrorType `json:"type,omitempty"`
 }
 
+// LogConfigurationsPipelineConfiguration - The pipeline configuration for an account, with metadata.
+type LogConfigurationsPipelineConfiguration struct {
+	// The account id.
+	AccountID int `json:"accountId"`
+	// Whether or not account-level native JSON is enabled."
+	AccountLevelNativeJsonEnabled bool `json:"accountLevelNativeJsonEnabled"`
+	// Whether or not enrichment is disabled.
+	EnrichmentDisabled bool `json:"enrichmentDisabled"`
+	// Whether or not JSON parsing is disabled.
+	JsonParsingDisabled bool `json:"jsonParsingDisabled"`
+	// Whether or not obfuscation is disabled.
+	ObfuscationDisabled bool `json:"obfuscationDisabled"`
+	// Whether or not parsing is disabled.
+	ParsingDisabled bool `json:"parsingDisabled"`
+	// Whether or not patterns are enabled.
+	PatternsEnabled bool `json:"patternsEnabled"`
+	// Whether or not plugin.* attributes should be dropped.
+	PluginAttributesCleanupEnabled bool `json:"pluginAttributesCleanupEnabled"`
+	// Whether or not recursive JSON parsing is disabled.
+	RecursiveJsonParsingDisabled bool `json:"recursiveJsonParsingDisabled"`
+	// Whether or not transformation is disabled.
+	TransformationDisabled bool `json:"transformationDisabled"`
+	// Identifies the date and time when the configuration was last updated, or null if this has never been changed from the defaults.
+	UpdatedAt nrtime.DateTime `json:"updatedAt,omitempty"`
+	// Identifies the user who has updated the configuration, or null if this has never been changed from the defaults.
+	UpdatedBy UserReference `json:"updatedBy,omitempty"`
+}
+
+// LogConfigurationsPipelineConfigurationInput - The pipeline configuration for an account.
+type LogConfigurationsPipelineConfigurationInput struct {
+	// Whether or not account-level native JSON is enabled."
+	AccountLevelNativeJsonEnabled bool `json:"accountLevelNativeJsonEnabled,omitempty"`
+	// Whether or not enrichment is disabled.
+	EnrichmentDisabled bool `json:"enrichmentDisabled,omitempty"`
+	// Whether or not JSON parsing is disabled.
+	JsonParsingDisabled bool `json:"jsonParsingDisabled,omitempty"`
+	// Whether or not obfuscation is disabled.
+	ObfuscationDisabled bool `json:"obfuscationDisabled,omitempty"`
+	// Whether or not parsing is disabled.
+	ParsingDisabled bool `json:"parsingDisabled,omitempty"`
+	// Whether or not patterns are enabled.
+	PatternsEnabled bool `json:"patternsEnabled,omitempty"`
+	// Whether or not plugin.* attributes should be dropped.
+	PluginAttributesCleanupEnabled bool `json:"pluginAttributesCleanupEnabled,omitempty"`
+	// Whether or not recursive JSON parsing is disabled.
+	RecursiveJsonParsingDisabled bool `json:"recursiveJsonParsingDisabled,omitempty"`
+	// Whether or not transformation is disabled.
+	TransformationDisabled bool `json:"transformationDisabled,omitempty"`
+}
+
 // LogConfigurationsUpdateDataPartitionRuleInput - An object for updating an existing data partition rule.
 type LogConfigurationsUpdateDataPartitionRuleInput struct {
 	// The description of the data partition rule.
 	Description string `json:"description,omitempty"`
 	// Whether or not this data partition rule is enabled.
-	// NOTE: DO NOT add 'omitempty' to the JSON description of Enabled as fetched from Tutone.
-	// It omits 'enabled' even if the calling service sends it as 'false', which is why 'omitempty' has been manually discarded.
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled,omitempty"`
 	// Unique data partition rule identifier.
 	ID string `json:"id"`
 	// The criteria of the data partition rule.
@@ -490,6 +608,12 @@ type LogConfigurationsUpdateParsingRuleResponse struct {
 	Rule *LogConfigurationsParsingRule `json:"rule,omitempty"`
 }
 
+// LogConfigurationsUpsertPipelineConfigurationResponse - The result after upserting pipeline configuration for an account.
+type LogConfigurationsUpsertPipelineConfigurationResponse struct {
+	// The updated pipeline configuration.
+	PipelineConfiguration LogConfigurationsPipelineConfiguration `json:"pipelineConfiguration,omitempty"`
+}
+
 // UserReference - The `UserReference` object provides basic identifying information about the user.
 type UserReference struct {
 	//
@@ -506,6 +630,10 @@ type dataPartitionRulesResponse struct {
 	Actor Actor `json:"actor"`
 }
 
+type liveArchiveConfigurationsResponse struct {
+	Actor Actor `json:"actor"`
+}
+
 type obfuscationExpressionsResponse struct {
 	Actor Actor `json:"actor"`
 }
@@ -515,6 +643,10 @@ type obfuscationRulesResponse struct {
 }
 
 type parsingRulesResponse struct {
+	Actor Actor `json:"actor"`
+}
+
+type pipelineConfigurationResponse struct {
 	Actor Actor `json:"actor"`
 }
 


### PR DESCRIPTION
### Re-Import schema: `logconfigurations`

Adding liveArchive and pipeline config mutations/queries present in NerdGraph but missing from Go client

**Before merging, please verify:**
- [ ] Review the `.tutone.yml` diff — additions are correct
- [ ] Review regenerated `pkg/logconfigurations/` files
- [ ] Update or add integration tests if needed

_Generated by the GenerateClientGo Jenkins job._