### PR TITLE
feat(cloud): add hasDimensionalMetrics and isEntitySupported for GCP DM WIF

### DIFF
--- a/pkg/cloud/cloud_api.go
+++ b/pkg/cloud/cloud_api.go
@@ -1765,6 +1765,7 @@ const CloudLinkAccountMutation = `mutation(
 		disabled
 		externalId
 		id
+		hasDimensionalMetrics
 		metricCollectionMode
 		name
 		nrAccountId
@@ -1833,6 +1834,7 @@ const CloudRenameAccountMutation = `mutation(
 		disabled
 		externalId
 		id
+		hasDimensionalMetrics
 		metricCollectionMode
 		name
 		nrAccountId
@@ -1903,6 +1905,7 @@ const CloudUnlinkAccountMutation = `mutation(
 		disabled
 		externalId
 		id
+		hasDimensionalMetrics
 		metricCollectionMode
 		name
 		nrAccountId
@@ -1958,6 +1961,7 @@ const CloudUpdateAccountMutation = `mutation(
 		disabled
 		externalId
 		id
+		hasDimensionalMetrics
 		metricCollectionMode
 		name
 		nrAccountId
@@ -2018,6 +2022,7 @@ const getLinkedAccountQuery = `query(
 			disabled
 			externalId
 			id
+			hasDimensionalMetrics
 			metricCollectionMode
 			name
 			nrAccountId
@@ -2030,6 +2035,7 @@ const getLinkedAccountQuery = `query(
 			icon
 			id
 			isEnabled
+			isEntitySupported
 			name
 			slug
 			updatedAt
@@ -2819,6 +2825,7 @@ const getLinkedAccountQuery = `query(
 			tagValue
 		}
 	}
+	hasDimensionalMetrics
 	metricCollectionMode
 	name
 	nrAccountId
@@ -2833,6 +2840,7 @@ const getLinkedAccountQuery = `query(
 			icon
 			id
 			isEnabled
+			isEntitySupported
 			name
 			slug
 			updatedAt
@@ -2921,6 +2929,7 @@ const getLinkedAccountsQuery = `query(
 			disabled
 			externalId
 			id
+			hasDimensionalMetrics
 			metricCollectionMode
 			name
 			nrAccountId
@@ -2933,6 +2942,7 @@ const getLinkedAccountsQuery = `query(
 			icon
 			id
 			isEnabled
+			isEntitySupported
 			name
 			slug
 			updatedAt
@@ -3722,6 +3732,7 @@ const getLinkedAccountsQuery = `query(
 			tagValue
 		}
 	}
+	hasDimensionalMetrics
 	metricCollectionMode
 	name
 	nrAccountId
@@ -3736,6 +3747,7 @@ const getLinkedAccountsQuery = `query(
 			icon
 			id
 			isEnabled
+			isEntitySupported
 			name
 			slug
 			updatedAt

--- a/pkg/cloud/cloud_api_integration_test.go
+++ b/pkg/cloud/cloud_api_integration_test.go
@@ -686,6 +686,8 @@ func TestCloudAccount_GcpDmWifBasic(t *testing.T) {
 		return
 	}
 
+	require.True(t, linkResponse.LinkedAccounts[0].HasDimensionalMetrics, "GCP account linked via WIF should use dimensional metrics")
+
 	linkedAccountId := linkResponse.LinkedAccounts[0].ID
 
 	// Step 3: Rename the linked account.
@@ -764,6 +766,8 @@ func TestCloudAccount_GcpDmWifIntegrations(t *testing.T) {
 		t.Skip("skipping TestCloudAccount_GcpDmWifIntegrations: no linked accounts returned")
 		return
 	}
+
+	require.True(t, linkResponse.LinkedAccounts[0].HasDimensionalMetrics, "GCP account linked via WIF should use dimensional metrics")
 
 	linkedAccountId := linkResponse.LinkedAccounts[0].ID
 

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -5566,6 +5566,8 @@ type CloudLinkedAccount struct {
 	Integration CloudIntegrationInterface `json:"integration"`
 	// Get details of all cloud service integrations.
 	Integrations []CloudIntegrationInterface `json:"integrations"`
+	// Indicates whether this linked account uses dimensional metrics.
+	HasDimensionalMetrics bool `json:"hasDimensionalMetrics,omitempty"`
 	// Indicate how the metrics will be collected (PUSH/PULL)
 	MetricCollectionMode CloudMetricCollectionMode `json:"metricCollectionMode"`
 	// The linked account name in NewRelic.
@@ -5648,6 +5650,11 @@ func (x *CloudLinkedAccount) UnmarshalJSON(b []byte) error {
 				if xxx != nil {
 					x.Integrations = append(x.Integrations, *xxx)
 				}
+			}
+		case "hasDimensionalMetrics":
+			err = json.Unmarshal(*v, &x.HasDimensionalMetrics)
+			if err != nil {
+				return err
 			}
 		case "metricCollectionMode":
 			err = json.Unmarshal(*v, &x.MetricCollectionMode)
@@ -6120,6 +6127,8 @@ type CloudService struct {
 	Icon string `json:"icon"`
 	// Shows if the cloud service is enabled for integrating.
 	IsEnabled bool `json:"isEnabled"`
+	// Whether this service supports entity synthesis (default: true)
+	IsEntitySupported bool `json:"isEntitySupported"`
 	// The cloud service name.
 	Name string `json:"name"`
 	// The cloud provider.
@@ -6166,6 +6175,11 @@ func (x *CloudService) UnmarshalJSON(b []byte) error {
 			}
 		case "isEnabled":
 			err = json.Unmarshal(*v, &x.IsEnabled)
+			if err != nil {
+				return err
+			}
+		case "isEntitySupported":
+			err = json.Unmarshal(*v, &x.IsEntitySupported)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary
- Mirrors the remaining `Beyond/gcp_v2_wif`-flagged GraphQL fields into the Go client: `LinkedAccount.hasDimensionalMetrics` and `Service.isEntitySupported` (struct fields, `UnmarshalJSON` cases, and query selections across all relevant queries/mutations).
- Adds an assertion in the existing GCP DM WIF integration tests that `hasDimensionalMetrics` is `true` after linking a GCP account via WIF.

## Test plan
- [x] `go build ./pkg/cloud/...`
- [x] `go vet ./pkg/cloud/...` and `go vet -tags integration ./pkg/cloud/...`
- [x] `go test -tags unit ./pkg/cloud/...`
- [x] `go test -tags integration ./pkg/cloud/...` with real `INTEGRATION_TESTING_GCP_DM_PROJECT_ID` / `INTEGRATION_TESTING_GCP_DM_WIF_CREDENTIAL` credentials