### PR TITLE
fix(fleetcontrol): add missing cursor to getEntitySearchQuery

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -2041,6 +2041,8 @@ packages:
             exclude_fields:
               - agents
               - tools
+            include_arguments:
+              - "cursor"
 
     types:
       - name: FleetControlFleetMembersFilterInput

--- a/pkg/fleetcontrol/entity_search_unit_test.go
+++ b/pkg/fleetcontrol/entity_search_unit_test.go
@@ -1,0 +1,93 @@
+//go:build unit
+// +build unit
+
+package fleetcontrol
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
+)
+
+const testEntitySearchMockResponse = `{
+	"data": {
+		"actor": {
+			"entityManagement": {
+				"entitySearch": {
+					"entities": [],
+					"nextCursor": "next-page-cursor"
+				}
+			}
+		}
+	}
+}`
+
+// newMockResponseCapturingRequest is like newMockResponse but also captures the
+// raw request body of the last request sent to the mock server, so tests can
+// assert on the GraphQL variables that were actually sent over the wire.
+func newMockResponseCapturingRequest(t *testing.T, mockJSONResponse string, statusCode int) (Fleetcontrol, *[]byte) {
+	var lastRequestBody []byte
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		lastRequestBody = body
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+
+		_, err = w.Write([]byte(mockJSONResponse))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(ts.Close)
+
+	tc := mock.NewTestConfig(t, ts)
+
+	return New(tc), &lastRequestBody
+}
+
+type graphQLRequestBody struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
+func TestUnitGetEntitySearch_SendsCursorVariable(t *testing.T) {
+	t.Parallel()
+
+	client, lastRequestBody := newMockResponseCapturingRequest(t, testEntitySearchMockResponse, http.StatusOK)
+
+	cursor := "current-page-cursor"
+	result, err := client.GetEntitySearch(&cursor, "type = 'FLEET'")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "next-page-cursor", result.NextCursor)
+
+	var reqBody graphQLRequestBody
+	require.NoError(t, json.Unmarshal(*lastRequestBody, &reqBody))
+
+	assert.Contains(t, reqBody.Query, "$cursor: String")
+	assert.Contains(t, reqBody.Query, "cursor: $cursor")
+	assert.Equal(t, cursor, reqBody.Variables["cursor"])
+	assert.Equal(t, "type = 'FLEET'", reqBody.Variables["query"])
+}
+
+func TestUnitGetEntitySearch_NilCursorSendsNull(t *testing.T) {
+	t.Parallel()
+
+	client, lastRequestBody := newMockResponseCapturingRequest(t, testEntitySearchMockResponse, http.StatusOK)
+
+	_, err := client.GetEntitySearch(nil, "type = 'FLEET'")
+	require.NoError(t, err)
+
+	var reqBody graphQLRequestBody
+	require.NoError(t, json.Unmarshal(*lastRequestBody, &reqBody))
+
+	assert.Nil(t, reqBody.Variables["cursor"])
+}

--- a/pkg/fleetcontrol/fleetcontrol_api.go
+++ b/pkg/fleetcontrol/fleetcontrol_api.go
@@ -928,7 +928,7 @@ const getEntityQuery = `query(
 
 // Retrieves a set of entities that match the given query predicate.
 func (a *Fleetcontrol) GetEntitySearch(
-	cursor string,
+	cursor *string,
 	query string,
 ) (*EntityManagementEntitySearchResult, error) {
 	return a.GetEntitySearchWithContext(context.Background(),
@@ -940,7 +940,7 @@ func (a *Fleetcontrol) GetEntitySearch(
 // Retrieves a set of entities that match the given query predicate.
 func (a *Fleetcontrol) GetEntitySearchWithContext(
 	ctx context.Context,
-	cursor string,
+	cursor *string,
 	query string,
 ) (*EntityManagementEntitySearchResult, error) {
 
@@ -958,8 +958,10 @@ func (a *Fleetcontrol) GetEntitySearchWithContext(
 }
 
 const getEntitySearchQuery = `query(
+	$cursor: String,
 	$query: String!,
 ) { actor { entityManagement { entitySearch(
+	cursor: $cursor,
 	query: $query,
 ) {
 	entities {

--- a/pkg/fleetcontrol/fleetcontrol_integration_test.go
+++ b/pkg/fleetcontrol/fleetcontrol_integration_test.go
@@ -119,7 +119,7 @@ func TestIntegrationFleetLifecycle(t *testing.T) {
 	require.Equal(t, "FLEET", fleetEntity.Type)
 
 	// --- GetEntitySearch (search for FLEET entities, verify ours is present) ---
-	searchResp, err := client.GetEntitySearch("", "type = 'FLEET'")
+	searchResp, err := client.GetEntitySearch(nil, "type = 'FLEET'")
 	require.NoError(t, err)
 	require.NotNil(t, searchResp)
 	require.GreaterOrEqual(t, len(searchResp.Entities), 1, "expected at least the fleet we created")
@@ -283,7 +283,7 @@ func TestIntegrationDeploymentAndManagedEntitySearch(t *testing.T) {
 	client := newIntegrationTestClient(t)
 
 	// Search for any fleet deployment entities in the org
-	deploymentSearch, err := client.GetEntitySearch("", "type = 'FLEET_DEPLOYMENT'")
+	deploymentSearch, err := client.GetEntitySearch(nil, "type = 'FLEET_DEPLOYMENT'")
 	require.NoError(t, err)
 	require.NotNil(t, deploymentSearch)
 	// Zero results is acceptable in a fresh account — we just verify the call works
@@ -294,7 +294,7 @@ func TestIntegrationDeploymentAndManagedEntitySearch(t *testing.T) {
 	}
 
 	// Search for any existing fleet entities (read-only sanity check)
-	fleetSearch, err := client.GetEntitySearch("", "type = 'FLEET'")
+	fleetSearch, err := client.GetEntitySearch(nil, "type = 'FLEET'")
 	require.NoError(t, err)
 	require.NotNil(t, fleetSearch)
 	for _, e := range fleetSearch.Entities {


### PR DESCRIPTION
## Summary

`GetEntitySearch(cursor string, query string)` in `pkg/fleetcontrol` accepted a `cursor` parameter that was a silent no-op: the generated `getEntitySearchQuery` GraphQL document only declared `$query: String!` and called `entitySearch(query: $query,)` — it never declared `$cursor` and never passed `cursor: $cursor` to the `entitySearch` field. The `vars` map set `"cursor": cursor`, but since the query text never referenced `$cursor`, the value was dropped before the request ever left the client. Every call re-fetched page one regardless of what cursor was passed in.

This is the exact same bug already found and fixed for `GetFleetMembers` in `93b8a99` ("fix(fleetcontrol): add missing cursor and fix cursor type in getFleetMembersQuery", #1394). That fix added `include_arguments: ["cursor"]` for the `fleetMembers` endpoint in `.tutone.yml`; the equivalent block for `entitySearch` was missing it.

## Changes

- `.tutone.yml`: add `include_arguments: ["cursor"]` to the `entitySearch` endpoint under the `fleetcontrol` package's `["actor", "entityManagement"]` queries block.
- `pkg/fleetcontrol/fleetcontrol_api.go`: `getEntitySearchQuery` now declares `$cursor: String,` and passes `cursor: $cursor,` to `entitySearch(...)`. Applied by hand rather than a full `tutone generate` — the live NerdGraph schema has drifted substantially since the last full regen, and running it here would have pulled ~16k lines of unrelated changes across 60 files (and even broken an unrelated package due to a `type`-as-identifier codegen bug in `entityrelationship_api.go`). The diff here mirrors exactly what `93b8a99` produced for `GetFleetMembers`.
- `GetEntitySearch`/`GetEntitySearchWithContext`: `cursor` changed from `string` to `*string`, matching the same non-Tutone-covered change `93b8a99` made for `GetFleetMembers` (the API expects `null` for "no cursor", not an empty string).
- `pkg/fleetcontrol/fleetcontrol_integration_test.go`: updated the 3 existing `GetEntitySearch("", ...)` call sites to pass `nil`.
- `pkg/fleetcontrol/entity_search_unit_test.go` (new): mocks the NerdGraph endpoint and asserts the actual JSON request body sent over the wire includes the cursor value (and that a nil cursor sends `null`), verifying the fix at the wire level rather than just via generated code inspection.

No `types.go` changes were needed — `EntityManagementEntitySearchResult` already has `NextCursor`.

Surveyed the rest of `fleetcontrol_api.go` for other queries with the same dead-cursor bug: `GetEntity` fetches a single entity by ID and correctly has no cursor; `GetEntitySearch` and `GetFleetMembers` are the only two paginated queries in this package, and both are now fixed.

## Verification

- `go build ./...`, `go vet -tags unit ./...`, `go vet -tags integration ./...` all clean.
- `golangci-lint run ./pkg/fleetcontrol/...` — 0 issues.
- `go test -tags unit ./pkg/fleetcontrol/...` — passes, including the new unit test.
- Verified against **live NerdGraph**: called `GetEntitySearch(nil, "type = 'FLEET'")`, took the returned `nextCursor`, called again with that cursor — page 2 returned a different set of entities and a new cursor, confirming the cursor now actually advances pagination against real data (not just a mocked assertion).

## Context

Discovered while fixing a pagination bug in `newrelic-cli`'s `fleetcontrol fleet search` command. That CLI-side fix is blocked on this PR merging and a new `newrelic-client-go` release.

## Test plan

- [x] `go build ./...`
- [x] `go vet -tags unit ./...` / `go vet -tags integration ./...`
- [x] `golangci-lint run ./pkg/fleetcontrol/...`
- [x] `go test -tags unit ./pkg/fleetcontrol/...`
- [x] Live NerdGraph pagination check (ad hoc, not committed)