### PR TITLE
feat(dashboards): add support for widget `description` and `link`

### DIFF
--- a/pkg/dashboards/dashboard.go
+++ b/pkg/dashboards/dashboard.go
@@ -66,7 +66,9 @@ const getDashboardEntityQuery = `query ($guid: EntityGuid!) {
               pie { nrqlQueries { accountId query } }
               table { nrqlQueries { accountId query } }
             }
+            description
             layout { column height row width }
+            link { url }
             title
             visualization { id }
             id

--- a/pkg/dashboards/dashboards_api.go
+++ b/pkg/dashboards/dashboards_api.go
@@ -124,12 +124,16 @@ const DashboardCreateMutation = `mutation(
 						}
 					}
 				}
+				description
 				id
 				layout {
 					column
 					height
 					row
 					width
+				}
+				link {
+					url
 				}
 				linkedEntities {
 					__typename
@@ -2302,12 +2306,16 @@ const DashboardUpdateMutation = `mutation(
 						}
 					}
 				}
+				description
 				id
 				layout {
 					column
 					height
 					row
 					width
+				}
+				link {
+					url
 				}
 				linkedEntities {
 					__typename

--- a/pkg/dashboards/dashboards_widgets_integration_test.go
+++ b/pkg/dashboards/dashboards_widgets_integration_test.go
@@ -81,6 +81,16 @@ func TestIntegrationDashboard_Billboard(t *testing.T) {
 						},
 						RawConfiguration: lineRawConfigJSON,
 					},
+					{
+						Title:       "Test Markdown Widget with Description and Link",
+						Description: "Test widget description",
+						Link:        DashboardWidgetLinkInput{URL: "https://example.com/runbook"},
+						Configuration: DashboardWidgetConfigurationInput{
+							Markdown: &DashboardMarkdownWidgetConfigurationInput{
+								Text: "Test Text widget **markdown**",
+							},
+						},
+					},
 				},
 			},
 		},
@@ -109,7 +119,7 @@ func TestIntegrationDashboard_Billboard(t *testing.T) {
 	// Input and Pages are different types so we can not easily compare them...
 	assert.Equal(t, len(dashboardInput.Pages), len(dash.Pages))
 	require.Equal(t, 1, len(dash.Pages))
-	require.Equal(t, 2, len(dash.Pages[0].Widgets))
+	require.Equal(t, 3, len(dash.Pages[0].Widgets))
 
 	// Check billboard widget
 	assert.Equal(t, dashboardInput.Pages[0].Widgets[0].Title, dash.Pages[0].Widgets[0].Title)
@@ -129,6 +139,10 @@ func TestIntegrationDashboard_Billboard(t *testing.T) {
 	assert.Equal(t, DashboardLineInterpolationTypes.SMOOTH, lineWidgetRawConfig.ChartStyles.LineInterpolation)
 	require.NotNil(t, lineWidgetRawConfig.ChartStyles.Gradient)
 	assert.True(t, lineWidgetRawConfig.ChartStyles.Gradient.Enabled)
+
+	// Check markdown widget description and link
+	assert.Equal(t, dashboardInput.Pages[0].Widgets[2].Description, dash.Pages[0].Widgets[2].Description)
+	assert.Equal(t, dashboardInput.Pages[0].Widgets[2].Link.URL, dash.Pages[0].Widgets[2].Link.URL)
 
 	testWarningThreshold := 10.0
 
@@ -189,6 +203,16 @@ func TestIntegrationDashboard_Billboard(t *testing.T) {
 						},
 						RawConfiguration: updatedLineRawConfigJSON,
 					},
+					{
+						Title:       "Test Markdown Widget with Description and Link",
+						Description: "Updated widget description",
+						Link:        DashboardWidgetLinkInput{URL: "https://example.com/updated-runbook"},
+						Configuration: DashboardWidgetConfigurationInput{
+							Markdown: &DashboardMarkdownWidgetConfigurationInput{
+								Text: "Test Text widget **markdown**",
+							},
+						},
+					},
 				},
 			},
 		},
@@ -199,7 +223,7 @@ func TestIntegrationDashboard_Billboard(t *testing.T) {
 	require.NotNil(t, upDash)
 
 	require.Equal(t, 1, len(upDash.EntityResult.Pages))
-	require.Equal(t, 2, len(upDash.EntityResult.Pages[0].Widgets))
+	require.Equal(t, 3, len(upDash.EntityResult.Pages[0].Widgets))
 
 	// Check updated billboard widget
 	assert.Equal(t, updatedDashboard.Pages[0].Widgets[0].Title, upDash.EntityResult.Pages[0].Widgets[0].Title)
@@ -221,13 +245,17 @@ func TestIntegrationDashboard_Billboard(t *testing.T) {
 	require.NotNil(t, updatedLineWidgetRawConfig.ChartStyles.Gradient)
 	assert.False(t, updatedLineWidgetRawConfig.ChartStyles.Gradient.Enabled)
 
+	// Check updated markdown widget description and link
+	assert.Equal(t, updatedDashboard.Pages[0].Widgets[2].Description, upDash.EntityResult.Pages[0].Widgets[2].Description)
+	assert.Equal(t, updatedDashboard.Pages[0].Widgets[2].Link.URL, upDash.EntityResult.Pages[0].Widgets[2].Link.URL)
+
 	// Test removal of threshold (set back to initial input)
 	removeThresholdDash, err := client.DashboardUpdate(dashboardInput, dashGUID)
 	require.NoError(t, err)
 	require.NotNil(t, removeThresholdDash)
 
 	require.Equal(t, 1, len(removeThresholdDash.EntityResult.Pages))
-	require.Equal(t, 2, len(removeThresholdDash.EntityResult.Pages[0].Widgets))
+	require.Equal(t, 3, len(removeThresholdDash.EntityResult.Pages[0].Widgets))
 
 	// Check billboard widget (threshold removed)
 	assert.Equal(t, dashboardInput.Pages[0].Widgets[0].Title, removeThresholdDash.EntityResult.Pages[0].Widgets[0].Title)
@@ -242,6 +270,10 @@ func TestIntegrationDashboard_Billboard(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, finalLineWidgetRawConfig.ChartStyles)
 	assert.Equal(t, DashboardLineInterpolationTypes.SMOOTH, finalLineWidgetRawConfig.ChartStyles.LineInterpolation)
+
+	// Verify markdown widget description and link still have original values
+	assert.Equal(t, dashboardInput.Pages[0].Widgets[2].Description, removeThresholdDash.EntityResult.Pages[0].Widgets[2].Description)
+	assert.Equal(t, dashboardInput.Pages[0].Widgets[2].Link.URL, removeThresholdDash.EntityResult.Pages[0].Widgets[2].Link.URL)
 
 	// Test: DashboardDelete
 	delRes, err := client.DashboardDelete(dashGUID)

--- a/pkg/dashboards/types.go
+++ b/pkg/dashboards/types.go
@@ -373,10 +373,14 @@ type DashboardUpdateResult struct {
 type DashboardUpdateWidgetInput struct {
 	// Typed widgets are area, bar, billboard, line, markdown, pie, and table. Check our [docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#widget-typed) for more info.
 	Configuration DashboardWidgetConfigurationInput `json:"configuration,omitempty"`
+	// A description of the widget, will be displayed in a tooltip.
+	Description string `json:"description,omitempty"`
 	// ID of the widget to be updated.
 	ID string `json:"id"`
 	// The widget's position and size in the dashboard.
 	Layout DashboardWidgetLayoutInput `json:"layout,omitempty"`
+	// Input for configuring a link to be displayed in the widget. The URL will be rendered as a clickable link.
+	Link DashboardWidgetLinkInput `json:"link,omitempty"`
 	// Entities related to the widget. Currently only supports one Dashboard entity guid, but may allow other cases in the future.
 	LinkedEntityGUIDs []common.EntityGUID `json:"linkedEntityGuids"`
 	// Untyped widgets are all other widgets, such as bullet, histogram, inventory, etc. Check our [docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#widget-untyped) for more info.
@@ -547,10 +551,14 @@ type DashboardWidgetConfigurationInput struct {
 type DashboardWidgetInput struct {
 	// Typed widgets are area, bar, billboard, line, markdown, pie, and table. Check our [docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#widget-typed) for more info.
 	Configuration DashboardWidgetConfigurationInput `json:"configuration,omitempty"`
+	// A description of the widget, will be displayed in a tooltip.
+	Description string `json:"description,omitempty"`
 	// ID of the widget. If null, a new widget will be created and added to a dashboard.
 	ID string `json:"id,omitempty"`
 	// The widget's position and size in the dashboard.
 	Layout DashboardWidgetLayoutInput `json:"layout,omitempty"`
+	// Input for configuring a link to be displayed in the widget. The URL will be rendered as a clickable link.
+	Link DashboardWidgetLinkInput `json:"link,omitempty"`
 	// Entities related to the widget. Currently only supports one Dashboard entity guid, but may allow other cases in the future.
 	LinkedEntityGUIDs []common.EntityGUID `json:"linkedEntityGuids"`
 	// Untyped widgets are all other widgets, such as bullet, histogram, inventory, etc. Check our [docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#widget-untyped) for more info.
@@ -571,6 +579,12 @@ type DashboardWidgetLayoutInput struct {
 	Row int `json:"row,omitempty"`
 	// Width of the widget. Valid values are 1 to 12 inclusive. Defaults to 4.
 	Width int `json:"width,omitempty"`
+}
+
+// DashboardWidgetLinkInput - Input for configuring a link to be displayed in the widget. The URL will be rendered as a clickable link.
+type DashboardWidgetLinkInput struct {
+	// The target URL for the link.
+	URL string `json:"url"`
 }
 
 // DashboardWidgetNRQLQueryInput - NRQL query used by a widget.

--- a/pkg/entities/types.go
+++ b/pkg/entities/types.go
@@ -5393,10 +5393,14 @@ type DashboardVariableOptions struct {
 type DashboardWidget struct {
 	// Typed widgets are area, bar, billboard, line, markdown, pie, and table.
 	Configuration DashboardWidgetConfiguration `json:"configuration,omitempty"`
+	// A description of the widget, will be displayed in a tooltip.
+	Description string `json:"description,omitempty"`
 	// ID of the widget.
 	ID string `json:"id"`
 	// The widget's position and size in the dashboard.
 	Layout DashboardWidgetLayout `json:"layout,omitempty"`
+	// Link configuration for the widget. The URL will be rendered as a clickable link.
+	Link DashboardWidgetLink `json:"link,omitempty"`
 	// Entities related to the widget. Currently only supports one Dashboard entity guid, but may allow other cases in the future.
 	LinkedEntities []EntityOutlineInterface `json:"linkedEntities,omitempty"`
 	// Untyped widgets are all other widgets, such as bullet, histogram, inventory, etc.
@@ -5426,6 +5430,11 @@ func (x *DashboardWidget) UnmarshalJSON(b []byte) error {
 			if err != nil {
 				return err
 			}
+		case "description":
+			err = json.Unmarshal(*v, &x.Description)
+			if err != nil {
+				return err
+			}
 		case "id":
 			err = json.Unmarshal(*v, &x.ID)
 			if err != nil {
@@ -5433,6 +5442,11 @@ func (x *DashboardWidget) UnmarshalJSON(b []byte) error {
 			}
 		case "layout":
 			err = json.Unmarshal(*v, &x.Layout)
+			if err != nil {
+				return err
+			}
+		case "link":
+			err = json.Unmarshal(*v, &x.Link)
 			if err != nil {
 				return err
 			}
@@ -5505,6 +5519,12 @@ type DashboardWidgetLayout struct {
 	Row int `json:"row,omitempty"`
 	// Width of the widget. Valid values are 1 to 12 inclusive. Defaults to 4.
 	Width int `json:"width,omitempty"`
+}
+
+// DashboardWidgetLink - Link configuration for the widget. The URL will be rendered as a clickable link.
+type DashboardWidgetLink struct {
+	// The target URL for the link.
+	URL string `json:"url"`
 }
 
 // DashboardWidgetNRQLQuery - Single NRQL query for a widget.


### PR DESCRIPTION
Prerequisite for newrelic/terraform-provider-newrelic#3155.

struct changes were cherry-picked from tutone's generated changes.