### PR TITLE
feat(cloud): re-import schema

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -477,6 +477,16 @@ packages:
             argument_type_overrides:
               - accountId: "Int!"
               - id: "Int!"
+          - name: provider
+            max_query_field_depth: 2
+            include_arguments:
+              - providerSlug
+            argument_type_overrides:
+              - accountId: "Int!"
+              - providerSlug: "String!"
+            exclude_fields:
+              - iconUrl
+              - links
     mutations:
       - name: cloudConfigureIntegration
         max_query_field_depth: 1
@@ -503,6 +513,13 @@ packages:
           - "integration"
           - "integrations"
           - "provider"
+      - name: cloudUpdateGcpIntegration
+        max_query_field_depth: 2
+        argument_type_overrides:
+          accountId: "Int!"
+          integrations: "CloudGcpIntegrationsInput!"
+        exclude_fields:
+          - errors
     types:
       #
       # Types that we should auto-detect are in another package someday
@@ -513,6 +530,8 @@ packages:
       - name: EpochMilliseconds
         field_type_override: nrtime.EpochMilliseconds
         skip_type_create: true
+      - name: CloudGcpIntegrationStatus
+        create_as: "map[string]interface{}"
 
   - name: dashboards
     path: pkg/dashboards

--- a/pkg/cloud/cloud_api.go
+++ b/pkg/cloud/cloud_api.go
@@ -107,6 +107,12 @@ const CloudConfigureIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+		... on CloudAwsAutoDiscoveryIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
 		... on CloudAwsCognitoIntegration {
 			__typename
 			awsRegions
@@ -161,12 +167,17 @@ const CloudConfigureIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMetadataIntegration {
+		... on CloudAwsMetadataEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMetadataEuSovereignIntegration {
+		... on CloudAwsMetadataGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMetadataIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -177,12 +188,17 @@ const CloudConfigureIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMsElasticacheIntegration {
+		... on CloudAwsMsElasticacheEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMsElasticacheEuSovereignIntegration {
+		... on CloudAwsMsElasticacheGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMsElasticacheIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -217,12 +233,17 @@ const CloudConfigureIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsTagsGlobalIntegration {
+		... on CloudAwsTagsGlobalEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsTagsGlobalEuSovereignIntegration {
+		... on CloudAwsTagsGlobalGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsTagsGlobalIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -251,12 +272,6 @@ const CloudConfigureIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-			... on CloudAwsAutoDiscoveryIntegration {
-				__typename
-				awsRegions
-				inventoryPollingInterval
-				metricsPollingInterval
-			}
 		... on CloudAzureApimanagementIntegration {
 			__typename
 			inventoryPollingInterval
@@ -368,6 +383,7 @@ const CloudConfigureIntegrationMutation = `mutation(
 		... on CloudAzureMonitorIntegration {
 			__typename
 			enabled
+			excludeResourceTypes
 			excludeTags
 			includeTags
 			inventoryPollingInterval
@@ -467,6 +483,14 @@ const CloudConfigureIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+		... on CloudCciAwsS3Integration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			s3BucketName
+			s3BucketPath
+			s3BucketRegion
+		}
 		... on CloudCloudfrontIntegration {
 			__typename
 			fetchLambdasAtEdge
@@ -479,6 +503,26 @@ const CloudConfigureIntegrationMutation = `mutation(
 		... on CloudCloudtrailIntegration {
 			__typename
 			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaConnectorResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaFlinkResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaKsqlResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaResourceIntegration {
+			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
@@ -574,6 +618,11 @@ const CloudConfigureIntegrationMutation = `mutation(
 			tagKey
 			tagValue
 		}
+		... on CloudFossaIssuesIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
 		... on CloudGcpAiplatformIntegration {
 			__typename
 			inventoryPollingInterval
@@ -646,6 +695,10 @@ const CloudConfigureIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+		... on CloudGcpGenericIntegration {
+			__typename
+			metricsPollingInterval
+		}
 		... on CloudGcpInterconnectIntegration {
 			__typename
 			inventoryPollingInterval
@@ -712,10 +765,6 @@ const CloudConfigureIntegrationMutation = `mutation(
 		... on CloudGcpVpcaccessIntegration {
 			__typename
 			inventoryPollingInterval
-			metricsPollingInterval
-		}
-		... on CloudGcpGenericIntegration {
-			__typename
 			metricsPollingInterval
 		}
 		... on CloudHealthIntegration {
@@ -896,10 +945,9 @@ type CloudDisableIntegrationQueryResponse struct {
 	CloudDisableIntegrationPayload CloudDisableIntegrationPayload `json:"CloudDisableIntegration"`
 }
 
-// Note: Do not make "$integrations" an optional field (as fetched from Tutone) to avoid a breaking change
 const CloudDisableIntegrationMutation = `mutation(
 	$accountId: Int!,
-	$integrations: CloudDisableIntegrationsInput!,
+	$integrations: CloudDisableIntegrationsInput,
 ) { cloudDisableIntegration(
 	accountId: $accountId,
 	integrations: $integrations,
@@ -944,6 +992,12 @@ const CloudDisableIntegrationMutation = `mutation(
 			metricsPollingInterval
 		}
 		... on CloudAwsAthenaIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsAutoDiscoveryIntegration {
 			__typename
 			awsRegions
 			inventoryPollingInterval
@@ -1003,12 +1057,17 @@ const CloudDisableIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMetadataIntegration {
+		... on CloudAwsMetadataEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMetadataEuSovereignIntegration {
+		... on CloudAwsMetadataGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMetadataIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -1019,12 +1078,17 @@ const CloudDisableIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMsElasticacheIntegration {
+		... on CloudAwsMsElasticacheEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMsElasticacheEuSovereignIntegration {
+		... on CloudAwsMsElasticacheGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMsElasticacheIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -1059,12 +1123,17 @@ const CloudDisableIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsTagsGlobalIntegration {
+		... on CloudAwsTagsGlobalEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsTagsGlobalEuSovereignIntegration {
+		... on CloudAwsTagsGlobalGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsTagsGlobalIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -1093,12 +1162,6 @@ const CloudDisableIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-			... on CloudAwsAutoDiscoveryIntegration {
-				__typename
-				awsRegions
-				inventoryPollingInterval
-				metricsPollingInterval
-			}
 		... on CloudAzureApimanagementIntegration {
 			__typename
 			inventoryPollingInterval
@@ -1210,6 +1273,7 @@ const CloudDisableIntegrationMutation = `mutation(
 		... on CloudAzureMonitorIntegration {
 			__typename
 			enabled
+			excludeResourceTypes
 			excludeTags
 			includeTags
 			inventoryPollingInterval
@@ -1309,6 +1373,14 @@ const CloudDisableIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+		... on CloudCciAwsS3Integration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			s3BucketName
+			s3BucketPath
+			s3BucketRegion
+		}
 		... on CloudCloudfrontIntegration {
 			__typename
 			fetchLambdasAtEdge
@@ -1321,6 +1393,26 @@ const CloudDisableIntegrationMutation = `mutation(
 		... on CloudCloudtrailIntegration {
 			__typename
 			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaConnectorResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaFlinkResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaKsqlResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaResourceIntegration {
+			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
@@ -1416,6 +1508,11 @@ const CloudDisableIntegrationMutation = `mutation(
 			tagKey
 			tagValue
 		}
+		... on CloudFossaIssuesIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
 		... on CloudGcpAiplatformIntegration {
 			__typename
 			inventoryPollingInterval
@@ -1488,6 +1585,10 @@ const CloudDisableIntegrationMutation = `mutation(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+		... on CloudGcpGenericIntegration {
+			__typename
+			metricsPollingInterval
+		}
 		... on CloudGcpInterconnectIntegration {
 			__typename
 			inventoryPollingInterval
@@ -1554,10 +1655,6 @@ const CloudDisableIntegrationMutation = `mutation(
 		... on CloudGcpVpcaccessIntegration {
 			__typename
 			inventoryPollingInterval
-			metricsPollingInterval
-		}
-		... on CloudGcpGenericIntegration {
-			__typename
 			metricsPollingInterval
 		}
 		... on CloudHealthIntegration {
@@ -1764,8 +1861,8 @@ const CloudLinkAccountMutation = `mutation(
 		createdAt
 		disabled
 		externalId
-		id
 		hasDimensionalMetrics
+		id
 		metricCollectionMode
 		name
 		nrAccountId
@@ -1833,8 +1930,8 @@ const CloudRenameAccountMutation = `mutation(
 		createdAt
 		disabled
 		externalId
-		id
 		hasDimensionalMetrics
+		id
 		metricCollectionMode
 		name
 		nrAccountId
@@ -1904,8 +2001,8 @@ const CloudUnlinkAccountMutation = `mutation(
 		createdAt
 		disabled
 		externalId
-		id
 		hasDimensionalMetrics
+		id
 		metricCollectionMode
 		name
 		nrAccountId
@@ -1960,8 +2057,8 @@ const CloudUpdateAccountMutation = `mutation(
 		createdAt
 		disabled
 		externalId
-		id
 		hasDimensionalMetrics
+		id
 		metricCollectionMode
 		name
 		nrAccountId
@@ -2000,10 +2097,9 @@ func (a *Cloud) GetLinkedAccountWithContext(
 	return &resp.Actor.Account.Cloud.LinkedAccount, nil
 }
 
-// Note: Do not make "$id" an optional field (as fetched from Tutone) to avoid a breaking change
 const getLinkedAccountQuery = `query(
 	$accountID: Int!,
-	$id: Int!,
+	$id: Int,
 ) { actor { account(id: $accountID) { cloud { linkedAccount(
 	id: $id,
 ) {
@@ -2011,6 +2107,7 @@ const getLinkedAccountQuery = `query(
 	createdAt
 	disabled
 	externalId
+	hasDimensionalMetrics
 	id
 	integrations {
 		__typename
@@ -2021,8 +2118,8 @@ const getLinkedAccountQuery = `query(
 			createdAt
 			disabled
 			externalId
-			id
 			hasDimensionalMetrics
+			id
 			metricCollectionMode
 			name
 			nrAccountId
@@ -2074,6 +2171,12 @@ const getLinkedAccountQuery = `query(
 			metricsPollingInterval
 		}
 		... on CloudAwsAthenaIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsAutoDiscoveryIntegration {
 			__typename
 			awsRegions
 			inventoryPollingInterval
@@ -2133,12 +2236,17 @@ const getLinkedAccountQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMetadataIntegration {
+		... on CloudAwsMetadataEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMetadataEuSovereignIntegration {
+		... on CloudAwsMetadataGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMetadataIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -2149,12 +2257,17 @@ const getLinkedAccountQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMsElasticacheIntegration {
+		... on CloudAwsMsElasticacheEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMsElasticacheEuSovereignIntegration {
+		... on CloudAwsMsElasticacheGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMsElasticacheIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -2189,12 +2302,17 @@ const getLinkedAccountQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsTagsGlobalIntegration {
+		... on CloudAwsTagsGlobalEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsTagsGlobalEuSovereignIntegration {
+		... on CloudAwsTagsGlobalGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsTagsGlobalIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -2223,12 +2341,6 @@ const getLinkedAccountQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-			... on CloudAwsAutoDiscoveryIntegration {
-				__typename
-				awsRegions
-				inventoryPollingInterval
-				metricsPollingInterval
-			}
 		... on CloudAzureApimanagementIntegration {
 			__typename
 			inventoryPollingInterval
@@ -2340,6 +2452,7 @@ const getLinkedAccountQuery = `query(
 		... on CloudAzureMonitorIntegration {
 			__typename
 			enabled
+			excludeResourceTypes
 			excludeTags
 			includeTags
 			inventoryPollingInterval
@@ -2439,6 +2552,14 @@ const getLinkedAccountQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+		... on CloudCciAwsS3Integration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			s3BucketName
+			s3BucketPath
+			s3BucketRegion
+		}
 		... on CloudCloudfrontIntegration {
 			__typename
 			fetchLambdasAtEdge
@@ -2451,6 +2572,26 @@ const getLinkedAccountQuery = `query(
 		... on CloudCloudtrailIntegration {
 			__typename
 			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaConnectorResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaFlinkResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaKsqlResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaResourceIntegration {
+			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
@@ -2546,6 +2687,11 @@ const getLinkedAccountQuery = `query(
 			tagKey
 			tagValue
 		}
+		... on CloudFossaIssuesIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
 		... on CloudGcpAiplatformIntegration {
 			__typename
 			inventoryPollingInterval
@@ -2618,6 +2764,10 @@ const getLinkedAccountQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+		... on CloudGcpGenericIntegration {
+			__typename
+			metricsPollingInterval
+		}
 		... on CloudGcpInterconnectIntegration {
 			__typename
 			inventoryPollingInterval
@@ -2684,10 +2834,6 @@ const getLinkedAccountQuery = `query(
 		... on CloudGcpVpcaccessIntegration {
 			__typename
 			inventoryPollingInterval
-			metricsPollingInterval
-		}
-		... on CloudGcpGenericIntegration {
-			__typename
 			metricsPollingInterval
 		}
 		... on CloudHealthIntegration {
@@ -2825,7 +2971,6 @@ const getLinkedAccountQuery = `query(
 			tagValue
 		}
 	}
-	hasDimensionalMetrics
 	metricCollectionMode
 	name
 	nrAccountId
@@ -2855,12 +3000,13 @@ const getLinkedAccountQuery = `query(
 			type
 		}
 		updatedAt
-		... on CloudAwsGovCloudProvider {
+		... on CloudAwsEuSovereignProvider {
 			__typename
 			awsAccountId
 		}
-		... on CloudAwsEuSovereignProvider {
+		... on CloudAwsGovCloudProvider {
 			__typename
+			awsAccountId
 		}
 		... on CloudAwsProvider {
 			__typename
@@ -2918,6 +3064,7 @@ const getLinkedAccountsQuery = `query(
 	createdAt
 	disabled
 	externalId
+	hasDimensionalMetrics
 	id
 	integrations {
 		__typename
@@ -2928,8 +3075,8 @@ const getLinkedAccountsQuery = `query(
 			createdAt
 			disabled
 			externalId
-			id
 			hasDimensionalMetrics
+			id
 			metricCollectionMode
 			name
 			nrAccountId
@@ -2981,6 +3128,12 @@ const getLinkedAccountsQuery = `query(
 			metricsPollingInterval
 		}
 		... on CloudAwsAthenaIntegration {
+			__typename
+			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsAutoDiscoveryIntegration {
 			__typename
 			awsRegions
 			inventoryPollingInterval
@@ -3040,12 +3193,17 @@ const getLinkedAccountsQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMetadataIntegration {
+		... on CloudAwsMetadataEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMetadataEuSovereignIntegration {
+		... on CloudAwsMetadataGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMetadataIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -3056,12 +3214,17 @@ const getLinkedAccountsQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMsElasticacheIntegration {
+		... on CloudAwsMsElasticacheEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsMsElasticacheEuSovereignIntegration {
+		... on CloudAwsMsElasticacheGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsMsElasticacheIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -3096,12 +3259,17 @@ const getLinkedAccountsQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsTagsGlobalIntegration {
+		... on CloudAwsTagsGlobalEuSovereignIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-		... on CloudAwsTagsGlobalEuSovereignIntegration {
+		... on CloudAwsTagsGlobalGovIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudAwsTagsGlobalIntegration {
 			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
@@ -3130,12 +3298,6 @@ const getLinkedAccountsQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
-			... on CloudAwsAutoDiscoveryIntegration {
-				__typename
-				awsRegions
-				inventoryPollingInterval
-				metricsPollingInterval
-			}
 		... on CloudAzureApimanagementIntegration {
 			__typename
 			inventoryPollingInterval
@@ -3247,6 +3409,7 @@ const getLinkedAccountsQuery = `query(
 		... on CloudAzureMonitorIntegration {
 			__typename
 			enabled
+			excludeResourceTypes
 			excludeTags
 			includeTags
 			inventoryPollingInterval
@@ -3346,6 +3509,14 @@ const getLinkedAccountsQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+		... on CloudCciAwsS3Integration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+			s3BucketName
+			s3BucketPath
+			s3BucketRegion
+		}
 		... on CloudCloudfrontIntegration {
 			__typename
 			fetchLambdasAtEdge
@@ -3358,6 +3529,26 @@ const getLinkedAccountsQuery = `query(
 		... on CloudCloudtrailIntegration {
 			__typename
 			awsRegions
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaConnectorResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaFlinkResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaKsqlResourceIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
+		... on CloudConfluentKafkaResourceIntegration {
+			__typename
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
@@ -3453,6 +3644,11 @@ const getLinkedAccountsQuery = `query(
 			tagKey
 			tagValue
 		}
+		... on CloudFossaIssuesIntegration {
+			__typename
+			inventoryPollingInterval
+			metricsPollingInterval
+		}
 		... on CloudGcpAiplatformIntegration {
 			__typename
 			inventoryPollingInterval
@@ -3525,6 +3721,10 @@ const getLinkedAccountsQuery = `query(
 			inventoryPollingInterval
 			metricsPollingInterval
 		}
+		... on CloudGcpGenericIntegration {
+			__typename
+			metricsPollingInterval
+		}
 		... on CloudGcpInterconnectIntegration {
 			__typename
 			inventoryPollingInterval
@@ -3591,10 +3791,6 @@ const getLinkedAccountsQuery = `query(
 		... on CloudGcpVpcaccessIntegration {
 			__typename
 			inventoryPollingInterval
-			metricsPollingInterval
-		}
-		... on CloudGcpGenericIntegration {
-			__typename
 			metricsPollingInterval
 		}
 		... on CloudHealthIntegration {
@@ -3732,7 +3928,6 @@ const getLinkedAccountsQuery = `query(
 			tagValue
 		}
 	}
-	hasDimensionalMetrics
 	metricCollectionMode
 	name
 	nrAccountId
@@ -3762,12 +3957,13 @@ const getLinkedAccountsQuery = `query(
 			type
 		}
 		updatedAt
-		... on CloudAwsGovCloudProvider {
+		... on CloudAwsEuSovereignProvider {
 			__typename
 			awsAccountId
 		}
-		... on CloudAwsEuSovereignProvider {
+		... on CloudAwsGovCloudProvider {
 			__typename
+			awsAccountId
 		}
 		... on CloudAwsProvider {
 			__typename
@@ -3785,54 +3981,212 @@ const getLinkedAccountsQuery = `query(
 	updatedAt
 } } } }`
 
-// CloudAuthenticateIntegration authenticates a cloud provider integration and returns
-// an auth reference ID that can be used with CloudLinkAccount.
-func (a *Cloud) CloudAuthenticateIntegration(
+// Get one cloud provider by short name.
+func (a *Cloud) GetProvider(
 	accountID int,
-	providerSlug string,
-	authType string,
-	payload string,
-) (*CloudAuthenticateIntegrationPayload, error) {
-	return a.CloudAuthenticateIntegrationWithContext(context.Background(), accountID, providerSlug, authType, payload)
+	hasDimensionalMetrics bool,
+	slug string,
+) (*CloudProviderInterface, error) {
+	return a.GetProviderWithContext(context.Background(),
+		accountID,
+		hasDimensionalMetrics,
+		slug,
+	)
 }
 
-// CloudAuthenticateIntegrationWithContext authenticates a cloud provider integration (context-aware).
-// providerSlug should be "GCP", authType should be "WIF", and payload should be the JSON-encoded
-// WIF credential (audience + service account email).
-func (a *Cloud) CloudAuthenticateIntegrationWithContext(
+// Get one cloud provider by short name.
+func (a *Cloud) GetProviderWithContext(
 	ctx context.Context,
 	accountID int,
-	providerSlug string,
-	authType string,
-	payload string,
-) (*CloudAuthenticateIntegrationPayload, error) {
-	resp := struct {
-		CloudAuthenticateIntegration CloudAuthenticateIntegrationPayload `json:"cloudAuthenticateIntegration"`
-	}{}
+	hasDimensionalMetrics bool,
+	slug string,
+) (*CloudProviderInterface, error) {
+
+	resp := providerResponse{}
 	vars := map[string]interface{}{
-		"accountId":    accountID,
-		"providerSlug": providerSlug,
-		"authType":     authType,
-		"payload":      payload,
+		"accountID":             accountID,
+		"hasDimensionalMetrics": hasDimensionalMetrics,
+		"slug":                  slug,
 	}
-	if err := a.client.NerdGraphQueryWithContext(ctx, cloudAuthenticateIntegrationMutation, vars, &resp); err != nil {
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, getProviderQuery, vars, &resp); err != nil {
 		return nil, err
 	}
-	return &resp.CloudAuthenticateIntegration, nil
+
+	return &resp.Actor.Account.Cloud.Provider, nil
 }
 
-const cloudAuthenticateIntegrationMutation = `mutation(
-	$accountId: Int!,
-	$providerSlug: CloudProviderType!,
-	$authType: CloudAuthenticationType!,
-	$payload: String!,
-) {
-	cloudAuthenticateIntegration(
-		accountId: $accountId
-		providerSlug: $providerSlug
-		authType: $authType
-		payload: $payload
-	) {
-		authReferenceId
+const getProviderQuery = `query(
+	$accountID: Int!,
+) { actor { account(id: $accountID) { cloud { provider {
+	createdAt
+	icon
+	id
+	name
+	services {
+		createdAt
+		dashboards {
+			createdAt
+			layout
+			name
+			slug
+			updatedAt
+		}
+		icon
+		id
+		isEnabled
+		isEntitySupported
+		name
+		provider {
+			__typename
+			createdAt
+			icon
+			id
+			name
+			slug
+			updatedAt
+			... on CloudAwsEuSovereignProvider {
+				__typename
+				awsAccountId
+			}
+			... on CloudAwsGovCloudProvider {
+				__typename
+				awsAccountId
+			}
+			... on CloudAwsProvider {
+				__typename
+				roleAccountId
+				roleExternalId
+			}
+			... on CloudBaseProvider {
+				__typename
+			}
+			... on CloudGcpProvider {
+				__typename
+				serviceAccountId
+			}
+		}
+		slug
+		updatedAt
 	}
-}`
+	slug
+	templateParams {
+		autocomplete
+		immutable
+		label
+		name
+		placeholder
+		type
+	}
+	updatedAt
+	... on CloudAwsEuSovereignProvider {
+		__typename
+		awsAccountId
+		services {
+			createdAt
+			icon
+			id
+			isEnabled
+			isEntitySupported
+			name
+			slug
+			updatedAt
+		}
+		templateParams {
+			autocomplete
+			immutable
+			label
+			name
+			placeholder
+			type
+		}
+	}
+	... on CloudAwsGovCloudProvider {
+		__typename
+		awsAccountId
+		services {
+			createdAt
+			icon
+			id
+			isEnabled
+			isEntitySupported
+			name
+			slug
+			updatedAt
+		}
+		templateParams {
+			autocomplete
+			immutable
+			label
+			name
+			placeholder
+			type
+		}
+	}
+	... on CloudAwsProvider {
+		__typename
+		roleAccountId
+		roleExternalId
+		services {
+			createdAt
+			icon
+			id
+			isEnabled
+			isEntitySupported
+			name
+			slug
+			updatedAt
+		}
+		templateParams {
+			autocomplete
+			immutable
+			label
+			name
+			placeholder
+			type
+		}
+	}
+	... on CloudBaseProvider {
+		__typename
+		services {
+			createdAt
+			icon
+			id
+			isEnabled
+			isEntitySupported
+			name
+			slug
+			updatedAt
+		}
+		templateParams {
+			autocomplete
+			immutable
+			label
+			name
+			placeholder
+			type
+		}
+	}
+	... on CloudGcpProvider {
+		__typename
+		serviceAccountId
+		services {
+			createdAt
+			icon
+			id
+			isEnabled
+			isEntitySupported
+			name
+			slug
+			updatedAt
+		}
+		templateParams {
+			autocomplete
+			immutable
+			label
+			name
+			placeholder
+			type
+		}
+	}
+} } } } }`

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -23,6 +23,82 @@ var CloudMetricCollectionModeTypes = struct {
 	PUSH: "PUSH",
 }
 
+// CloudOciTrustType - OCI WIF trust type. UPST impersonates a service user; RPST uses claim-based ephemeral principals.
+type CloudOciTrustType string
+
+var CloudOciTrustTypeTypes = struct {
+	// Resource Principal Session Token — exchange grants an ephemeral identityfederateddomainapp principal. Customer IAM policies authorize via JWT claims (ext_account_id, ext_tenancy_id, ext_resource_tag) instead of a service-user group, enabling multi-account scoping and bypassing OCI's per-policy statement limit.
+	RPST CloudOciTrustType
+	// User Principal Session Token — exchange grants impersonation of a dedicated OCI service user. Default for backward compatibility with existing integrations.
+	UPST CloudOciTrustType
+}{
+	// Resource Principal Session Token — exchange grants an ephemeral identityfederateddomainapp principal. Customer IAM policies authorize via JWT claims (ext_account_id, ext_tenancy_id, ext_resource_tag) instead of a service-user group, enabling multi-account scoping and bypassing OCI's per-policy statement limit.
+	RPST: "RPST",
+	// User Principal Session Token — exchange grants impersonation of a dedicated OCI service user. Default for backward compatibility with existing integrations.
+	UPST: "UPST",
+}
+
+// EntityManagementCloudProvider - Supported cloud providers for federated log deployments.
+type EntityManagementCloudProvider string
+
+var EntityManagementCloudProviderTypes = struct {
+	// Amazon Web Services
+	AWS EntityManagementCloudProvider
+	// Microsoft Azure
+	AZURE EntityManagementCloudProvider
+	// Google Cloud Platform
+	GCP EntityManagementCloudProvider
+	// Oracle Cloud Infrastructure
+	OCI EntityManagementCloudProvider
+}{
+	// Amazon Web Services
+	AWS: "AWS",
+	// Microsoft Azure
+	AZURE: "AZURE",
+	// Google Cloud Platform
+	GCP: "GCP",
+	// Oracle Cloud Infrastructure
+	OCI: "OCI",
+}
+
+// EntityManagementProvider - Enum for creator of the entity
+type EntityManagementProvider string
+
+var EntityManagementProviderTypes = struct {
+	// created by external user
+	EXTERNAL EntityManagementProvider
+	// created by NR
+	INTERNAL EntityManagementProvider
+}{
+	// created by external user
+	EXTERNAL: "EXTERNAL",
+	// created by NR
+	INTERNAL: "INTERNAL",
+}
+
+// FederatedLogsCloudProvider - Supported cloud providers for federated logs.
+type FederatedLogsCloudProvider string
+
+var FederatedLogsCloudProviderTypes = struct {
+	// Amazon Web Services
+	AWS FederatedLogsCloudProvider
+	// Microsoft Azure
+	AZURE FederatedLogsCloudProvider
+	// Google Cloud Platform
+	GCP FederatedLogsCloudProvider
+	// Oracle Cloud Infrastructure
+	OCI FederatedLogsCloudProvider
+}{
+	// Amazon Web Services
+	AWS: "AWS",
+	// Microsoft Azure
+	AZURE: "AZURE",
+	// Google Cloud Platform
+	GCP: "GCP",
+	// Oracle Cloud Infrastructure
+	OCI: "OCI",
+}
+
 // Account - The `Account` object provides general data about the account, as well as
 // being the entry point into more detailed data about a single account.
 //
@@ -43,6 +119,10 @@ type Account struct {
 type Actor struct {
 	// The `cloud` field provides access to cloud integrations configuration data scoped to the Actor.
 	Cloud CloudActorFields `json:"cloud,omitempty"`
+}
+
+// Actor - The `Actor` object contains fields that are scoped to the API user's access level.
+type Actor struct {
 	// The `account` field is the entry point into data that is scoped to a single account.
 	Account Account `json:"account,omitempty"`
 }
@@ -122,12 +202,6 @@ type CloudAccountMutationError struct {
 	ProviderSlug string `json:"providerSlug,omitempty"`
 	// The error status.
 	Type string `json:"type"`
-}
-
-// CloudAuthenticateIntegrationPayload - Response payload for cloudAuthenticateIntegration mutation.
-type CloudAuthenticateIntegrationPayload struct {
-	// Short-lived reference ID (TTL ~30 minutes) used in subsequent CloudLinkAccount calls.
-	AuthReferenceId string `json:"authReferenceId"`
 }
 
 type CloudActorFields struct {
@@ -307,6 +381,44 @@ type CloudAwsAthenaIntegrationInput struct {
 	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
 }
 
+// CloudAwsAutoDiscoveryIntegration - AwsAutoDiscovery Integration
+type CloudAwsAutoDiscoveryIntegration struct {
+	// Specify each AWS region that includes the resources that you want to monitor.
+	AwsRegions []string `json:"awsRegions,omitempty"`
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudAwsAutoDiscoveryIntegration) ImplementsCloudIntegration() {}
+
+// CloudAwsAutoDiscoveryIntegrationInput - AWS Auto Discovery
+type CloudAwsAutoDiscoveryIntegrationInput struct {
+	// Specify each AWS region that includes the resources that you want to monitor.
+	AwsRegions []string `json:"awsRegions,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
 // CloudAwsCognitoIntegration - Cognito Integration
 type CloudAwsCognitoIntegration struct {
 	// Specify each AWS region that includes the resources that you want to monitor.
@@ -433,6 +545,8 @@ type CloudAwsDisableIntegrationsInput struct {
 	AwsAppsync []CloudDisableAccountIntegrationInput `json:"awsAppsync,omitempty"`
 	// Athena integration
 	AwsAthena []CloudDisableAccountIntegrationInput `json:"awsAthena,omitempty"`
+	// AutoDiscovery integration
+	AwsAutoDiscovery []CloudDisableAccountIntegrationInput `json:"awsAutoDiscovery,omitempty"`
 	// Cognito integration
 	AwsCognito []CloudDisableAccountIntegrationInput `json:"awsCognito,omitempty"`
 	// Connect integration
@@ -477,8 +591,6 @@ type CloudAwsDisableIntegrationsInput struct {
 	AwsWafv2 []CloudDisableAccountIntegrationInput `json:"awsWafv2,omitempty"`
 	// X-Ray integration
 	AwsXray []CloudDisableAccountIntegrationInput `json:"awsXray,omitempty"`
-	// Auto Discovery integration
-	AwsAutoDiscovery []CloudDisableAccountIntegrationInput `json:"awsAutoDiscovery,omitempty"`
 	// Billing integration
 	Billing []CloudDisableAccountIntegrationInput `json:"billing,omitempty"`
 	// CloudFront integration
@@ -575,6 +687,86 @@ type CloudAwsDocdbIntegrationInput struct {
 	LinkedAccountId int `json:"linkedAccountId"`
 	// The data polling interval in seconds.
 	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudAwsEuSovereignDisableIntegrationsInput - Disable integrations for AWS EU Sovereign Cloud
+type CloudAwsEuSovereignDisableIntegrationsInput struct {
+	// AWS Metadata EU Sovereign integration
+	AwsMetadataEuSovereign []CloudDisableAccountIntegrationInput `json:"awsMetadataEuSovereign,omitempty"`
+	// ElastiCache EU Sovereign integration
+	AwsMsElasticacheEuSovereign []CloudDisableAccountIntegrationInput `json:"awsMsElasticacheEuSovereign,omitempty"`
+	// AWS Tags Global EU Sovereign integration
+	AwsTagsGlobalEuSovereign []CloudDisableAccountIntegrationInput `json:"awsTagsGlobalEuSovereign,omitempty"`
+	// X-Ray integration
+	AwsXray []CloudDisableAccountIntegrationInput `json:"awsXray,omitempty"`
+	// Billing integration
+	Billing []CloudDisableAccountIntegrationInput `json:"billing,omitempty"`
+	// CloudTrail integration
+	Cloudtrail []CloudDisableAccountIntegrationInput `json:"cloudtrail,omitempty"`
+}
+
+// CloudAwsEuSovereignIntegrationsInput - List of integrations for AWS EU Sovereign Cloud
+type CloudAwsEuSovereignIntegrationsInput struct {
+	// Fetch Metadata for AWS EU Sovereign integrations integration
+	AwsMetadataEuSovereign []CloudAwsMetadataEuSovereignIntegrationInput `json:"awsMetadataEuSovereign,omitempty"`
+	// ElastiCache EU Sovereign integration
+	AwsMsElasticacheEuSovereign []CloudAwsMsElasticacheEuSovereignIntegrationInput `json:"awsMsElasticacheEuSovereign,omitempty"`
+	// Tags EU Sovereign integration
+	AwsTagsGlobalEuSovereign []CloudAwsTagsGlobalEuSovereignIntegrationInput `json:"awsTagsGlobalEuSovereign,omitempty"`
+	// X-Ray integration
+	AwsXray []CloudAwsXrayIntegrationInput `json:"awsXray,omitempty"`
+	// Billing integration
+	Billing []CloudBillingIntegrationInput `json:"billing,omitempty"`
+	// CloudTrail integration
+	Cloudtrail []CloudCloudtrailIntegrationInput `json:"cloudtrail,omitempty"`
+}
+
+// CloudAwsEuSovereignLinkAccountInput - Information required to link an AWS EU Sovereign Cloud account to a NewRelic account.
+type CloudAwsEuSovereignLinkAccountInput struct {
+	// The AWS role ARN (used to fetch data).
+	Arn string `json:"arn"`
+	// How metrics will be collected.
+	MetricCollectionMode CloudMetricCollectionMode `json:"metricCollectionMode,omitempty"`
+	// The linked account name.
+	Name string `json:"name"`
+}
+
+// CloudAwsEuSovereignProvider - The Amazon Web Services cloud provider (EU Sovereign Cloud)
+type CloudAwsEuSovereignProvider struct {
+	// The AWS Account ID
+	AwsAccountId string `json:"awsAccountId"`
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud provider identifier in NewRelic.
+	ID int `json:"id"`
+	// The cloud provider icon name.
+	Icon string `json:"icon"`
+	// The cloud provider name.
+	Name string `json:"name"`
+	// Get details of one cloud provider service.
+	Service CloudService `json:"service,omitempty"`
+	// Get details of all the cloud provider services available for integration.
+	Services []CloudService `json:"services"`
+	// The cloud provider short name.
+	Slug string `json:"slug"`
+	// Get template params of one cloud provider service.
+	TemplateParams []CloudTemplateParam `json:"templateParams"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudAwsEuSovereignProvider) ImplementsCloudProvider() {}
+
+// CloudAwsEuSovereignUpdateAccountInput - Information required to update an AWS EU Sovereign Cloud account to a NewRelic account.
+type CloudAwsEuSovereignUpdateAccountInput struct {
+	// The AWS role ARN (used to fetch data).
+	Arn string `json:"arn,omitempty"`
+	// Disable the linked account.
+	Disabled bool `json:"disabled,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The linked account new name.
+	Name string `json:"name,omitempty"`
 }
 
 // CloudAwsFsxIntegration - FSx Integration
@@ -709,176 +901,6 @@ type CloudAwsGovCloudUpdateAccountInput struct {
 	SecretAccessKey SecureValue `json:"secretAccessKey,omitempty"`
 }
 
-// CloudAwsEuSovereignLinkAccountInput - Information required to link an AWS EU Sovereign account to a NewRelic account.
-type CloudAwsEuSovereignLinkAccountInput struct {
-	// The AWS role ARN (used to fetch data).
-	Arn string `json:"arn"`
-	// How metrics will be collected.
-	MetricCollectionMode CloudMetricCollectionMode `json:"metricCollectionMode,omitempty"`
-	// The linked account name.
-	Name string `json:"name"`
-}
-
-// CloudAwsEuSovereignUpdateAccountInput - Information required to update an AWS EU Sovereign account to a NewRelic account.
-type CloudAwsEuSovereignUpdateAccountInput struct {
-	// The AWS role ARN (used to fetch data).
-	Arn string `json:"arn,omitempty"`
-	// Disable the linked account.
-	Disabled bool `json:"disabled,omitempty"`
-	// The linked account identifier.
-	LinkedAccountId int `json:"linkedAccountId"`
-	// The linked account new name.
-	Name string `json:"name,omitempty"`
-}
-
-// CloudAwsEuSovereignProvider - The Amazon Web Services cloud provider (EU Sovereign)
-type CloudAwsEuSovereignProvider struct {
-	// The object creation date, in epoch (Unix) time
-	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
-	// The cloud provider identifier in NewRelic.
-	ID int `json:"id"`
-	// The cloud provider icon name.
-	Icon string `json:"icon"`
-	// The cloud provider name.
-	Name string `json:"name"`
-	// Get details of one cloud provider service.
-	Service CloudService `json:"service,omitempty"`
-	// Get details of all the cloud provider services available for integration.
-	Services []CloudService `json:"services"`
-	// The cloud provider short name.
-	Slug string `json:"slug"`
-	// Get template params of one cloud provider service.
-	TemplateParams []CloudTemplateParam `json:"templateParams"`
-	// The object last update date, in epoch (Unix) time
-	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
-}
-
-func (x *CloudAwsEuSovereignProvider) ImplementsCloudProvider() {}
-
-// CloudAwsMetadataEuSovereignIntegration - Fetch Metadata for AWS EU Sovereign integrations Integration
-type CloudAwsMetadataEuSovereignIntegration struct {
-	// The object creation date, in epoch (Unix) time
-	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
-	// The cloud service integration identifier.
-	ID int `json:"id,omitempty"`
-	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
-	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
-	// The parent linked account identifier.
-	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
-	// The data polling interval in seconds.
-	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
-	// The cloud service integration name.
-	Name string `json:"name,omitempty"`
-	// The parent NewRelic account identifier.
-	NrAccountId int `json:"nrAccountId"`
-	// The cloud service used in the integration.
-	Service CloudService `json:"service,omitempty"`
-	// The object last update date, in epoch (Unix) time
-	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
-}
-
-func (x *CloudAwsMetadataEuSovereignIntegration) ImplementsCloudIntegration() {}
-
-// CloudAwsMetadataEuSovereignIntegrationInput - Fetch Metadata for AWS EU Sovereign integrations
-type CloudAwsMetadataEuSovereignIntegrationInput struct {
-	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
-	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
-	// The linked account identifier.
-	LinkedAccountId int `json:"linkedAccountId"`
-	// The data polling interval in seconds.
-	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
-}
-
-// CloudAwsMsElasticacheEuSovereignIntegration - Fetch ElastiCache EU Sovereign entities Integration
-type CloudAwsMsElasticacheEuSovereignIntegration struct {
-	// The object creation date, in epoch (Unix) time
-	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
-	// The cloud service integration identifier.
-	ID int `json:"id,omitempty"`
-	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
-	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
-	// The parent linked account identifier.
-	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
-	// The data polling interval in seconds.
-	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
-	// The cloud service integration name.
-	Name string `json:"name,omitempty"`
-	// The parent NewRelic account identifier.
-	NrAccountId int `json:"nrAccountId"`
-	// The cloud service used in the integration.
-	Service CloudService `json:"service,omitempty"`
-	// The object last update date, in epoch (Unix) time
-	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
-}
-
-func (x *CloudAwsMsElasticacheEuSovereignIntegration) ImplementsCloudIntegration() {}
-
-// CloudAwsMsElasticacheEuSovereignIntegrationInput - Fetch ElastiCache EU Sovereign entities
-type CloudAwsMsElasticacheEuSovereignIntegrationInput struct {
-	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
-	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
-	// The linked account identifier.
-	LinkedAccountId int `json:"linkedAccountId"`
-	// The data polling interval in seconds.
-	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
-}
-
-// CloudAwsTagsGlobalEuSovereignIntegration - Fetch tags for all AWS EU Sovereign integrations Integration
-type CloudAwsTagsGlobalEuSovereignIntegration struct {
-	// The object creation date, in epoch (Unix) time
-	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
-	// The cloud service integration identifier.
-	ID int `json:"id,omitempty"`
-	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
-	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
-	// The parent linked account identifier.
-	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
-	// The data polling interval in seconds.
-	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
-	// The cloud service integration name.
-	Name string `json:"name,omitempty"`
-	// The parent NewRelic account identifier.
-	NrAccountId int `json:"nrAccountId"`
-	// The cloud service used in the integration.
-	Service CloudService `json:"service,omitempty"`
-	// The object last update date, in epoch (Unix) time
-	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
-}
-
-func (x *CloudAwsTagsGlobalEuSovereignIntegration) ImplementsCloudIntegration() {}
-
-// CloudAwsTagsGlobalEuSovereignIntegrationInput - Fetch tags for all AWS EU Sovereign integrations
-type CloudAwsTagsGlobalEuSovereignIntegrationInput struct {
-	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
-	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
-	// The linked account identifier.
-	LinkedAccountId int `json:"linkedAccountId"`
-	// The data polling interval in seconds.
-	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
-}
-
-// CloudAwsEuSovereignDisableIntegrationsInput - List of integrations
-// EU Sovereign only supports: billing, cloudtrail, xray
-type CloudAwsEuSovereignDisableIntegrationsInput struct {
-	// Billing integration
-	Billing []CloudDisableAccountIntegrationInput `json:"billing,omitempty"`
-	// CloudTrail integration
-	Cloudtrail []CloudDisableAccountIntegrationInput `json:"cloudtrail,omitempty"`
-	// X-Ray integration
-	AwsXray []CloudDisableAccountIntegrationInput `json:"awsXray,omitempty"`
-}
-
-// CloudAwsEuSovereignIntegrationsInput - List of integrations
-// EU Sovereign only supports: billing, cloudtrail, awsXray
-type CloudAwsEuSovereignIntegrationsInput struct {
-	// Billing integration
-	Billing []CloudBillingIntegrationInput `json:"billing,omitempty"`
-	// CloudTrail integration
-	Cloudtrail []CloudCloudtrailIntegrationInput `json:"cloudtrail,omitempty"`
-	// X-Ray integration
-	AwsXray []CloudAwsXrayIntegrationInput `json:"awsXray,omitempty"`
-}
-
 // CloudAwsGovcloudDisableIntegrationsInput - List of integrations
 type CloudAwsGovcloudDisableIntegrationsInput struct {
 	// API Gateway integration
@@ -889,8 +911,14 @@ type CloudAwsGovcloudDisableIntegrationsInput struct {
 	Autoscaling []CloudDisableAccountIntegrationInput `json:"autoscaling,omitempty"`
 	// Direct Connect integration
 	AwsDirectconnect []CloudDisableAccountIntegrationInput `json:"awsDirectconnect,omitempty"`
+	// Metdata Gov integration
+	AwsMetaDataGov []CloudDisableAccountIntegrationInput `json:"awsMetaDataGov,omitempty"`
+	// ElasticCache Gov integration
+	AwsMsElasticacheGov []CloudDisableAccountIntegrationInput `json:"awsMsElasticacheGov,omitempty"`
 	// Step Functions integration
 	AwsStates []CloudDisableAccountIntegrationInput `json:"awsStates,omitempty"`
+	// Tags Gov integration
+	AwsTagsGlobalGov []CloudDisableAccountIntegrationInput `json:"awsTagsGlobalGov,omitempty"`
 	// CloudTrail integration
 	Cloudtrail []CloudDisableAccountIntegrationInput `json:"cloudtrail,omitempty"`
 	// DynamoDB integration
@@ -933,8 +961,14 @@ type CloudAwsGovcloudIntegrationsInput struct {
 	Autoscaling []CloudAutoscalingIntegrationInput `json:"autoscaling,omitempty"`
 	// Direct Connect integration
 	AwsDirectconnect []CloudAwsDirectconnectIntegrationInput `json:"awsDirectconnect,omitempty"`
+	// Fetch Metadata for AWS Gov integrations integration
+	AwsMetadataGov []CloudAwsMetadataGovIntegrationInput `json:"awsMetadataGov,omitempty"`
+	// ElasticCache Gov integration
+	AwsMsElasticacheGov []CloudAwsMsElasticacheGovIntegrationInput `json:"awsMsElasticacheGov,omitempty"`
 	// Step Functions integration
 	AwsStates []CloudAwsStatesIntegrationInput `json:"awsStates,omitempty"`
+	// Tags Gov integration
+	AwsTagsGlobalGov []CloudAwsTagsGlobalGovIntegrationInput `json:"awsTagsGlobalGov,omitempty"`
 	// CloudTrail integration
 	Cloudtrail []CloudCloudtrailIntegrationInput `json:"cloudtrail,omitempty"`
 	// DynamoDB integration
@@ -979,6 +1013,8 @@ type CloudAwsIntegrationsInput struct {
 	AwsAppsync []CloudAwsAppsyncIntegrationInput `json:"awsAppsync,omitempty"`
 	// Athena integration
 	AwsAthena []CloudAwsAthenaIntegrationInput `json:"awsAthena,omitempty"`
+	// AutoDiscovery integration
+	AwsAutoDiscovery []CloudAwsAutoDiscoveryIntegrationInput `json:"awsAutoDiscovery,omitempty"`
 	// Cognito integration
 	AwsCognito []CloudAwsCognitoIntegrationInput `json:"awsCognito,omitempty"`
 	// Connect integration
@@ -1023,8 +1059,6 @@ type CloudAwsIntegrationsInput struct {
 	AwsWafv2 []CloudAwsWafv2IntegrationInput `json:"awsWafv2,omitempty"`
 	// X-Ray integration
 	AwsXray []CloudAwsXrayIntegrationInput `json:"awsXray,omitempty"`
-	// Aws Auto Discovery Integration
-	AwsAutoDiscovery []CloudAwsAutoDiscoveryIntegrationInput `json:"awsAutoDiscovery,omitempty"`
 	// Billing integration
 	Billing []CloudBillingIntegrationInput `json:"billing,omitempty"`
 	// CloudFront integration
@@ -1209,6 +1243,74 @@ type CloudAwsMediapackagevodIntegrationInput struct {
 	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
 }
 
+// CloudAwsMetadataEuSovereignIntegration - Fetch Metadata for AWS EU Sovereign integrations Integration
+type CloudAwsMetadataEuSovereignIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudAwsMetadataEuSovereignIntegration) ImplementsCloudIntegration() {}
+
+// CloudAwsMetadataEuSovereignIntegrationInput - Fetch Metadata for AWS EU Sovereign integrations
+type CloudAwsMetadataEuSovereignIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudAwsMetadataGovIntegration - Fetch Metadata for AWS integrations Integration
+type CloudAwsMetadataGovIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudAwsMetadataGovIntegration) ImplementsCloudIntegration() {}
+
+// CloudAwsMetadataGovIntegrationInput - Fetch Metadata for AWS Gov integrations
+type CloudAwsMetadataGovIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
 // CloudAwsMetadataIntegration - Fetch Metadata for AWS integrations Integration
 type CloudAwsMetadataIntegration struct {
 	// The object creation date, in epoch (Unix) time
@@ -1281,7 +1383,75 @@ type CloudAwsMqIntegrationInput struct {
 	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
 }
 
-// CloudAwsMsElasticacheIntegration - Fetch ElastiCache entities Integration
+// CloudAwsMsElasticacheEuSovereignIntegration - Fetch ElastiCache EU Sovereign entities Integration
+type CloudAwsMsElasticacheEuSovereignIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudAwsMsElasticacheEuSovereignIntegration) ImplementsCloudIntegration() {}
+
+// CloudAwsMsElasticacheEuSovereignIntegrationInput - Fetch ElastiCache EU Sovereign entities
+type CloudAwsMsElasticacheEuSovereignIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudAwsMsElasticacheGovIntegration - Fetch ElastiCache entities Integration
+type CloudAwsMsElasticacheGovIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudAwsMsElasticacheGovIntegration) ImplementsCloudIntegration() {}
+
+// CloudAwsMsElasticacheGovIntegrationInput - Fetch ElastiCache entities
+type CloudAwsMsElasticacheGovIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudAwsMsElasticacheIntegration - Fetch ElastiCache Gov entities Integration
 type CloudAwsMsElasticacheIntegration struct {
 	// The object creation date, in epoch (Unix) time
 	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
@@ -1533,6 +1703,74 @@ type CloudAwsStatesIntegrationInput struct {
 	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
 }
 
+// CloudAwsTagsGlobalEuSovereignIntegration - Fetch tags for all AWS EU Sovereign integrations Integration
+type CloudAwsTagsGlobalEuSovereignIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudAwsTagsGlobalEuSovereignIntegration) ImplementsCloudIntegration() {}
+
+// CloudAwsTagsGlobalEuSovereignIntegrationInput - Fetch tags for all AWS EU Sovereign integrations
+type CloudAwsTagsGlobalEuSovereignIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudAwsTagsGlobalGovIntegration - Fetch tags Gov for all integrations Integration
+type CloudAwsTagsGlobalGovIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudAwsTagsGlobalGovIntegration) ImplementsCloudIntegration() {}
+
+// CloudAwsTagsGlobalGovIntegrationInput - Fetch tags for Gov for all integrations
+type CloudAwsTagsGlobalGovIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
 // CloudAwsTagsGlobalIntegration - Fetch tags for all integrations Integration
 type CloudAwsTagsGlobalIntegration struct {
 	// The object creation date, in epoch (Unix) time
@@ -1721,44 +1959,6 @@ func (x *CloudAwsXrayIntegration) ImplementsCloudIntegration() {}
 
 // CloudAwsXrayIntegrationInput - X-Ray
 type CloudAwsXrayIntegrationInput struct {
-	// Specify each AWS region that includes the resources that you want to monitor.
-	AwsRegions []string `json:"awsRegions,omitempty"`
-	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
-	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
-	// The linked account identifier.
-	LinkedAccountId int `json:"linkedAccountId"`
-	// The data polling interval in seconds.
-	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
-}
-
-// CloudAwsAutoDiscoveryIntegration - Aws Auto Discovery Integration
-type CloudAwsAutoDiscoveryIntegration struct {
-	// Specify each AWS region that includes the resources that you want to monitor.
-	AwsRegions []string `json:"awsRegions,omitempty"`
-	// The object creation date, in epoch (Unix) time
-	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
-	// The cloud service integration identifier.
-	ID int `json:"id,omitempty"`
-	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
-	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
-	// The parent linked account identifier.
-	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
-	// The data polling interval in seconds.
-	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
-	// The cloud service integration name.
-	Name string `json:"name,omitempty"`
-	// The parent NewRelic account identifier.
-	NrAccountId int `json:"nrAccountId"`
-	// The cloud service used in the integration.
-	Service CloudService `json:"service,omitempty"`
-	// The object last update date, in epoch (Unix) time
-	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
-}
-
-func (x *CloudAwsAutoDiscoveryIntegration) ImplementsCloudIntegration() {}
-
-// CloudAwsAutoDiscoveryIntegrationInput - AWS Auto Discovery Integration
-type CloudAwsAutoDiscoveryIntegrationInput struct {
 	// Specify each AWS region that includes the resources that you want to monitor.
 	AwsRegions []string `json:"awsRegions,omitempty"`
 	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
@@ -2079,7 +2279,7 @@ type CloudAzureDisableIntegrationsInput struct {
 	AzureAppgateway []CloudDisableAccountIntegrationInput `json:"azureAppgateway,omitempty"`
 	// App Service integration
 	AzureAppservice []CloudDisableAccountIntegrationInput `json:"azureAppservice,omitempty"`
-	// Azure Auto Discovery Integration
+	// Azure Auto Discovery integration
 	AzureAutoDiscovery []CloudDisableAccountIntegrationInput `json:"azureAutoDiscovery,omitempty"`
 	// Containers integration
 	AzureContainers []CloudDisableAccountIntegrationInput `json:"azureContainers,omitempty"`
@@ -2339,7 +2539,7 @@ type CloudAzureIntegrationsInput struct {
 	AzureAppgateway []CloudAzureAppgatewayIntegrationInput `json:"azureAppgateway,omitempty"`
 	// App Service integration
 	AzureAppservice []CloudAzureAppserviceIntegrationInput `json:"azureAppservice,omitempty"`
-	// Azure Auto Discovery Integration
+	// Azure Auto Discovery integration
 	AzureAutoDiscovery []CloudAzureAutoDiscoveryIntegrationInput `json:"azureAutoDiscovery,omitempty"`
 	// Containers integration
 	AzureContainers []CloudAzureContainersIntegrationInput `json:"azureContainers,omitempty"`
@@ -2611,6 +2811,8 @@ type CloudAzureMonitorIntegration struct {
 	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
 	// Specify if integration is active
 	Enabled bool `json:"enabled,omitempty"`
+	// Specify each Azure resource type that you don't want to monitor.
+	ExcludeResourceTypes []string `json:"excludeResourceTypes,omitempty"`
 	// Specify resource tags (in 'key:value' form) associated with the resources that you want to exclude from monitoring. Exclusion takes precedence over inclusion.
 	ExcludeTags []string `json:"excludeTags,omitempty"`
 	// The cloud service integration identifier.
@@ -2643,6 +2845,8 @@ func (x *CloudAzureMonitorIntegration) ImplementsCloudIntegration() {}
 type CloudAzureMonitorIntegrationInput struct {
 	// Specify if integration is active
 	Enabled bool `json:"enabled,omitempty"`
+	// Specify each Azure resource type that you don't want to monitor.
+	ExcludeResourceTypes []string `json:"excludeResourceTypes,omitempty"`
 	// Specify resource tags (in 'key:value' form) associated with the resources that you want to exclude from monitoring. Exclusion takes precedence over inclusion.
 	ExcludeTags []string `json:"excludeTags,omitempty"`
 	// Specify resource tags (in 'key:value' form) associated with the resources that you want to monitor. If empty, all resources will be monitored.
@@ -3046,7 +3250,7 @@ type CloudAzureUpdateAccountInput struct {
 	// The Azure account application secret key.
 	ClientSecret SecureValue `json:"clientSecret,omitempty"`
 	// Disable the linked account.
-	Disabled *bool `json:"disabled,omitempty"`
+	Disabled bool `json:"disabled,omitempty"`
 	// The linked account identifier.
 	LinkedAccountId int `json:"linkedAccountId"`
 	// The linked account new name.
@@ -3287,6 +3491,76 @@ type CloudBillingIntegrationInput struct {
 	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
 }
 
+// CloudCciAwsDisableIntegrationsInput - List of integrations
+type CloudCciAwsDisableIntegrationsInput struct {
+	// CCI AWS S3 integration
+	CciAwsS3 []CloudDisableAccountIntegrationInput `json:"cciAwsS3,omitempty"`
+}
+
+// CloudCciAwsIntegrationsInput - List of integrations
+type CloudCciAwsIntegrationsInput struct {
+	// CCI AWS S3 Integration integration
+	CciAwsS3 []CloudCciAwsS3IntegrationInput `json:"cciAwsS3,omitempty"`
+}
+
+// CloudCciAwsLinkAccountInput - Information required to link a CCI AWS account to a NewRelic account.
+type CloudCciAwsLinkAccountInput struct {
+	// The arn of the AWS Payer Account
+	Arn string `json:"arn"`
+	// External ID to assume the role
+	ExternalId string `json:"externalId,omitempty"`
+	// How metrics will be collected.
+	MetricCollectionMode CloudMetricCollectionMode `json:"metricCollectionMode,omitempty"`
+	// The name of the CCI AWS Connection
+	Name string `json:"name"`
+}
+
+// CloudCciAwsS3Integration - CCI AWS S3 Integration
+type CloudCciAwsS3Integration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The name of the S3 bucket to collect data from.
+	S3BucketName string `json:"s3BucketName,omitempty"`
+	// The path within the S3 bucket to collect data from.
+	S3BucketPath string `json:"s3BucketPath,omitempty"`
+	// The region of the S3 bucket to collect data from.
+	S3BucketRegion string `json:"s3BucketRegion,omitempty"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudCciAwsS3Integration) ImplementsCloudIntegration() {}
+
+// CloudCciAwsS3IntegrationInput - Cci AWS S3
+type CloudCciAwsS3IntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The name of the S3 bucket to collect data from.
+	S3BucketName string `json:"s3BucketName,omitempty"`
+	// The path within the S3 bucket to collect data from.
+	S3BucketPath string `json:"s3BucketPath,omitempty"`
+	// The region of the S3 bucket to collect data from.
+	S3BucketRegion string `json:"s3BucketRegion,omitempty"`
+}
+
 // CloudCloudfrontIntegration - CloudFront Integration
 type CloudCloudfrontIntegration struct {
 	// The object creation date, in epoch (Unix) time
@@ -3428,6 +3702,178 @@ func (x *CloudConfigureIntegrationPayload) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// CloudConfluentDisableIntegrationsInput - List of integrations
+type CloudConfluentDisableIntegrationsInput struct {
+	// Confluent Kafka Connector integration
+	ConfluentKafkaConnectorResource []CloudDisableAccountIntegrationInput `json:"confluentKafkaConnectorResource,omitempty"`
+	// Confluent Kafka Flink integration
+	ConfluentKafkaFlinkResource []CloudDisableAccountIntegrationInput `json:"confluentKafkaFlinkResource,omitempty"`
+	// Confluent Kafka Ksql integration
+	ConfluentKafkaKsqlResource []CloudDisableAccountIntegrationInput `json:"confluentKafkaKsqlResource,omitempty"`
+	// Confluent Kafka Resource integration
+	ConfluentKafkaResource []CloudDisableAccountIntegrationInput `json:"confluentKafkaResource,omitempty"`
+}
+
+// CloudConfluentIntegrationsInput - List of integrations
+type CloudConfluentIntegrationsInput struct {
+	// Confluent Kafka Connector integration
+	ConfluentKafkaConnectorResource []CloudConfluentKafkaConnectorResourceIntegrationInput `json:"confluentKafkaConnectorResource,omitempty"`
+	// Confluent Kafka Flink integration
+	ConfluentKafkaFlinkResource []CloudConfluentKafkaFlinkResourceIntegrationInput `json:"confluentKafkaFlinkResource,omitempty"`
+	// Confluent Kafka Ksql integration
+	ConfluentKafkaKsqlResource []CloudConfluentKafkaKsqlResourceIntegrationInput `json:"confluentKafkaKsqlResource,omitempty"`
+	// Confluent Kafka Resource integration
+	ConfluentKafkaResource []CloudConfluentKafkaResourceIntegrationInput `json:"confluentKafkaResource,omitempty"`
+}
+
+// CloudConfluentKafkaConnectorResourceIntegration - Confluent Kafka Connector Resource Integration
+type CloudConfluentKafkaConnectorResourceIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudConfluentKafkaConnectorResourceIntegration) ImplementsCloudIntegration() {}
+
+// CloudConfluentKafkaConnectorResourceIntegrationInput - Confluent Kafka Connector Resource
+type CloudConfluentKafkaConnectorResourceIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudConfluentKafkaFlinkResourceIntegration - Confluent Kafka flink Resource Integration
+type CloudConfluentKafkaFlinkResourceIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudConfluentKafkaFlinkResourceIntegration) ImplementsCloudIntegration() {}
+
+// CloudConfluentKafkaFlinkResourceIntegrationInput - Confluent Kafka Flink Resource
+type CloudConfluentKafkaFlinkResourceIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudConfluentKafkaKsqlResourceIntegration - Confluent Kafka Ksql Resource Integration
+type CloudConfluentKafkaKsqlResourceIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudConfluentKafkaKsqlResourceIntegration) ImplementsCloudIntegration() {}
+
+// CloudConfluentKafkaKsqlResourceIntegrationInput - Confluent Kafka Ksql Resource
+type CloudConfluentKafkaKsqlResourceIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudConfluentKafkaResourceIntegration - Confluent Kafka Resource Integration
+type CloudConfluentKafkaResourceIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudConfluentKafkaResourceIntegration) ImplementsCloudIntegration() {}
+
+// CloudConfluentKafkaResourceIntegrationInput - Confluent Kafka Resource
+type CloudConfluentKafkaResourceIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudConfluentLinkAccountInput - Information required to link a Confluent Cloud account to a NewRelic account.
+type CloudConfluentLinkAccountInput struct {
+	// The Confluent Cloud account API key.
+	APIKey SecureValue `json:"apiKey"`
+	// The Confluent Cloud account API Secret key.
+	APISecret SecureValue `json:"apiSecret"`
+	// The Confluent Cloud account identifier.
+	ExternalId string `json:"externalId,omitempty"`
+	// The linked account name.
+	Name string `json:"name"`
+}
+
 // CloudConfluentUpdateAccountInput - Information required to update a Confluent Cloud account to a NewRelic account.
 type CloudConfluentUpdateAccountInput struct {
 	// The Confluent account API key.
@@ -3521,12 +3967,18 @@ func (x *CloudDisableIntegrationPayload) UnmarshalJSON(b []byte) error {
 type CloudDisableIntegrationsInput struct {
 	// Aws provider
 	Aws CloudAwsDisableIntegrationsInput `json:"aws,omitempty"`
-	// AwsEuSovereign provider
+	// AWS EU Sovereign Cloud provider
 	AwsEuSovereign CloudAwsEuSovereignDisableIntegrationsInput `json:"awsEuSovereign,omitempty"`
 	// AwsGovcloud provider
 	AwsGovcloud CloudAwsGovcloudDisableIntegrationsInput `json:"awsGovcloud,omitempty"`
 	// Azure provider
 	Azure CloudAzureDisableIntegrationsInput `json:"azure,omitempty"`
+	// CciAws provider
+	CciAws CloudCciAwsDisableIntegrationsInput `json:"cciAws,omitempty"`
+	// Confluent provider
+	Confluent CloudConfluentDisableIntegrationsInput `json:"confluent,omitempty"`
+	// Fossa provider
+	Fossa CloudFossaDisableIntegrationsInput `json:"fossa,omitempty"`
 	// Gcp provider
 	Gcp CloudGcpDisableIntegrationsInput `json:"gcp,omitempty"`
 	// OCI Provider
@@ -4041,6 +4493,62 @@ type CloudEmrIntegrationInput struct {
 	TagValue string `json:"tagValue,omitempty"`
 }
 
+// CloudFossaDisableIntegrationsInput - List of integrations
+type CloudFossaDisableIntegrationsInput struct {
+	// FOSSA Issues integration
+	FossaIssues []CloudDisableAccountIntegrationInput `json:"fossaIssues,omitempty"`
+}
+
+// CloudFossaIntegrationsInput - List of integrations
+type CloudFossaIntegrationsInput struct {
+	// FOSSA Issues integration
+	FossaIssues []CloudFossaIssuesIntegrationInput `json:"fossaIssues,omitempty"`
+}
+
+// CloudFossaIssuesIntegration - FOSSA Issues Integration
+type CloudFossaIssuesIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudFossaIssuesIntegration) ImplementsCloudIntegration() {}
+
+// CloudFossaIssuesIntegrationInput - FOSSA Issues
+type CloudFossaIssuesIntegrationInput struct {
+	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
+	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
+// CloudFossaLinkAccountInput - Information required to link a Fossa account to a NewRelic account.
+type CloudFossaLinkAccountInput struct {
+	// The Fossa account application api key(bearer token).
+	APIKey SecureValue `json:"apiKey"`
+	// The Fossa account identifier.
+	ExternalId string `json:"externalId,omitempty"`
+	// The linked account name.
+	Name string `json:"name"`
+}
+
 // CloudFossaUpdateAccountInput - Information required to update a Fossa account to a NewRelic account.
 type CloudFossaUpdateAccountInput struct {
 	// The Fossa account application api key(bearer token).
@@ -4117,40 +4625,6 @@ func (x *CloudGcpAlloydbIntegration) ImplementsCloudIntegration() {}
 type CloudGcpAlloydbIntegrationInput struct {
 	// [DEPRECATED] Multiple polling interval is no longer supported, use only metrics_polling_interval
 	InventoryPollingInterval int `json:"inventoryPollingInterval,omitempty"`
-	// The linked account identifier.
-	LinkedAccountId int `json:"linkedAccountId"`
-	// The data polling interval in seconds.
-	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
-}
-
-// CloudGcpGenericIntegration - Generic GCP DM integration used for API Gateway, Firebase
-// Authentication, Firebase Vertex AI, Firebase App Hosting, Istio, Managed Kafka, and
-// Memorystore, none of which have a dedicated integration type in the schema.
-type CloudGcpGenericIntegration struct {
-	// The object creation date, in epoch (Unix) time
-	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
-	// The cloud service integration identifier.
-	ID int `json:"id,omitempty"`
-	// The parent linked account identifier.
-	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
-	// The data polling interval in seconds.
-	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
-	// The cloud service integration name.
-	Name string `json:"name,omitempty"`
-	// The parent NewRelic account identifier.
-	NrAccountId int `json:"nrAccountId"`
-	// The cloud service used in the integration.
-	Service CloudService `json:"service,omitempty"`
-	// The object last update date, in epoch (Unix) time
-	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
-}
-
-func (x *CloudGcpGenericIntegration) ImplementsCloudIntegration() {}
-
-// CloudGcpGenericIntegrationInput - Generic GCP DM integration input used for API Gateway,
-// Firebase Authentication, Firebase Vertex AI, Firebase App Hosting, Istio, Managed Kafka,
-// and Memorystore (Dimensional Metrics only).
-type CloudGcpGenericIntegrationInput struct {
 	// The linked account identifier.
 	LinkedAccountId int `json:"linkedAccountId"`
 	// The data polling interval in seconds.
@@ -4405,6 +4879,8 @@ type CloudGcpDatastoreIntegrationInput struct {
 
 // CloudGcpDisableIntegrationsInput - List of integrations
 type CloudGcpDisableIntegrationsInput struct {
+	// API Gateway integration
+	GcpAPIGateway []CloudDisableAccountIntegrationInput `json:"gcpApiGateway,omitempty"`
 	// Vertex AI integration
 	GcpAiplatform []CloudDisableAccountIntegrationInput `json:"gcpAiplatform,omitempty"`
 	// AlloyDB integration
@@ -4423,6 +4899,12 @@ type CloudGcpDisableIntegrationsInput struct {
 	GcpDataproc []CloudDisableAccountIntegrationInput `json:"gcpDataproc,omitempty"`
 	// Datastore integration
 	GcpDatastore []CloudDisableAccountIntegrationInput `json:"gcpDatastore,omitempty"`
+	// Firebase App Hosting integration
+	GcpFirebaseAppHosting []CloudDisableAccountIntegrationInput `json:"gcpFirebaseAppHosting,omitempty"`
+	// Firebase Authentication integration
+	GcpFirebaseAuth []CloudDisableAccountIntegrationInput `json:"gcpFirebaseAuth,omitempty"`
+	// Firebase Vertex AI integration
+	GcpFirebaseVertexAi []CloudDisableAccountIntegrationInput `json:"gcpFirebaseVertexAi,omitempty"`
 	// Firebase Database integration
 	GcpFirebasedatabase []CloudDisableAccountIntegrationInput `json:"gcpFirebasedatabase,omitempty"`
 	// Firebase Hosting integration
@@ -4435,12 +4917,18 @@ type CloudGcpDisableIntegrationsInput struct {
 	GcpFunctions []CloudDisableAccountIntegrationInput `json:"gcpFunctions,omitempty"`
 	// Interconnect integration
 	GcpInterconnect []CloudDisableAccountIntegrationInput `json:"gcpInterconnect,omitempty"`
+	// Istio integration
+	GcpIstio []CloudDisableAccountIntegrationInput `json:"gcpIstio,omitempty"`
 	// Kubernetes Engine integration
 	GcpKubernetes []CloudDisableAccountIntegrationInput `json:"gcpKubernetes,omitempty"`
 	// Cloud Load Balancing integration
 	GcpLoadbalancing []CloudDisableAccountIntegrationInput `json:"gcpLoadbalancing,omitempty"`
+	// Managed Service for Apache Kafka integration
+	GcpManagedKafka []CloudDisableAccountIntegrationInput `json:"gcpManagedKafka,omitempty"`
 	// Memcache integration
 	GcpMemcache []CloudDisableAccountIntegrationInput `json:"gcpMemcache,omitempty"`
+	// Memorystore integration
+	GcpMemoryStore []CloudDisableAccountIntegrationInput `json:"gcpMemoryStore,omitempty"`
 	// Cloud Pub/Sub integration
 	GcpPubsub []CloudDisableAccountIntegrationInput `json:"gcpPubsub,omitempty"`
 	// Redis integration
@@ -4459,20 +4947,6 @@ type CloudGcpDisableIntegrationsInput struct {
 	GcpVms []CloudDisableAccountIntegrationInput `json:"gcpVms,omitempty"`
 	// VPC Access integration
 	GcpVpcaccess []CloudDisableAccountIntegrationInput `json:"gcpVpcaccess,omitempty"`
-	// API Gateway integration (Dimensional Metrics only)
-	GcpApiGateway []CloudDisableAccountIntegrationInput `json:"gcpApiGateway,omitempty"`
-	// Firebase Authentication integration (Dimensional Metrics only)
-	GcpFirebaseAuth []CloudDisableAccountIntegrationInput `json:"gcpFirebaseAuth,omitempty"`
-	// Firebase Vertex AI integration (Dimensional Metrics only)
-	GcpFirebaseVertexAi []CloudDisableAccountIntegrationInput `json:"gcpFirebaseVertexAi,omitempty"`
-	// Firebase App Hosting integration (Dimensional Metrics only)
-	GcpFirebaseAppHosting []CloudDisableAccountIntegrationInput `json:"gcpFirebaseAppHosting,omitempty"`
-	// Istio integration (Dimensional Metrics only)
-	GcpIstio []CloudDisableAccountIntegrationInput `json:"gcpIstio,omitempty"`
-	// Managed Kafka integration (Dimensional Metrics only)
-	GcpManagedKafka []CloudDisableAccountIntegrationInput `json:"gcpManagedKafka,omitempty"`
-	// Memorystore integration (Dimensional Metrics only)
-	GcpMemoryStore []CloudDisableAccountIntegrationInput `json:"gcpMemoryStore,omitempty"`
 }
 
 // CloudGcpFirebasedatabaseIntegration - Firebase Database Integration
@@ -4645,8 +5119,40 @@ type CloudGcpFunctionsIntegrationInput struct {
 	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
 }
 
+// CloudGcpGenericIntegration - Generic GCP integration for services with no service-specific configuration. Use service.slug to identify the specific integration.
+type CloudGcpGenericIntegration struct {
+	// The object creation date, in epoch (Unix) time
+	CreatedAt nrtime.EpochSeconds `json:"createdAt"`
+	// The cloud service integration identifier.
+	ID int `json:"id,omitempty"`
+	// The parent linked account identifier.
+	LinkedAccount CloudLinkedAccount `json:"linkedAccount,omitempty"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+	// The cloud service integration name.
+	Name string `json:"name,omitempty"`
+	// The parent NewRelic account identifier.
+	NrAccountId int `json:"nrAccountId"`
+	// The cloud service used in the integration.
+	Service CloudService `json:"service,omitempty"`
+	// The object last update date, in epoch (Unix) time
+	UpdatedAt nrtime.EpochSeconds `json:"updatedAt"`
+}
+
+func (x *CloudGcpGenericIntegration) ImplementsCloudIntegration() {}
+
+// CloudGcpGenericIntegrationInput - Generic GCP integration input for integrations with no service-specific configuration
+type CloudGcpGenericIntegrationInput struct {
+	// The linked account identifier.
+	LinkedAccountId int `json:"linkedAccountId"`
+	// The data polling interval in seconds.
+	MetricsPollingInterval int `json:"metricsPollingInterval,omitempty"`
+}
+
 // CloudGcpIntegrationsInput - List of integrations
 type CloudGcpIntegrationsInput struct {
+	// API Gateway integration
+	GcpAPIGateway []CloudGcpGenericIntegrationInput `json:"gcpApiGateway,omitempty"`
 	// Vertex AI integration
 	GcpAiplatform []CloudGcpAiplatformIntegrationInput `json:"gcpAiplatform,omitempty"`
 	// AlloyDB integration
@@ -4665,6 +5171,12 @@ type CloudGcpIntegrationsInput struct {
 	GcpDataproc []CloudGcpDataprocIntegrationInput `json:"gcpDataproc,omitempty"`
 	// Datastore integration
 	GcpDatastore []CloudGcpDatastoreIntegrationInput `json:"gcpDatastore,omitempty"`
+	// Firebase App Hosting integration
+	GcpFirebaseAppHosting []CloudGcpGenericIntegrationInput `json:"gcpFirebaseAppHosting,omitempty"`
+	// Firebase Authentication integration
+	GcpFirebaseAuth []CloudGcpGenericIntegrationInput `json:"gcpFirebaseAuth,omitempty"`
+	// Firebase Vertex AI integration
+	GcpFirebaseVertexAi []CloudGcpGenericIntegrationInput `json:"gcpFirebaseVertexAi,omitempty"`
 	// Firebase Database integration
 	GcpFirebasedatabase []CloudGcpFirebasedatabaseIntegrationInput `json:"gcpFirebasedatabase,omitempty"`
 	// Firebase Hosting integration
@@ -4677,12 +5189,18 @@ type CloudGcpIntegrationsInput struct {
 	GcpFunctions []CloudGcpFunctionsIntegrationInput `json:"gcpFunctions,omitempty"`
 	// Interconnect integration
 	GcpInterconnect []CloudGcpInterconnectIntegrationInput `json:"gcpInterconnect,omitempty"`
+	// Istio integration
+	GcpIstio []CloudGcpGenericIntegrationInput `json:"gcpIstio,omitempty"`
 	// Kubernetes Engine integration
 	GcpKubernetes []CloudGcpKubernetesIntegrationInput `json:"gcpKubernetes,omitempty"`
 	// Cloud Load Balancing integration
 	GcpLoadbalancing []CloudGcpLoadbalancingIntegrationInput `json:"gcpLoadbalancing,omitempty"`
+	// Managed Service for Apache Kafka integration
+	GcpManagedKafka []CloudGcpGenericIntegrationInput `json:"gcpManagedKafka,omitempty"`
 	// Memcache integration
 	GcpMemcache []CloudGcpMemcacheIntegrationInput `json:"gcpMemcache,omitempty"`
+	// Memorystore integration
+	GcpMemoryStore []CloudGcpGenericIntegrationInput `json:"gcpMemoryStore,omitempty"`
 	// Cloud Pub/Sub integration
 	GcpPubsub []CloudGcpPubsubIntegrationInput `json:"gcpPubsub,omitempty"`
 	// Redis integration
@@ -4701,20 +5219,6 @@ type CloudGcpIntegrationsInput struct {
 	GcpVms []CloudGcpVmsIntegrationInput `json:"gcpVms,omitempty"`
 	// VPC Access integration
 	GcpVpcaccess []CloudGcpVpcaccessIntegrationInput `json:"gcpVpcaccess,omitempty"`
-	// API Gateway integration (Dimensional Metrics only)
-	GcpApiGateway []CloudGcpGenericIntegrationInput `json:"gcpApiGateway,omitempty"`
-	// Firebase Authentication integration (Dimensional Metrics only)
-	GcpFirebaseAuth []CloudGcpGenericIntegrationInput `json:"gcpFirebaseAuth,omitempty"`
-	// Firebase Vertex AI integration (Dimensional Metrics only)
-	GcpFirebaseVertexAi []CloudGcpGenericIntegrationInput `json:"gcpFirebaseVertexAi,omitempty"`
-	// Firebase App Hosting integration (Dimensional Metrics only)
-	GcpFirebaseAppHosting []CloudGcpGenericIntegrationInput `json:"gcpFirebaseAppHosting,omitempty"`
-	// Istio integration (Dimensional Metrics only)
-	GcpIstio []CloudGcpGenericIntegrationInput `json:"gcpIstio,omitempty"`
-	// Managed Kafka integration (Dimensional Metrics only)
-	GcpManagedKafka []CloudGcpGenericIntegrationInput `json:"gcpManagedKafka,omitempty"`
-	// Memorystore integration (Dimensional Metrics only)
-	GcpMemoryStore []CloudGcpGenericIntegrationInput `json:"gcpMemoryStore,omitempty"`
 }
 
 // CloudGcpInterconnectIntegration - Interconnect Integration
@@ -4787,13 +5291,12 @@ type CloudGcpKubernetesIntegrationInput struct {
 
 // CloudGcpLinkAccountInput - Information required to link a GCP account to a NewRelic account.
 type CloudGcpLinkAccountInput struct {
+	// Optional: Session key from cloudAuthenticateIntegration for WIF-based authentication
+	AuthReferenceId string `json:"authReferenceId,omitempty"`
 	// The linked account name.
 	Name string `json:"name"`
 	// The GCP project identifier.
 	ProjectId string `json:"projectId"`
-	// The authentication reference ID obtained from CloudAuthenticateIntegration.
-	// Required for GCP Dimensional Metrics (WIF) account linking; omit for legacy service-account key auth.
-	AuthReferenceId string `json:"authReferenceId,omitempty"`
 }
 
 // CloudGcpLoadbalancingIntegration - Cloud Load Balancing Integration
@@ -5334,12 +5837,18 @@ type CloudIntegrationMutationError struct {
 type CloudIntegrationsInput struct {
 	// Aws provider
 	Aws CloudAwsIntegrationsInput `json:"aws,omitempty"`
-	// AwsEuSovereign provider
+	// AWS EU Sovereign Cloud provider
 	AwsEuSovereign CloudAwsEuSovereignIntegrationsInput `json:"awsEuSovereign,omitempty"`
 	// AwsGovcloud provider
 	AwsGovcloud CloudAwsGovcloudIntegrationsInput `json:"awsGovcloud,omitempty"`
 	// Azure provider
 	Azure CloudAzureIntegrationsInput `json:"azure,omitempty"`
+	// CciAws provider
+	CciAws CloudCciAwsIntegrationsInput `json:"cciAws,omitempty"`
+	// Confluent provider
+	Confluent CloudConfluentIntegrationsInput `json:"confluent,omitempty"`
+	// Fossa provider
+	Fossa CloudFossaIntegrationsInput `json:"fossa,omitempty"`
 	// Gcp provider
 	Gcp CloudGcpIntegrationsInput `json:"gcp,omitempty"`
 	// OCI Provider
@@ -5538,12 +6047,18 @@ type CloudLinkAccountPayload struct {
 type CloudLinkCloudAccountsInput struct {
 	// Aws provider
 	Aws []CloudAwsLinkAccountInput `json:"aws,omitempty"`
-	// AwsEuSovereign provider
+	// AWS EU Sovereign Cloud provider
 	AwsEuSovereign []CloudAwsEuSovereignLinkAccountInput `json:"awsEuSovereign,omitempty"`
 	// AwsGovCloud provider
 	AwsGovcloud []CloudAwsGovCloudLinkAccountInput `json:"awsGovcloud,omitempty"`
 	// Azure provider
 	Azure []CloudAzureLinkAccountInput `json:"azure,omitempty"`
+	// CCI AWS provider
+	CciAws []CloudCciAwsLinkAccountInput `json:"cciAws,omitempty"`
+	// Confluent Cloud provider
+	Confluent []CloudConfluentLinkAccountInput `json:"confluent,omitempty"`
+	// Fossa provider
+	Fossa []CloudFossaLinkAccountInput `json:"fossa,omitempty"`
 	// Gcp provider
 	Gcp []CloudGcpLinkAccountInput `json:"gcp,omitempty"`
 	// OCI Provider
@@ -5560,14 +6075,14 @@ type CloudLinkedAccount struct {
 	Disabled bool `json:"disabled,omitempty"`
 	// The cloud account identifier. This is the Account ID in AWS, the Subscription ID in Azure and the Project ID in GCP.
 	ExternalId string `json:"externalId,omitempty"`
+	// Indicates whether this linked account uses dimensional metrics.
+	HasDimensionalMetrics bool `json:"hasDimensionalMetrics,omitempty"`
 	// The linked account identifier in NewRelic.
 	ID int `json:"id"`
 	// Get details of one cloud service integration.
 	Integration CloudIntegrationInterface `json:"integration"`
 	// Get details of all cloud service integrations.
 	Integrations []CloudIntegrationInterface `json:"integrations"`
-	// Indicates whether this linked account uses dimensional metrics.
-	HasDimensionalMetrics bool `json:"hasDimensionalMetrics,omitempty"`
 	// Indicate how the metrics will be collected (PUSH/PULL)
 	MetricCollectionMode CloudMetricCollectionMode `json:"metricCollectionMode"`
 	// The linked account name in NewRelic.
@@ -5614,6 +6129,11 @@ func (x *CloudLinkedAccount) UnmarshalJSON(b []byte) error {
 			if err != nil {
 				return err
 			}
+		case "hasDimensionalMetrics":
+			err = json.Unmarshal(*v, &x.HasDimensionalMetrics)
+			if err != nil {
+				return err
+			}
 		case "id":
 			err = json.Unmarshal(*v, &x.ID)
 			if err != nil {
@@ -5650,11 +6170,6 @@ func (x *CloudLinkedAccount) UnmarshalJSON(b []byte) error {
 				if xxx != nil {
 					x.Integrations = append(x.Integrations, *xxx)
 				}
-			}
-		case "hasDimensionalMetrics":
-			err = json.Unmarshal(*v, &x.HasDimensionalMetrics)
-			if err != nil {
-				return err
 			}
 		case "metricCollectionMode":
 			err = json.Unmarshal(*v, &x.MetricCollectionMode)
@@ -5717,7 +6232,7 @@ type CloudOciLinkAccountInput struct {
 	// The OCI ingest secret OCID.
 	IngestVaultOcid string `json:"ingestVaultOcid"`
 	// Specifies the type of integration, such as metrics, logs, or a combination of logs and metrics.
-	InstrumentationType string `json:"instrumentationType,omitempty"`
+	InstrumentationType string `json:"instrumentationType"`
 	// The linked account name.
 	Name string `json:"name"`
 	// The client ID for OCI WIF.
@@ -5736,19 +6251,6 @@ type CloudOciLinkAccountInput struct {
 	TrustType CloudOciTrustType `json:"trustType,omitempty"`
 	// The user secret OCID.
 	UserVaultOcid string `json:"userVaultOcid"`
-}
-
-// CloudOciTrustType - OCI WIF trust type. UPST impersonates a service user; RPST uses claim-based ephemeral principals.
-type CloudOciTrustType string
-
-var CloudOciTrustTypeTypes = struct {
-	// Resource Principal Session Token — exchange grants an ephemeral identityfederateddomainapp principal. Customer IAM policies authorize via JWT claims (ext_account_id, ext_tenancy_id, ext_resource_tag) instead of a service-user group, enabling multi-account scoping and bypassing OCI's per-policy statement limit.
-	RPST CloudOciTrustType
-	// User Principal Session Token — exchange grants impersonation of a dedicated OCI service user. Default for backward compatibility with existing integrations.
-	UPST CloudOciTrustType
-}{
-	RPST: "RPST",
-	UPST: "UPST",
 }
 
 // CloudOciLogsIntegration - Fetch Metadata and Tags for OCI Logs integrations Integration
@@ -6428,7 +6930,7 @@ type CloudUpdateAccountPayload struct {
 type CloudUpdateCloudAccountsInput struct {
 	// Aws provider
 	Aws []CloudAwsUpdateAccountInput `json:"aws,omitempty"`
-	// AwsEuSovereign provider
+	// AWS EU Sovereign Cloud provider
 	AwsEuSovereign []CloudAwsEuSovereignUpdateAccountInput `json:"awsEuSovereign,omitempty"`
 	// AwsGovCloud provider
 	AwsGovcloud []CloudAwsGovCloudUpdateAccountInput `json:"awsGovcloud,omitempty"`
@@ -6503,6 +7005,10 @@ type linkedAccountResponse struct {
 }
 
 type linkedAccountsResponse struct {
+	Actor Actor `json:"actor"`
+}
+
+type providerResponse struct {
 	Actor Actor `json:"actor"`
 }
 
@@ -6581,6 +7087,16 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			return &xxx, nil
 		case "CloudAwsAthenaIntegration":
 			var interfaceType CloudAwsAthenaIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
+		case "CloudAwsAutoDiscoveryIntegration":
+			var interfaceType CloudAwsAutoDiscoveryIntegration
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err
@@ -6679,8 +7195,8 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			var xxx CloudIntegrationInterface = &interfaceType
 
 			return &xxx, nil
-		case "CloudAwsMetadataIntegration":
-			var interfaceType CloudAwsMetadataIntegration
+		case "CloudAwsMetadataEuSovereignIntegration":
+			var interfaceType CloudAwsMetadataEuSovereignIntegration
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err
@@ -6689,8 +7205,18 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			var xxx CloudIntegrationInterface = &interfaceType
 
 			return &xxx, nil
-		case "CloudAwsMetadataEuSovereignIntegration":
-			var interfaceType CloudAwsMetadataEuSovereignIntegration
+		case "CloudAwsMetadataGovIntegration":
+			var interfaceType CloudAwsMetadataGovIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
+		case "CloudAwsMetadataIntegration":
+			var interfaceType CloudAwsMetadataIntegration
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err
@@ -6709,8 +7235,8 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			var xxx CloudIntegrationInterface = &interfaceType
 
 			return &xxx, nil
-		case "CloudAwsMsElasticacheIntegration":
-			var interfaceType CloudAwsMsElasticacheIntegration
+		case "CloudAwsMsElasticacheEuSovereignIntegration":
+			var interfaceType CloudAwsMsElasticacheEuSovereignIntegration
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err
@@ -6719,8 +7245,18 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			var xxx CloudIntegrationInterface = &interfaceType
 
 			return &xxx, nil
-		case "CloudAwsMsElasticacheEuSovereignIntegration":
-			var interfaceType CloudAwsMsElasticacheEuSovereignIntegration
+		case "CloudAwsMsElasticacheGovIntegration":
+			var interfaceType CloudAwsMsElasticacheGovIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
+		case "CloudAwsMsElasticacheIntegration":
+			var interfaceType CloudAwsMsElasticacheIntegration
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err
@@ -6779,8 +7315,8 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			var xxx CloudIntegrationInterface = &interfaceType
 
 			return &xxx, nil
-		case "CloudAwsTagsGlobalIntegration":
-			var interfaceType CloudAwsTagsGlobalIntegration
+		case "CloudAwsTagsGlobalEuSovereignIntegration":
+			var interfaceType CloudAwsTagsGlobalEuSovereignIntegration
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err
@@ -6789,8 +7325,18 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			var xxx CloudIntegrationInterface = &interfaceType
 
 			return &xxx, nil
-		case "CloudAwsTagsGlobalEuSovereignIntegration":
-			var interfaceType CloudAwsTagsGlobalEuSovereignIntegration
+		case "CloudAwsTagsGlobalGovIntegration":
+			var interfaceType CloudAwsTagsGlobalGovIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
+		case "CloudAwsTagsGlobalIntegration":
+			var interfaceType CloudAwsTagsGlobalIntegration
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err
@@ -6839,14 +7385,6 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			var xxx CloudIntegrationInterface = &interfaceType
 
 			return &xxx, nil
-		case "CloudAwsAutoDiscoveryIntegration":
-			var interfaceType CloudAwsAutoDiscoveryIntegration
-			err = json.Unmarshal(b, &interfaceType)
-			if err != nil {
-				return nil, err
-			}
-			var xxx CloudIntegrationInterface = &interfaceType
-			return &xxx, nil
 		case "CloudAzureApimanagementIntegration":
 			var interfaceType CloudAzureAPImanagementIntegration
 			err = json.Unmarshal(b, &interfaceType)
@@ -6877,7 +7415,6 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			var xxx CloudIntegrationInterface = &interfaceType
 
 			return &xxx, nil
-
 		case "CloudAzureAutoDiscoveryIntegration":
 			var interfaceType CloudAzureAutoDiscoveryIntegration
 			err = json.Unmarshal(b, &interfaceType)
@@ -7198,6 +7735,16 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			var xxx CloudIntegrationInterface = &interfaceType
 
 			return &xxx, nil
+		case "CloudCciAwsS3Integration":
+			var interfaceType CloudCciAwsS3Integration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
 		case "CloudCloudfrontIntegration":
 			var interfaceType CloudCloudfrontIntegration
 			err = json.Unmarshal(b, &interfaceType)
@@ -7210,6 +7757,46 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			return &xxx, nil
 		case "CloudCloudtrailIntegration":
 			var interfaceType CloudCloudtrailIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
+		case "CloudConfluentKafkaConnectorResourceIntegration":
+			var interfaceType CloudConfluentKafkaConnectorResourceIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
+		case "CloudConfluentKafkaFlinkResourceIntegration":
+			var interfaceType CloudConfluentKafkaFlinkResourceIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
+		case "CloudConfluentKafkaKsqlResourceIntegration":
+			var interfaceType CloudConfluentKafkaKsqlResourceIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
+		case "CloudConfluentKafkaResourceIntegration":
+			var interfaceType CloudConfluentKafkaResourceIntegration
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err
@@ -7310,6 +7897,16 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			return &xxx, nil
 		case "CloudEmrIntegration":
 			var interfaceType CloudEmrIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
+		case "CloudFossaIssuesIntegration":
+			var interfaceType CloudFossaIssuesIntegration
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err
@@ -7458,6 +8055,16 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			var xxx CloudIntegrationInterface = &interfaceType
 
 			return &xxx, nil
+		case "CloudGcpGenericIntegration":
+			var interfaceType CloudGcpGenericIntegration
+			err = json.Unmarshal(b, &interfaceType)
+			if err != nil {
+				return nil, err
+			}
+
+			var xxx CloudIntegrationInterface = &interfaceType
+
+			return &xxx, nil
 		case "CloudGcpInterconnectIntegration":
 			var interfaceType CloudGcpInterconnectIntegration
 			err = json.Unmarshal(b, &interfaceType)
@@ -7580,16 +8187,6 @@ func UnmarshalCloudIntegrationInterface(b []byte) (*CloudIntegrationInterface, e
 			return &xxx, nil
 		case "CloudGcpVpcaccessIntegration":
 			var interfaceType CloudGcpVpcaccessIntegration
-			err = json.Unmarshal(b, &interfaceType)
-			if err != nil {
-				return nil, err
-			}
-
-			var xxx CloudIntegrationInterface = &interfaceType
-
-			return &xxx, nil
-		case "CloudGcpGenericIntegration":
-			var interfaceType CloudGcpGenericIntegration
 			err = json.Unmarshal(b, &interfaceType)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
### Re-Import schema: `cloud`

Adding cloudUpdateGcpIntegration mutation and provider query — both exist in NerdGraph but are missing from the Go client.

**Before merging, please verify:**
- [ ] Review the `.tutone.yml` diff — additions are correct
- [ ] Review regenerated `pkg/cloud/` files
- [ ] Update or add integration tests if needed

_Generated by the GenerateClientGo Jenkins job._