### PR TITLE
feat(dashboards): re-import schema

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -541,6 +541,8 @@ packages:
         exclude_fields:
           - goldenMetrics
           - goldenTags
+      - name: dashboardAddWidgetsToPage
+        max_query_field_depth: 10
     types:
       # This must be a string, as where ID is used the type is a string...
       - name: ID

--- a/pkg/dashboards/dashboards_api.go
+++ b/pkg/dashboards/dashboards_api.go
@@ -3,10 +3,57 @@ package dashboards
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 )
+
+// Add widgets to a `DashboardPage`
+func (a *Dashboards) DashboardAddWidgetsToPage(
+	gUID common.EntityGUID,
+	widgets []DashboardWidgetInput,
+) (*DashboardAddWidgetsToPageResult, error) {
+	return a.DashboardAddWidgetsToPageWithContext(context.Background(),
+		gUID,
+		widgets,
+	)
+}
+
+// Add widgets to a `DashboardPage`
+func (a *Dashboards) DashboardAddWidgetsToPageWithContext(
+	ctx context.Context,
+	gUID common.EntityGUID,
+	widgets []DashboardWidgetInput,
+) (*DashboardAddWidgetsToPageResult, error) {
+
+	resp := DashboardAddWidgetsToPageQueryResponse{}
+	vars := map[string]interface{}{
+		"guid":    gUID,
+		"widgets": widgets,
+	}
+
+	if err := a.client.NerdGraphQueryWithContext(ctx, DashboardAddWidgetsToPageMutation, vars, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.DashboardAddWidgetsToPageResult, nil
+}
+
+type DashboardAddWidgetsToPageQueryResponse struct {
+	DashboardAddWidgetsToPageResult DashboardAddWidgetsToPageResult `json:"DashboardAddWidgetsToPage"`
+}
+
+const DashboardAddWidgetsToPageMutation = `mutation(
+	$guid: EntityGuid!,
+	$widgets: [DashboardWidgetInput!]!,
+) { dashboardAddWidgetsToPage(
+	guid: $guid,
+	widgets: $widgets,
+) {
+	errors {
+		description
+		type
+	}
+} }`
 
 // Create a `DashboardEntity`
 func (a *Dashboards) DashboardCreate(
@@ -36,14 +83,6 @@ func (a *Dashboards) DashboardCreateWithContext(
 		return nil, err
 	}
 
-	if len(resp.DashboardCreateResult.Errors) > 0 {
-		errs := fmt.Errorf("query error")
-		for _, err := range resp.DashboardCreateResult.Errors {
-			errs = fmt.Errorf("%w; %s", errs, err.Description)
-		}
-		return nil, errs
-	}
-
 	return &resp.DashboardCreateResult, nil
 }
 
@@ -66,6 +105,8 @@ const DashboardCreateMutation = `mutation(
 		name
 		owner {
 			email
+			id
+			type
 			userId
 		}
 		pages {
@@ -75,6 +116,8 @@ const DashboardCreateMutation = `mutation(
 			name
 			owner {
 				email
+				id
+				type
 				userId
 			}
 			updatedAt
@@ -124,12 +167,16 @@ const DashboardCreateMutation = `mutation(
 						}
 					}
 				}
+				description
 				id
 				layout {
 					column
 					height
 					row
 					width
+				}
+				link {
+					url
 				}
 				linkedEntities {
 					__typename
@@ -166,6 +213,7 @@ const DashboardCreateMutation = `mutation(
 									name
 								}
 								badEvents {
+									facets
 									from
 									select {
 										attribute
@@ -175,6 +223,7 @@ const DashboardCreateMutation = `mutation(
 									where
 								}
 								goodEvents {
+									facets
 									from
 									select {
 										attribute
@@ -184,6 +233,7 @@ const DashboardCreateMutation = `mutation(
 									where
 								}
 								validEvents {
+									facets
 									from
 									select {
 										attribute
@@ -195,6 +245,32 @@ const DashboardCreateMutation = `mutation(
 							}
 							guid
 							id
+							metadata {
+								createdAt
+								createdBy {
+									__typename
+									id
+									type
+									... on ServiceLevelSystemIdentityActor {
+										__typename
+									}
+									... on ServiceLevelUserActor {
+										__typename
+									}
+								}
+								updatedAt
+								updatedBy {
+									__typename
+									id
+									type
+									... on ServiceLevelSystemIdentityActor {
+										__typename
+									}
+									... on ServiceLevelUserActor {
+										__typename
+									}
+								}
+							}
 							name
 							objectives {
 								description
@@ -287,6 +363,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -296,6 +373,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -305,6 +383,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -316,6 +395,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -389,6 +494,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -398,6 +504,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -407,6 +514,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -418,6 +526,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -491,6 +625,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -500,6 +635,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -509,6 +645,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -520,6 +657,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -605,6 +768,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -614,6 +778,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -623,6 +788,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -634,6 +800,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -692,6 +884,8 @@ const DashboardCreateMutation = `mutation(
 						dashboardParentGuid
 						owner {
 							email
+							id
+							type
 							userId
 						}
 						permissions
@@ -712,6 +906,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -721,6 +916,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -730,6 +926,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -741,6 +938,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -809,6 +1032,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -818,6 +1042,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -827,6 +1052,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -838,6 +1064,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -905,6 +1157,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -914,6 +1167,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -923,6 +1177,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -934,6 +1189,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -1002,6 +1283,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1011,6 +1293,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1020,6 +1303,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1031,6 +1315,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -1100,6 +1410,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1109,6 +1420,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1118,6 +1430,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1129,6 +1442,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -1204,6 +1543,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1213,6 +1553,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1222,6 +1563,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1233,6 +1575,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -1300,6 +1668,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1309,6 +1678,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1318,6 +1688,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1329,6 +1700,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -1409,6 +1806,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1418,6 +1816,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1427,6 +1826,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1438,6 +1838,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -1511,6 +1937,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1520,6 +1947,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1529,6 +1957,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1540,6 +1969,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -1618,6 +2073,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1627,6 +2083,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1636,6 +2093,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1647,6 +2105,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -1714,6 +2198,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1723,6 +2208,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1732,6 +2218,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1743,6 +2230,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -1810,6 +2323,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1819,6 +2333,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1828,6 +2343,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1839,6 +2355,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -1906,6 +2448,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1915,6 +2458,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1924,6 +2468,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -1935,6 +2480,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -2009,6 +2580,7 @@ const DashboardCreateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2018,6 +2590,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2027,6 +2600,7 @@ const DashboardCreateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2038,6 +2612,32 @@ const DashboardCreateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -2119,6 +2719,7 @@ const DashboardCreateMutation = `mutation(
 			}
 			options {
 				excluded
+				hiddenOnVariablesBar
 				ignoreTimeRange
 				showApplyAction
 			}
@@ -2155,15 +2756,6 @@ func (a *Dashboards) DashboardDeleteWithContext(
 
 	if err := a.client.NerdGraphQueryWithContext(ctx, DashboardDeleteMutation, vars, &resp); err != nil {
 		return nil, err
-	}
-
-	// If we got errors back, wrap them all up
-	if len(resp.DashboardDeleteResult.Errors) > 0 {
-		errs := fmt.Errorf("query error")
-		for _, err := range resp.DashboardDeleteResult.Errors {
-			errs = fmt.Errorf("%w; %s", errs, err.Description)
-		}
-		return nil, errs
 	}
 
 	return &resp.DashboardDeleteResult, nil
@@ -2213,15 +2805,6 @@ func (a *Dashboards) DashboardUpdateWithContext(
 		return nil, err
 	}
 
-	// If we got errors back, wrap them all up
-	if len(resp.DashboardUpdateResult.Errors) > 0 {
-		errs := fmt.Errorf("query error")
-		for _, err := range resp.DashboardUpdateResult.Errors {
-			errs = fmt.Errorf("%w; %s", errs, err.Description)
-		}
-		return nil, errs
-	}
-
 	return &resp.DashboardUpdateResult, nil
 }
 
@@ -2244,6 +2827,8 @@ const DashboardUpdateMutation = `mutation(
 		name
 		owner {
 			email
+			id
+			type
 			userId
 		}
 		pages {
@@ -2253,6 +2838,8 @@ const DashboardUpdateMutation = `mutation(
 			name
 			owner {
 				email
+				id
+				type
 				userId
 			}
 			updatedAt
@@ -2302,12 +2889,16 @@ const DashboardUpdateMutation = `mutation(
 						}
 					}
 				}
+				description
 				id
 				layout {
 					column
 					height
 					row
 					width
+				}
+				link {
+					url
 				}
 				linkedEntities {
 					__typename
@@ -2344,6 +2935,7 @@ const DashboardUpdateMutation = `mutation(
 									name
 								}
 								badEvents {
+									facets
 									from
 									select {
 										attribute
@@ -2353,6 +2945,7 @@ const DashboardUpdateMutation = `mutation(
 									where
 								}
 								goodEvents {
+									facets
 									from
 									select {
 										attribute
@@ -2362,6 +2955,7 @@ const DashboardUpdateMutation = `mutation(
 									where
 								}
 								validEvents {
+									facets
 									from
 									select {
 										attribute
@@ -2373,6 +2967,32 @@ const DashboardUpdateMutation = `mutation(
 							}
 							guid
 							id
+							metadata {
+								createdAt
+								createdBy {
+									__typename
+									id
+									type
+									... on ServiceLevelSystemIdentityActor {
+										__typename
+									}
+									... on ServiceLevelUserActor {
+										__typename
+									}
+								}
+								updatedAt
+								updatedBy {
+									__typename
+									id
+									type
+									... on ServiceLevelSystemIdentityActor {
+										__typename
+									}
+									... on ServiceLevelUserActor {
+										__typename
+									}
+								}
+							}
 							name
 							objectives {
 								description
@@ -2465,6 +3085,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2474,6 +3095,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2483,6 +3105,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2494,6 +3117,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -2567,6 +3216,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2576,6 +3226,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2585,6 +3236,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2596,6 +3248,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -2669,6 +3347,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2678,6 +3357,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2687,6 +3367,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2698,6 +3379,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -2783,6 +3490,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2792,6 +3500,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2801,6 +3510,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2812,6 +3522,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -2870,6 +3606,8 @@ const DashboardUpdateMutation = `mutation(
 						dashboardParentGuid
 						owner {
 							email
+							id
+							type
 							userId
 						}
 						permissions
@@ -2890,6 +3628,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2899,6 +3638,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2908,6 +3648,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2919,6 +3660,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -2987,6 +3754,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -2996,6 +3764,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3005,6 +3774,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3016,6 +3786,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -3083,6 +3879,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3092,6 +3889,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3101,6 +3899,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3112,6 +3911,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -3180,6 +4005,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3189,6 +4015,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3198,6 +4025,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3209,6 +4037,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -3278,6 +4132,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3287,6 +4142,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3296,6 +4152,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3307,6 +4164,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -3382,6 +4265,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3391,6 +4275,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3400,6 +4285,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3411,6 +4297,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -3478,6 +4390,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3487,6 +4400,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3496,6 +4410,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3507,6 +4422,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -3587,6 +4528,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3596,6 +4538,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3605,6 +4548,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3616,6 +4560,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -3689,6 +4659,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3698,6 +4669,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3707,6 +4679,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3718,6 +4691,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -3796,6 +4795,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3805,6 +4805,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3814,6 +4815,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3825,6 +4827,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -3892,6 +4920,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3901,6 +4930,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3910,6 +4940,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3921,6 +4952,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -3988,6 +5045,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -3997,6 +5055,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -4006,6 +5065,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -4017,6 +5077,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -4084,6 +5170,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -4093,6 +5180,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -4102,6 +5190,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -4113,6 +5202,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -4187,6 +5302,7 @@ const DashboardUpdateMutation = `mutation(
 										name
 									}
 									badEvents {
+										facets
 										from
 										select {
 											attribute
@@ -4196,6 +5312,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									goodEvents {
+										facets
 										from
 										select {
 											attribute
@@ -4205,6 +5322,7 @@ const DashboardUpdateMutation = `mutation(
 										where
 									}
 									validEvents {
+										facets
 										from
 										select {
 											attribute
@@ -4216,6 +5334,32 @@ const DashboardUpdateMutation = `mutation(
 								}
 								guid
 								id
+								metadata {
+									createdAt
+									createdBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+									updatedAt
+									updatedBy {
+										__typename
+										id
+										type
+										... on ServiceLevelSystemIdentityActor {
+											__typename
+										}
+										... on ServiceLevelUserActor {
+											__typename
+										}
+									}
+								}
 								name
 								objectives {
 									description
@@ -4297,6 +5441,7 @@ const DashboardUpdateMutation = `mutation(
 			}
 			options {
 				excluded
+				hiddenOnVariablesBar
 				ignoreTimeRange
 				showApplyAction
 			}

--- a/pkg/dashboards/types.go
+++ b/pkg/dashboards/types.go
@@ -8,6 +8,25 @@ import (
 	"github.com/newrelic/newrelic-client-go/v2/pkg/nrtime"
 )
 
+// DashboardAddWidgetsToPageErrorType - Expected error types that can be returned by addWidgetsToPage operation.
+type DashboardAddWidgetsToPageErrorType string
+
+var DashboardAddWidgetsToPageErrorTypeTypes = struct {
+	// User is not allowed to execute the operation.
+	FORBIDDEN_OPERATION DashboardAddWidgetsToPageErrorType
+	// Invalid input error.
+	INVALID_INPUT DashboardAddWidgetsToPageErrorType
+	// Page not found in the system.
+	PAGE_NOT_FOUND DashboardAddWidgetsToPageErrorType
+}{
+	// User is not allowed to execute the operation.
+	FORBIDDEN_OPERATION: "FORBIDDEN_OPERATION",
+	// Invalid input error.
+	INVALID_INPUT: "INVALID_INPUT",
+	// Page not found in the system.
+	PAGE_NOT_FOUND: "PAGE_NOT_FOUND",
+}
+
 // DashboardCreateErrorType - Expected error types that can be returned by create operation.
 type DashboardCreateErrorType string
 
@@ -49,6 +68,17 @@ var DashboardDeleteResultStatusTypes = struct {
 	SUCCESS: "SUCCESS",
 }
 
+// DashboardLiveURLAuthType - The auth type used to protect the Live URL
+type DashboardLiveURLAuthType string
+
+var DashboardLiveURLAuthTypeTypes = struct {
+	// The Live URL is protected by a password.
+	PASSWORD DashboardLiveURLAuthType
+}{
+	// The Live URL is protected by a password.
+	PASSWORD: "PASSWORD",
+}
+
 // DashboardLiveURLType - Live URL type.
 type DashboardLiveURLType string
 
@@ -62,6 +92,21 @@ var DashboardLiveURLTypeTypes = struct {
 	DASHBOARD: "DASHBOARD",
 	// Widget.
 	WIDGET: "WIDGET",
+}
+
+// DashboardSnapshotURLFormat - Format for the snapshot URL.
+type DashboardSnapshotURLFormat string
+
+var DashboardSnapshotURLFormatTypes = struct {
+	// PDF format.
+	PDF DashboardSnapshotURLFormat
+	// PNG format.
+	PNG DashboardSnapshotURLFormat
+}{
+	// PDF format.
+	PDF: "PDF",
+	// PNG format.
+	PNG: "PNG",
 }
 
 // DashboardUpdateErrorType - Expected error types that can be returned by update operation.
@@ -163,6 +208,26 @@ var DashboardVariableTypeTypes = struct {
 	STRING: "STRING",
 }
 
+// AccountReference - The `AccountReference` object provides basic identifying information about the account.
+type AccountReference struct {
+	ID   int    `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// DashboardAddWidgetsToPageError - Expected errors that can be returned by addWidgetsToPage operation.
+type DashboardAddWidgetsToPageError struct {
+	// Error description.
+	Description string `json:"description,omitempty"`
+	// Error type.
+	Type DashboardAddWidgetsToPageErrorType `json:"type"`
+}
+
+// DashboardAddWidgetsToPageResult - Result of addWidgetsToPage operation.
+type DashboardAddWidgetsToPageResult struct {
+	// Expected errors while processing request. No errors means successful request.
+	Errors []DashboardAddWidgetsToPageError `json:"errors,omitempty"`
+}
+
 // DashboardAreaWidgetConfigurationInput - Configuration for visualization type 'viz.area'
 type DashboardAreaWidgetConfigurationInput struct {
 	// NRQL queries.
@@ -236,7 +301,7 @@ type DashboardEntityResult struct {
 	// Dashboard update timestamp.
 	UpdatedAt nrtime.DateTime `json:"updatedAt,omitempty"`
 	// Dashboard-local variable definitions.
-	Variables []entities.DashboardVariable `json:"variables,omitempty"`
+	Variables []DashboardVariable `json:"variables,omitempty"`
 }
 
 // DashboardInput - Dashboard input.
@@ -261,8 +326,16 @@ type DashboardLineWidgetConfigurationInput struct {
 
 // DashboardLiveURL - Live URL.
 type DashboardLiveURL struct {
+	// The account(s) of the Live URL. For live dashboards only one account is present
+	Accounts []AccountReference `json:"accounts,omitempty"`
+	// The authorization policies that will be used to protect the Live URL
+	Auth DashboardLiveURLAuth `json:"auth,omitempty"`
 	// Creation date.
 	CreatedAt nrtime.EpochMilliseconds `json:"createdAt,omitempty"`
+	// Information of the user that created the LiveUrl.
+	CreatedBy UserReference `json:"createdBy,omitempty"`
+	// Date when the Live Url will become unavailable
+	ExpiresOn nrtime.EpochMilliseconds `json:"expiresOn,omitempty"`
 	// Title that describes the source entity that is accessible through the public live URL.
 	Title string `json:"title,omitempty"`
 	// Live URL type.
@@ -271,6 +344,64 @@ type DashboardLiveURL struct {
 	URL string `json:"url"`
 	// The unique identifier of the public live URL.
 	Uuid string `json:"uuid"`
+}
+
+// DashboardLiveURLAuth - The authorization policies that will be used to protect the Live URL
+type DashboardLiveURLAuth struct {
+	// The different authorization factors that will be used to protect the Live URL
+	Factors []DashboardLiveURLAuthFactor `json:"factors"`
+}
+
+// DashboardLiveURLAuthCreationInput - Input type used to setup the Live URL auth policies in creation time
+type DashboardLiveURLAuthCreationInput struct {
+	// The auth factors that will be used to protect the Live URL
+	Factors []DashboardLiveURLAuthFactorInput `json:"factors,omitempty"`
+}
+
+// DashboardLiveURLAuthFactor - Live URL authentication factor.
+type DashboardLiveURLAuthFactor struct {
+	// Details for the Live URL authentication factor of type `PASSWORD`
+	Password DashboardLiveURLAuthPasswordDetails `json:"password,omitempty"`
+	// Type of authentication factor.
+	Type DashboardLiveURLAuthType `json:"type"`
+}
+
+// DashboardLiveURLAuthFactorInput - Input type use to define each Live URL auth factor
+type DashboardLiveURLAuthFactorInput struct {
+	// Type of authentication factor.
+	Type DashboardLiveURLAuthType `json:"type"`
+}
+
+// DashboardLiveURLAuthPasswordDetails - Live URL authentication details.
+type DashboardLiveURLAuthPasswordDetails struct {
+	// The actual password of the Live URL, contains value only upon public link creation
+	Value SecureValue `json:"value,omitempty"`
+}
+
+// DashboardLiveURLAuthUpdateInput - Input type used to update the Live URL auth policies
+type DashboardLiveURLAuthUpdateInput struct {
+	// The auth factors that will be used to protect the Live URL
+	Factors []DashboardLiveURLAuthFactorInput `json:"factors,omitempty"`
+}
+
+// DashboardLiveURLCreationPoliciesResult - Result of fetching list of live URL creation policies.
+type DashboardLiveURLCreationPoliciesResult struct {
+	// List of live URL creation policies.
+	LiveURLCreationPolicies []DashboardLiveURLCreationPolicy `json:"liveUrlCreationPolicies,omitempty"`
+}
+
+// DashboardLiveURLCreationPolicy - Represents a live URL creation policy. A live URL creation policy controls whether creating Live URLs is allowed or not for an account.
+type DashboardLiveURLCreationPolicy struct {
+	// The account id for which the policy applies.
+	AccountID int `json:"accountId,omitempty"`
+	// Whether or not live URL creation is allowed for the account.
+	LiveURLCreationAllowed bool `json:"liveUrlCreationAllowed,omitempty"`
+}
+
+// DashboardLiveURLOptionsInput - Options to configure the Live URL
+type DashboardLiveURLOptionsInput struct {
+	// The amount of time (in seconds) until the Live Url becomes unavailable from the date on which the operation is executed. Min value of 300 (5 minutes). Max value of 631,152,000 (20 year). When it is not set, by default 2,592,000 (30 days) will be used.
+	Ttl Seconds `json:"ttl,omitempty"`
 }
 
 // DashboardMarkdownWidgetConfigurationInput - Configuration for visualization type 'viz.markdown'. Learn more about [markdown](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#markdown) widget.
@@ -287,13 +418,8 @@ type DashboardPageInput struct {
 	GUID common.EntityGUID `json:"guid,omitempty"`
 	// The name of the page.
 	Name string `json:"name"`
-
-	// NOTE: The JSON description of the following attribute, "Widgets" has been modified manually
-	// (removal of "omitempty") to facilitate creating pages with no widgets (empty pages).
-	// Please DO NOT regenerate/modify this attribute and its datatype via Tutone (which would add "omitempty" back).
-
 	// A nested block of all widgets belonging to the page.
-	Widgets []DashboardWidgetInput `json:"widgets"`
+	Widgets []DashboardWidgetInput `json:"widgets,omitempty"`
 }
 
 // DashboardPieWidgetConfigurationInput - Configuration for visualization type 'viz.pie'.  Learn more about [pie](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#pie) widget.
@@ -302,10 +428,26 @@ type DashboardPieWidgetConfigurationInput struct {
 	NRQLQueries []DashboardWidgetNRQLQueryInput `json:"nrqlQueries,omitempty"`
 }
 
+// DashboardSnapshotURLDisplayInput - Display configuration of the snapshot.
+type DashboardSnapshotURLDisplayInput struct {
+	// Height in pixels for the snapshot.
+	Height int `json:"height,omitempty"`
+	// Width in pixels for the snapshot.
+	Width int `json:"width,omitempty"`
+}
+
 // DashboardSnapshotURLInput - Parameters that affect the data and the rendering of the dashboards returned by the snapshot url mutation.
 type DashboardSnapshotURLInput struct {
+	// Display configuration of the snapshot.
+	Display DashboardSnapshotURLDisplayInput `json:"display,omitempty"`
+	// Filter applied to the dashboard at the moment of creating the snapshot.
+	Filter string `json:"filter,omitempty"`
+	// Snapshot format.
+	Format DashboardSnapshotURLFormat `json:"format,omitempty"`
 	// Period of time from which the data to be displayed on the dashboard will be obtained.
 	TimeWindow DashboardSnapshotURLTimeWindowInput `json:"timeWindow,omitempty"`
+	// Values for the variables defined in the dashboard at the moment of creating the snapshot.
+	Variables []DashboardSnapshotURLVariableInput `json:"variables,omitempty"`
 }
 
 // DashboardSnapshotURLTimeWindowInput - Period of time from which the data to be displayed on the dashboard will be obtained.
@@ -316,6 +458,14 @@ type DashboardSnapshotURLTimeWindowInput struct {
 	Duration nrtime.Milliseconds `json:"duration,omitempty"`
 	// The end time of the time window. If specified, a beginTime or a duration must also be specified.
 	EndTime nrtime.EpochMilliseconds `json:"endTime,omitempty"`
+}
+
+// DashboardSnapshotURLVariableInput - Values for the variables defined in the dashboard at the moment of creating the snapshot.
+type DashboardSnapshotURLVariableInput struct {
+	// Variable identifier.
+	Name string `json:"name"`
+	// Variable value/s.
+	Values []string `json:"values"`
 }
 
 // DashboardTableWidgetConfigurationInput - Configuration for visualization type 'viz.table'.  Learn more about [table](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#table) widget.
@@ -332,6 +482,14 @@ type DashboardUpdateError struct {
 	Type DashboardUpdateErrorType `json:"type"`
 }
 
+// DashboardUpdateLiveURLCreationPoliciesInput - Parameters for setting the Live URL creation policies.
+type DashboardUpdateLiveURLCreationPoliciesInput struct {
+	// The account ids for which the policy applies.
+	AccountIDs []int `json:"accountIds"`
+	// Whether or not live URL creation is allowed for the accounts.
+	LiveURLCreationAllowed bool `json:"liveUrlCreationAllowed"`
+}
+
 // DashboardUpdatePageError - Expected errors that can be returned by updatePage operation.
 type DashboardUpdatePageError struct {
 	// Error description.
@@ -346,13 +504,8 @@ type DashboardUpdatePageInput struct {
 	Description string `json:"description,omitempty"`
 	// Page name.
 	Name string `json:"name"`
-
-	// NOTE: The JSON description of the following attribute, "Widgets" has been modified manually
-	// (removal of "omitempty") to facilitate creating pages with no widgets (empty pages).
-	// Please DO NOT regenerate/modify this attribute and its datatype via Tutone (which would add "omitempty" back).
-
 	// Page widgets.
-	Widgets []DashboardWidgetInput `json:"widgets"`
+	Widgets []DashboardWidgetInput `json:"widgets,omitempty"`
 }
 
 // DashboardUpdatePageResult - Result of updatePage operation.
@@ -373,10 +526,14 @@ type DashboardUpdateResult struct {
 type DashboardUpdateWidgetInput struct {
 	// Typed widgets are area, bar, billboard, line, markdown, pie, and table. Check our [docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#widget-typed) for more info.
 	Configuration DashboardWidgetConfigurationInput `json:"configuration,omitempty"`
+	// A description of the widget, will be displayed in a tooltip.
+	Description string `json:"description,omitempty"`
 	// ID of the widget to be updated.
 	ID string `json:"id"`
 	// The widget's position and size in the dashboard.
 	Layout DashboardWidgetLayoutInput `json:"layout,omitempty"`
+	// Input for configuring a link to be displayed in the widget. The URL will be rendered as a clickable link.
+	Link DashboardWidgetLinkInput `json:"link,omitempty"`
 	// Entities related to the widget. Currently only supports one Dashboard entity guid, but may allow other cases in the future.
 	LinkedEntityGUIDs []common.EntityGUID `json:"linkedEntityGuids"`
 	// Untyped widgets are all other widgets, such as bullet, histogram, inventory, etc. Check our [docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#widget-untyped) for more info.
@@ -434,7 +591,7 @@ type DashboardVariableDefaultItem struct {
 // DashboardVariableDefaultItemInput - Represents a possible default value item.
 type DashboardVariableDefaultItemInput struct {
 	// The value of this default item.
-	Value DashboardVariableDefaultValueInput `json:"value,omitempty"`
+	Value *DashboardVariableDefaultValueInput `json:"value,omitempty"`
 }
 
 // DashboardVariableDefaultValue - Specifies a default value for variables.
@@ -470,13 +627,13 @@ type DashboardVariableInput struct {
 	// [DEPRECATED] Default value for this variable. The actual value to be used will depend on the type.
 	DefaultValue *DashboardVariableDefaultValueInput `json:"defaultValue,omitempty"`
 	// Default values for this variable. The actual value to be used will depend on the type.
-	DefaultValues *[]DashboardVariableDefaultItemInput `json:"defaultValues,omitempty"`
+	DefaultValues []*DashboardVariableDefaultItemInput `json:"defaultValues,omitempty"`
 	// Indicates whether this variable supports multiple selection or not. Only applies to variables of type NRQL or ENUM.
 	IsMultiSelection bool `json:"isMultiSelection,omitempty"`
 	// List of possible values for variables of type ENUM
 	Items []DashboardVariableEnumItemInput `json:"items,omitempty"`
 	// Configuration for variables of type NRQL.
-	NRQLQuery *DashboardVariableNRQLQueryInput `json:"nrqlQuery,omitempty"`
+	NRQLQuery DashboardVariableNRQLQueryInput `json:"nrqlQuery,omitempty"`
 	// Variable identifier.
 	Name string `json:"name"`
 	// Options applied to the variable
@@ -509,6 +666,8 @@ type DashboardVariableNRQLQueryInput struct {
 type DashboardVariableOptions struct {
 	// With this turned on, query condition defined with the variable will not be included in the query.
 	Excluded bool `json:"excluded,omitempty"`
+	// Controls whether this variable is visible in the UI when not in edit mode.
+	HiddenOnVariablesBar bool `json:"hiddenOnVariablesBar,omitempty"`
 	// Only applies to variables of type NRQL. With this turned on, the time range for the NRQL query will override the time picker on dashboards and other pages. Turn this off to use the time picker as normal.
 	IgnoreTimeRange bool `json:"ignoreTimeRange,omitempty"`
 	// Determines whether or not an Apply action will be shown when selecting multiple values in ENUM and NRQL variables.
@@ -518,11 +677,13 @@ type DashboardVariableOptions struct {
 // DashboardVariableOptionsInput - Options applied to the variable
 type DashboardVariableOptionsInput struct {
 	// With this turned on, query condition defined with the variable will not be included in the query.
-	Excluded *bool `json:"excluded,omitempty"`
+	Excluded bool `json:"excluded,omitempty"`
+	// Controls whether this variable is visible in the UI when not in edit mode.
+	HiddenOnVariablesBar bool `json:"hiddenOnVariablesBar,omitempty"`
 	// Only applies to variables of type NRQL. With this turned on, the time range for the NRQL query will override the time picker on dashboards and other pages. Turn this off to use the time picker as normal.
-	IgnoreTimeRange *bool `json:"ignoreTimeRange,omitempty"`
+	IgnoreTimeRange bool `json:"ignoreTimeRange,omitempty"`
 	// Determines whether or not an Apply action will be shown when selecting multiple values in ENUM and NRQL variables.
-	ShowApplyAction *bool `json:"showApplyAction,omitempty"`
+	ShowApplyAction bool `json:"showApplyAction,omitempty"`
 }
 
 // DashboardWidgetConfigurationInput - Typed configuration for known visualizations. At most one may be populated.
@@ -547,10 +708,14 @@ type DashboardWidgetConfigurationInput struct {
 type DashboardWidgetInput struct {
 	// Typed widgets are area, bar, billboard, line, markdown, pie, and table. Check our [docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#widget-typed) for more info.
 	Configuration DashboardWidgetConfigurationInput `json:"configuration,omitempty"`
+	// A description of the widget, will be displayed in a tooltip.
+	Description string `json:"description,omitempty"`
 	// ID of the widget. If null, a new widget will be created and added to a dashboard.
 	ID string `json:"id,omitempty"`
 	// The widget's position and size in the dashboard.
 	Layout DashboardWidgetLayoutInput `json:"layout,omitempty"`
+	// Input for configuring a link to be displayed in the widget. The URL will be rendered as a clickable link.
+	Link DashboardWidgetLinkInput `json:"link,omitempty"`
 	// Entities related to the widget. Currently only supports one Dashboard entity guid, but may allow other cases in the future.
 	LinkedEntityGUIDs []common.EntityGUID `json:"linkedEntityGuids"`
 	// Untyped widgets are all other widgets, such as bullet, histogram, inventory, etc. Check our [docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#widget-untyped) for more info.
@@ -573,12 +738,16 @@ type DashboardWidgetLayoutInput struct {
 	Width int `json:"width,omitempty"`
 }
 
+// DashboardWidgetLinkInput - Input for configuring a link to be displayed in the widget. The URL will be rendered as a clickable link.
+type DashboardWidgetLinkInput struct {
+	// The target URL for the link.
+	URL string `json:"url"`
+}
+
 // DashboardWidgetNRQLQueryInput - NRQL query used by a widget.
 type DashboardWidgetNRQLQueryInput struct {
 	// New Relic account ID to issue the query against.
-	AccountID int `json:"accountId,omitempty"`
-	// New Relic account IDs to issue the query against.
-	AccountIDS []int `json:"accountIds,omitempty"`
+	AccountID int `json:"accountId"`
 	// NRQL formatted query.
 	Query nrdb.NRQL `json:"query"`
 }
@@ -588,3 +757,17 @@ type DashboardWidgetVisualizationInput struct {
 	// This field can either have a known type like `viz.area` or `<nerdpack-id>.<visualization-id>` in the case of [custom visualizations](https://developer.newrelic.com/explore-docs/custom-viz/build-visualization/). Check out [docs](https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/#widget-schema) for more info.
 	ID string `json:"id,omitempty"`
 }
+
+// UserReference - The `UserReference` object provides basic identifying information about the user.
+type UserReference struct {
+	Email    string `json:"email,omitempty"`
+	Gravatar string `json:"gravatar,omitempty"`
+	ID       int    `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+}
+
+// Seconds - The `Seconds` scalar represents a duration in seconds
+type Seconds string
+
+// SecureValue - The `SecureValue` scalar represents a secure value, ie a password, an API key, etc.
+type SecureValue string


### PR DESCRIPTION
### Re-Import schema: `dashboards`

test

**Before merging, please verify:**
- [ ] Review the `.tutone.yml` diff — additions are correct
- [ ] Review regenerated `pkg/dashboards/` files
- [ ] Update or add integration tests if needed

_Generated by the GenerateClientGo Jenkins job._

<!-- generated by the GenerateClientGo job -->
> **Regeneration removed 49 line(s)** from files this job rewrote.
>
> tutone rewrites these files wholesale, so any hand edit inside them is gone. Most
> deletions are ordinary schema drift — but please confirm none of these were edits
> someone made on purpose. Hand edits belong in a hand-owned file in the same package
> (`type_overrides.go`), or in `.tutone.yml` via `field_type_override` /
> `skip_type_create`, so a reimport cannot revert them.
>
> - `pkg/dashboards/dashboards_api.go` — 27 line(s) removed
> - `pkg/dashboards/types.go` — 22 line(s) removed