### PR TITLE
fix(testhelpers): refresh stale MobileApplicationEntity GUIDs for entity relationship tests

### DIFF
--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -17,8 +17,8 @@ const IntegrationTestApplicationEntityGUIDNew = "MzgwNjUyNnxBUE18QVBQTElDQVRJT05
 
 // GUIDs for the entity relationship
 // Upon expiration of these GUIDs, please replace them with GUIDs of Mobile Applications
-const EntityRelationshipTestSourceEntityGUID = "MzgwNjUyNnxNT0JJTEV8QVBQTElDQVRJT058NjAxNjQ2NTM1"
-const EntityRelationshipTestTargetEntityGUID = "MzgwNjUyNnxNT0JJTEV8QVBQTElDQVRJT058NjAxNjQ2NTM2"
+const EntityRelationshipTestSourceEntityGUID = "MzgwNjUyNnxNT0JJTEV8QVBQTElDQVRJT058NjAxNjcwMzA0"
+const EntityRelationshipTestTargetEntityGUID = "MzgwNjUyNnxNT0JJTEV8QVBQTElDQVRJT058NjAxNjcwMzA1"
 
 // name of the APM Application with the GUID IntegrationTestApplicationEntityGUIDNew
 const IntegrationTestApplicationEntityNameNew = "Dummy App Pro Max"


### PR DESCRIPTION
## Summary

- Replaces the two `MobileApplicationEntity` GUIDs used by `TestIntegrationEntityRelationship_CRUD` with live entities confirmed in the integration test account
- The old GUIDs no longer exist in the account, causing `GetEntity` to return `nil` and a subsequent unguarded type assertion `(*entity).(*entities.MobileApplicationEntity)` to panic, aborting the entire `gotestsum --rerun-fails` run with `ERROR rerun aborted because previous run had a suspected panic`
- A sibling test (`TestIntegrationGetEntity_MobileApplicationEntity`) already carries a `t.Skip("MobileApplicationEntities are fragile, need to be recreated")` comment acknowledging this exact failure mode

## Test plan

- [ ] `TestIntegrationEntityRelationship_CRUD` passes against the updated GUIDs
- [ ] `TestIntegrationGetEntity_MobileApplicationEntity` can be un-skipped and verified against the same entities (optional follow-up)
- [ ] No other integration tests regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)