### PR TITLE
feat(pipelinecontrol): add OttlTransform field and make NRQL nullable on PipelineCloudRuleEntity

### DIFF
--- a/pkg/pipelinecontrol/pipelinecontrol_api.go
+++ b/pkg/pipelinecontrol/pipelinecontrol_api.go
@@ -310,6 +310,12 @@ const getEntityQuery = `query(
 			version
 		}
 		nrql
+		ottlTransform {
+			eventStatements
+			logStatements
+			metricStatements
+			traceStatements
+		}
 		scope {
 			id
 			type
@@ -424,6 +430,12 @@ const getEntitySearchQuery = `query(
 				version
 			}
 			nrql
+			ottlTransform {
+				eventStatements
+				logStatements
+				metricStatements
+				traceStatements
+			}
 			scope {
 				id
 				type

--- a/pkg/pipelinecontrol/types.go
+++ b/pkg/pipelinecontrol/types.go
@@ -4763,15 +4763,32 @@ type EntityManagementPipelineCloudRuleEntity struct {
 	// Metadata about the entity.
 	Metadata EntityManagementMetadata `json:"metadata"`
 	// The NRQL string used to specify the action you want to take and data you want to take the specified action on.
-	NRQL nrdb.NRQL `json:"nrql"`
+	// Nullable: mutually exclusive with OttlTransform; exactly one must be set on any given rule.
+	NRQL *nrdb.NRQL `json:"nrql,omitempty"`
 	// The name of this entity.
 	Name string `json:"name"`
+	// OTTL transformation statements for non-NRQL rules.
+	// Mutually exclusive with NRQL; exactly one must be set on any given rule.
+	OttlTransform *EntityManagementPipelineCloudRuleEntityOttlTransform `json:"ottlTransform,omitempty"`
 	// The entity's scope.
 	Scope EntityManagementScopedReference `json:"scope"`
 	// Collection of tags.
 	Tags []EntityManagementTag `json:"tags"`
 	// The entity type.
 	Type string `json:"type"`
+}
+
+// EntityManagementPipelineCloudRuleEntityOttlTransform - OTTL transformation statements for a pipeline cloud rule.
+// Exactly one of the statement fields must be set, scoped to a single telemetry type.
+type EntityManagementPipelineCloudRuleEntityOttlTransform struct {
+	// OTTL statements applied to event data.
+	EventStatements []string `json:"eventStatements,omitempty"`
+	// OTTL statements applied to log data.
+	LogStatements []string `json:"logStatements,omitempty"`
+	// OTTL statements applied to metric data.
+	MetricStatements []string `json:"metricStatements,omitempty"`
+	// OTTL statements applied to trace data.
+	TraceStatements []string `json:"traceStatements,omitempty"`
 }
 
 func (x *EntityManagementPipelineCloudRuleEntity) ImplementsEntityManagementEntity() {}


### PR DESCRIPTION
## Summary

Prepares `pkg/pipelinecontrol` for the NGEP schema change in [ep-next-gen-api PR #1860](https://source.datanerd.us/entity-platform/ep-next-gen-api/pull/1860), which relaxes `PipelineCloudRuleEntity.nrql` from `Nrql!` to `Nrql` and adds a new `ottlTransform` sibling field to support OTTL-based pipeline cloud rules alongside existing NRQL rules.

## Changes

- **`EntityManagementPipelineCloudRuleEntity.NRQL`**: `nrdb.NRQL` → `*nrdb.NRQL` with `omitempty` — null responses from NGEP now deserialise to `nil` instead of silently coercing to empty string
- **`OttlTransform` field added** to `EntityManagementPipelineCloudRuleEntity` with a new `EntityManagementPipelineCloudRuleEntityOttlTransform` struct (`logStatements`, `eventStatements`, `metricStatements`, `traceStatements`)
- **`getEntityQuery` and `getEntitySearchQuery`** updated to fetch `ottlTransform { ... }` in the `... on EntityManagementPipelineCloudRuleEntity` inline fragment
- **Create/Update input types are intentionally unchanged** — they still carry `NRQL nrdb.NRQL` (non-pointer) for NRQL-based rules; OTTL input support is deferred until the backend ships

## Test plan

- [ ] `go build ./pkg/pipelinecontrol/...` passes (verified locally)
- [ ] Existing NRQL-based integration tests pass unchanged (NRQL rules always return non-null `nrql`)
- [ ] After ep-next-gen-api PR #1860 merges and NGEP schema is live: end-to-end read of an OTTL rule returns populated `OttlTransform` and nil `NRQL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)