### PR TITLE
fix(cloud): don't drop if enabled is false

### DIFF
--- a/pkg/cloud/cloud_api_integration_test.go
+++ b/pkg/cloud/cloud_api_integration_test.go
@@ -360,11 +360,12 @@ func TestCloudAccount_AzureMonitorIntegration(t *testing.T) {
 	require.NotZero(t, linkedAccountID)
 
 	// Create a new AzureMonitor Cloud Integration.
+	azureMonitorEnabled := true
 	azureMonitorIntegrationRes, azureMonitorIntegrationErr := client.CloudConfigureIntegration(testAccountID, CloudIntegrationsInput{
 		Azure: CloudAzureIntegrationsInput{
 			AzureMonitor: []CloudAzureMonitorIntegrationInput{{
 				LinkedAccountId:        linkedAccountID,
-				Enabled:                true,
+				Enabled:                &azureMonitorEnabled,
 				ExcludeTags:            []string{"env:staging", "env:testing"},
 				IncludeTags:            []string{"env:production"},
 				MetricsPollingInterval: 1200,

--- a/pkg/cloud/cloud_api_unit_test.go
+++ b/pkg/cloud/cloud_api_unit_test.go
@@ -94,11 +94,12 @@ func TestUnitCreateAzureMonitor(t *testing.T) {
 	t.Parallel()
 	createAzureMonitorResponse := newMockResponse(t, testCreateAzureMonitor, http.StatusCreated)
 	linkedAccountIDAsInt, _ := strconv.Atoi(linkedAccountID)
+	azureMonitorEnabled := true
 	createAzureMonitorInput := CloudIntegrationsInput{
 		Azure: CloudAzureIntegrationsInput{
 			AzureMonitor: []CloudAzureMonitorIntegrationInput{{
 				LinkedAccountId:        linkedAccountIDAsInt,
-				Enabled:                true,
+				Enabled:                &azureMonitorEnabled,
 				ExcludeTags:            []string{"env:staging", "env:testing"},
 				IncludeTags:            []string{"env:production"},
 				MetricsPollingInterval: 1200,

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -2642,7 +2642,7 @@ func (x *CloudAzureMonitorIntegration) ImplementsCloudIntegration() {}
 // CloudAzureMonitorIntegrationInput - Azure Monitor metrics
 type CloudAzureMonitorIntegrationInput struct {
 	// Specify if integration is active
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
 	// Specify resource tags (in 'key:value' form) associated with the resources that you want to exclude from monitoring. Exclusion takes precedence over inclusion.
 	ExcludeTags []string `json:"excludeTags,omitempty"`
 	// Specify resource tags (in 'key:value' form) associated with the resources that you want to monitor. If empty, all resources will be monitored.


### PR DESCRIPTION
Currently, when enabled is set to false, the Go client drops the field while building the request payload. As a result, customers are unable to disable the integration.